### PR TITLE
fix: add validator index in validator registration duty id

### DIFF
--- a/operator/duties/validatorregistration.go
+++ b/operator/duties/validatorregistration.go
@@ -52,9 +52,10 @@ func (h *ValidatorRegistrationHandler) HandleDuties(ctx context.Context) {
 				copy(pk[:], share.ValidatorPubKey)
 
 				h.executeDuties(h.logger, []*spectypes.Duty{{
-					Type:   spectypes.BNRoleValidatorRegistration,
-					PubKey: pk,
-					Slot:   slot,
+					Type:           spectypes.BNRoleValidatorRegistration,
+					PubKey:         pk,
+					Slot:           slot,
+					ValidatorIndex: share.BeaconMetadata.Index,
 					// no need for other params
 				}})
 


### PR DESCRIPTION
## Description

Our duty ids for validators registrations we're missing the validator index hence all of them were being printed like this :
`VALIDATOR_REGISTRATION-e32454-s1038539-v0` for all validators. 

## Changes
This PR adds the validator index to the Duty passed from the validator registration scheduler so the duty format func will put in a validator index.

*NOTE*: This PR has no effect on consensus as the validator registration duty runner isn't signing or using the full duty struct for anything.