### PR TITLE
experiment: cache attestation data to prevent wrong block routes.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_COMMIT_SHA $DOCKER_REPO_INFRA_STAGE:$CI_COMMIT_SHA
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_COMMIT_SHA
   only:
-    - stage
+    - deploy/cache-attdata
 
 # +---------------------+
 # | STAGE HETZNER NODES |
@@ -83,7 +83,7 @@ Deploy nodes to hetzner stage:
     - .k8/hetzner-stage/scripts/deploy-cluster-65--68.sh $DOCKER_REPO_INFRA_STAGE $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_STAGE hetzner.stage.k8s.local hetzner.stage.k8s.local stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
     - .k8/hetzner-stage/scripts/deploy-cluster-69--72.sh $DOCKER_REPO_INFRA_STAGE $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_STAGE hetzner.stage.k8s.local hetzner.stage.k8s.local stage.ssv.network $K8S_API_VERSION $STAGE_HEALTH_CHECK_IMAGE $SSV_NODES_CPU_LIMIT $SSV_NODES_MEM_LIMIT
   only:
-    - stage
+    - deploy/cache-attdata
 
 Deploy exporter to hetzner stage:
   stage: deploy

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -38,6 +38,8 @@ func (gc *goClient) GetAttestationData(slot phase0.Slot, committeeIndex phase0.C
 		gc.attestationDataCacheMu.Unlock()
 		m.Lock()
 		defer m.Unlock()
+		gc.attestationDataCacheMu.Lock()
+		defer gc.attestationDataCacheMu.Unlock()
 		attdata, ok := gc.attestationDataCache[SlotAndCommittee{slot, committeeIndex}]
 		if !ok {
 			return nil, DataVersionNil, fmt.Errorf("attestation data not found in cache")

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -161,7 +161,7 @@ type goClient struct {
 	registrationCache    map[phase0.BLSPubKey]*api.VersionedSignedValidatorRegistration
 
 	attestationDataCacheMu  sync.Mutex
-	attestationDataPendings map[SlotAndCommittee]sync.Mutex
+	attestationDataPendings map[SlotAndCommittee]*sync.Mutex
 	attestationDataCache    map[SlotAndCommittee]*phase0.AttestationData
 	commonTimeout           time.Duration
 	longTimeout             time.Duration
@@ -206,7 +206,7 @@ func New(
 		operatorDataStore:       operatorDataStore,
 		registrationCache:       map[phase0.BLSPubKey]*api.VersionedSignedValidatorRegistration{},
 		attestationDataCache:    make(map[SlotAndCommittee]*phase0.AttestationData),
-		attestationDataPendings: make(map[SlotAndCommittee]sync.Mutex),
+		attestationDataPendings: make(map[SlotAndCommittee]*sync.Mutex),
 		commonTimeout:           commonTimeout,
 		longTimeout:             longTimeout,
 	}


### PR DESCRIPTION
### Problem

We see on stage cases where operators submit an attestation but it ends up as missed because (we assume) the block root is different than the slot's proposed block root. 

### Solution

This PR aims to solve this and reduce calls to beacon node by caching AttestationData for Slot-CommitteeIndex, this way we always use same root, even for aggregator and also don't need to call it again.

### TODOs
- [ ] - Unit tests
- [ ] - Audit the concurrency solution (maybe there's and existing lib that does this better?)
- [ ] - Deploy half stage with this and half just stage branch and create a report to compare the amount of misses because of wrong block root.