### PR TITLE
optimization: inc block propgagation

### DIFF
--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -46,7 +46,7 @@ func init() {
 const (
 	// blockPropagationDelay time to propagate around the nodes
 	// before kicking off duties for the block's slot.
-	blockPropagationDelay = 200 * time.Millisecond
+	blockPropagationDelay = 300 * time.Millisecond
 )
 
 type SlotTicker interface {


### PR DESCRIPTION
### Description

We found out that sometimes a node receives a head event about a block that arrived early and starts consensus, then other nodes dropping the message because it takes them longer to get the event. 
For this we added the block propagation delay, but we see this delay isn't enough, hence adding 100 more ms.