### PR TITLE
fix: data race in `StreamLogs` tests

### DIFF
--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -583,7 +583,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 	select {
 	case _, ok := <-logs:
 		require.False(t, ok, "logs channel should be closed")
-	case <-time.After(time.Millisecond * 100):
+	case <-time.After(time.Second):
 		require.Fail(t, "logs channel should be closed")
 	}
 }

--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bloxapp/ssv/operator/validator"
 	"github.com/bloxapp/ssv/operator/validator/mocks"
@@ -574,6 +575,17 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, ethcommon.HexToAddress("0x1").String(), recepientData.FeeRecipient.String())
 	})
+
+	// Cancel StreamLogs context.
+	cancel()
+
+	// Wait for the stream to be closed.
+	select {
+	case _, ok := <-logs:
+		require.False(t, ok, "logs channel should be closed")
+	case <-time.After(time.Millisecond * 100):
+		require.Fail(t, "logs channel should be closed")
+	}
 }
 
 func setupEventHandler(t *testing.T, ctx context.Context, logger *zap.Logger, operator *testOperator, useMockCtrl bool) (*EventHandler, *mocks.MockController, error) {

--- a/eth/executionclient/execution_client_test.go
+++ b/eth/executionclient/execution_client_test.go
@@ -200,6 +200,14 @@ Unfollowed:
 	require.NotEmpty(t, streamedLogs)
 	require.Equal(t, blocksWithLogsLength, len(streamedLogs))
 	require.NoError(t, sim.Close())
+
+	// Wait for logs channel to be closed.
+	select {
+	case _, ok := <-logs:
+		require.False(t, ok, "logs channel should be closed")
+	case <-time.After(time.Millisecond * 100):
+		require.Fail(t, "logs channel should be closed")
+	}
 }
 
 func TestFetchLogsInBatches(t *testing.T) {
@@ -583,4 +591,12 @@ func TestSimSSV(t *testing.T) {
 
 	require.NoError(t, client.Close())
 	require.NoError(t, sim.Close())
+
+	// Wait for logs channel to be closed.
+	select {
+	case _, ok := <-logs:
+		require.False(t, ok, "logs channel should be closed")
+	case <-time.After(time.Millisecond * 100):
+		require.Fail(t, "logs channel should be closed")
+	}
 }

--- a/eth/executionclient/execution_client_test.go
+++ b/eth/executionclient/execution_client_test.go
@@ -205,7 +205,7 @@ Unfollowed:
 	select {
 	case _, ok := <-logs:
 		require.False(t, ok, "logs channel should be closed")
-	case <-time.After(time.Millisecond * 100):
+	case <-time.After(time.Second):
 		require.Fail(t, "logs channel should be closed")
 	}
 }
@@ -596,7 +596,7 @@ func TestSimSSV(t *testing.T) {
 	select {
 	case _, ok := <-logs:
 		require.False(t, ok, "logs channel should be closed")
-	case <-time.After(time.Millisecond * 100):
+	case <-time.After(time.Second):
 		require.Fail(t, "logs channel should be closed")
 	}
 }


### PR DESCRIPTION
[This unit-test run](https://github.com/bloxapp/ssv/actions/runs/6111633418/job/16587300361) failed with a data race in `TestHandleBlockEventsStream` because that test wasn't waiting for `StreamLogs`'s inner goroutine to end before finishing.

This data race is described [here](https://github.com/uber-go/zap/issues/687#issuecomment-473382859).

This PR fixes 3 tests to signal `StreamLogs` to stop (with context cancellation or `ExecutionLayer.Close()`) and then wait for the `logs` channel to close before returning.