### PR TITLE
Use partial signature messages instead of decided in exporter

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_COMMIT_SHA $DOCKER_REPO_INFRA_STAGE:$CI_COMMIT_SHA
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_COMMIT_SHA
   only:
-    - stage
+    - exporter-partial-sig
 
 # +---------------------+
 # | STAGE HETZNER NODES |
@@ -100,7 +100,7 @@ Deploy exporter to hetzner stage:
     - kubectl config get-contexts
     - .k8/hetzner-stage/scripts/deploy-holesky-exporters.sh $DOCKER_REPO_INFRA_STAGE $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_STAGE hetzner.stage.k8s.local hetzner.stage.k8s.local stage.ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - stage
+    - exporter-partial-sig
 
 # +---------------+
 # |     Prod      |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_COMMIT_SHA $DOCKER_REPO_INFRA_STAGE:$CI_COMMIT_SHA
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_COMMIT_SHA
   only:
-    - stage
+    - exporter-partial-sig
 
 # +---------------------+
 # | STAGE HETZNER NODES |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,7 @@ Deploy exporter to hetzner stage:
     - kubectl config get-contexts
     - .k8/hetzner-stage/scripts/deploy-holesky-exporters.sh $DOCKER_REPO_INFRA_STAGE $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_STAGE hetzner.stage.k8s.local hetzner.stage.k8s.local stage.ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - stage
+    - origin/exporter-partial-sig
 
 # +---------------+
 # |     Prod      |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_COMMIT_SHA $DOCKER_REPO_INFRA_STAGE:$CI_COMMIT_SHA
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_COMMIT_SHA
   only:
-    - stage
+    - exporter-partial-sig
 
 # +---------------------+
 # | STAGE HETZNER NODES |
@@ -100,7 +100,7 @@ Deploy exporter to hetzner stage:
     - kubectl config get-contexts
     - .k8/hetzner-stage/scripts/deploy-holesky-exporters.sh $DOCKER_REPO_INFRA_STAGE $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_STAGE hetzner.stage.k8s.local hetzner.stage.k8s.local stage.ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - origin/exporter-partial-sig
+    - exporter-partial-sig
 
 # +---------------+
 # |     Prod      |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ Build stage Docker image:
     - docker tag $IMAGE_NAME:$CI_COMMIT_SHA $DOCKER_REPO_INFRA_STAGE:$CI_COMMIT_SHA
     - $DOCKER_LOGIN_TO_INFRA_STAGE_REPO && docker push $DOCKER_REPO_INFRA_STAGE:$CI_COMMIT_SHA
   only:
-    - exporter-partial-sig
+    - stage
 
 # +---------------------+
 # | STAGE HETZNER NODES |
@@ -100,7 +100,7 @@ Deploy exporter to hetzner stage:
     - kubectl config get-contexts
     - .k8/hetzner-stage/scripts/deploy-holesky-exporters.sh $DOCKER_REPO_INFRA_STAGE $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_STAGE hetzner.stage.k8s.local hetzner.stage.k8s.local stage.ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - exporter-partial-sig
+    - stage
 
 # +---------------+
 # |     Prod      |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,7 @@ Deploy exporter to hetzner stage:
     - kubectl config get-contexts
     - .k8/hetzner-stage/scripts/deploy-holesky-exporters.sh $DOCKER_REPO_INFRA_STAGE $CI_COMMIT_SHA ssv $APP_REPLICAS_INFRA_STAGE hetzner.stage.k8s.local hetzner.stage.k8s.local stage.ssv.network $K8S_API_VERSION $SSV_EXPORTER_CPU_LIMIT $SSV_EXPORTER_MEM_LIMIT
   only:
-    - stage
+    - exporter-partial-sig
 
 # +---------------+
 # |     Prod      |

--- a/.k8/hetzner-stage/ssv-exporter-holesky.yml
+++ b/.k8/hetzner-stage/ssv-exporter-holesky.yml
@@ -119,7 +119,7 @@ spec:
             - name: ENABLE_PROFILE
               value: "true"
             - name: USE_NEW_EXPORTER_API
-              value: "true"
+              value: "false"
             - name: UDP_PORT
               value: "12073"
             - name: TCP_PORT

--- a/.k8/hetzner-stage/ssv-exporter-holesky.yml
+++ b/.k8/hetzner-stage/ssv-exporter-holesky.yml
@@ -118,6 +118,8 @@ spec:
               value: "16073"
             - name: ENABLE_PROFILE
               value: "true"
+            - name: USE_NEW_EXPORTER_API
+              value: "true"
             - name: UDP_PORT
               value: "12073"
             - name: TCP_PORT

--- a/.k8/hetzner-stage/ssv-exporter-holesky.yml
+++ b/.k8/hetzner-stage/ssv-exporter-holesky.yml
@@ -150,3 +150,7 @@ spec:
           configMap:
             name: ssv-exporter-holesky-cm
       hostNetwork: true
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/role
+          operator: Exists

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -252,7 +252,7 @@ var StartNodeCmd = &cobra.Command{
 			ws := exporterapi.NewWsServer(cmd.Context(), nil, http.NewServeMux(), cfg.WithPing)
 			cfg.SSVOptions.WS = ws
 			cfg.SSVOptions.WsAPIPort = cfg.WsAPIPort
-			cfg.SSVOptions.ValidatorOptions.NewDecidedHandler = decided.NewStreamPublisher(logger, ws)
+			cfg.SSVOptions.ValidatorOptions.NewDecidedHandler = decided.NewStreamPublisher(logger, ws, cfg.SSVOptions.ValidatorOptions.UseNewExporterAPI)
 		}
 
 		cfg.SSVOptions.ValidatorOptions.DutyRoles = []spectypes.BeaconRole{spectypes.BNRoleAttester} // TODO could be better to set in other place

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -253,6 +253,7 @@ var StartNodeCmd = &cobra.Command{
 			cfg.SSVOptions.WS = ws
 			cfg.SSVOptions.WsAPIPort = cfg.WsAPIPort
 			cfg.SSVOptions.ValidatorOptions.NewDecidedHandler = decided.NewStreamPublisher(logger, ws)
+			cfg.SSVOptions.ValidatorOptions.NewParticipantsHandler = decided.NewStreamPublisherParticipants(logger, ws)
 		}
 
 		cfg.SSVOptions.ValidatorOptions.DutyRoles = []spectypes.BeaconRole{spectypes.BNRoleAttester} // TODO could be better to set in other place

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -253,7 +253,6 @@ var StartNodeCmd = &cobra.Command{
 			cfg.SSVOptions.WS = ws
 			cfg.SSVOptions.WsAPIPort = cfg.WsAPIPort
 			cfg.SSVOptions.ValidatorOptions.NewDecidedHandler = decided.NewStreamPublisher(logger, ws)
-			cfg.SSVOptions.ValidatorOptions.NewParticipantsHandler = decided.NewStreamPublisherParticipants(logger, ws)
 		}
 
 		cfg.SSVOptions.ValidatorOptions.DutyRoles = []spectypes.BeaconRole{spectypes.BNRoleAttester} // TODO could be better to set in other place

--- a/e2e/cmd/ssv-e2e/beacon_proxy.go
+++ b/e2e/cmd/ssv-e2e/beacon_proxy.go
@@ -126,7 +126,6 @@ func (cmd *BeaconProxyCmd) Run(logger *zap.Logger, globals Globals) error {
 	//		validatorsRunningSlashing = append(validatorsRunningSlashing, valData)
 	//	}
 	//}
-
 	networkCfg := networkconfig.HoleskyE2E
 
 	const startEpochDelay = 1 // TODO: change to 2 after debugging is done

--- a/exporter/api/decided/stream.go
+++ b/exporter/api/decided/stream.go
@@ -31,6 +31,6 @@ func NewStreamPublisher(logger *zap.Logger, ws api.WebSocketServer) controller.N
 		logger.Debug("broadcast decided stream", zap.String("identifier", identifier), fields.Slot(msg.Slot))
 
 		feed.Send(api.NewDecidedAPIMsg(msg))
-		feed.Send(api.NewParticipantsAPIMsg(msg))
+		//feed.Send(api.NewParticipantsAPIMsg(msg))
 	}
 }

--- a/exporter/api/decided/stream.go
+++ b/exporter/api/decided/stream.go
@@ -47,7 +47,7 @@ func NewStreamPublisherParticipants(logger *zap.Logger, ws api.WebSocketServer) 
 		}
 		c.SetDefault(key, true)
 
-		logger.Debug("broadcast decided stream", zap.String("identifier", identifier), fields.Slot(msg.Slot))
+		logger.Debug("broadcast participants stream", zap.String("identifier", identifier), fields.Slot(msg.Slot))
 
 		feed.Send(api.NewParticipantsAPIMsg(msg))
 	}

--- a/exporter/api/decided/stream.go
+++ b/exporter/api/decided/stream.go
@@ -21,7 +21,7 @@ func NewStreamPublisher(logger *zap.Logger, ws api.WebSocketServer) controller.N
 	feed := ws.BroadcastFeed()
 	return func(msg qbftstorage.ParticipantsRangeEntry) {
 		identifier := hex.EncodeToString(msg.Identifier[:])
-		key := fmt.Sprintf("%s:%d:%d", identifier, msg.Slot, len(msg.Operators))
+		key := fmt.Sprintf("%s:%d:%d", identifier, msg.Slot, len(msg.Signers))
 		_, ok := c.Get(key)
 		if ok {
 			return

--- a/exporter/api/decided/stream.go
+++ b/exporter/api/decided/stream.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	"github.com/patrickmn/go-cache"
 	"go.uber.org/zap"
 
@@ -20,24 +19,6 @@ import (
 func NewStreamPublisher(logger *zap.Logger, ws api.WebSocketServer) controller.NewDecidedHandler {
 	c := cache.New(time.Minute, time.Minute*3/2)
 	feed := ws.BroadcastFeed()
-	return func(msg *specqbft.SignedMessage) {
-		identifier := hex.EncodeToString(msg.Message.Identifier)
-		key := fmt.Sprintf("%s:%d:%d", identifier, msg.Message.Height, len(msg.Signers))
-		_, ok := c.Get(key)
-		if ok {
-			return
-		}
-		c.SetDefault(key, true)
-
-		logger.Debug("broadcast decided stream", zap.String("identifier", identifier), fields.Height(msg.Message.Height))
-
-		feed.Send(api.NewDecidedAPIMsg(msg))
-	}
-}
-
-func NewStreamPublisherParticipants(logger *zap.Logger, ws api.WebSocketServer) controller.NewParticipantsHandler {
-	c := cache.New(time.Minute, time.Minute*3/2)
-	feed := ws.BroadcastFeed()
 	return func(msg qbftstorage.ParticipantsRangeEntry) {
 		identifier := hex.EncodeToString(msg.Identifier[:])
 		key := fmt.Sprintf("%s:%d:%d", identifier, msg.Slot, len(msg.Operators))
@@ -47,8 +28,9 @@ func NewStreamPublisherParticipants(logger *zap.Logger, ws api.WebSocketServer) 
 		}
 		c.SetDefault(key, true)
 
-		logger.Debug("broadcast participants stream", zap.String("identifier", identifier), fields.Slot(msg.Slot))
+		logger.Debug("broadcast decided stream", zap.String("identifier", identifier), fields.Slot(msg.Slot))
 
+		feed.Send(api.NewDecidedAPIMsg(msg))
 		feed.Send(api.NewParticipantsAPIMsg(msg))
 	}
 }

--- a/exporter/api/msg.go
+++ b/exporter/api/msg.go
@@ -101,6 +101,7 @@ func DecidedAPIData(msgs ...qbftstorage.ParticipantsRangeEntry) (interface{}, er
 		apiMsg := &SignedMessageAPI{
 			Signers: msg.Operators,
 			Message: specqbft.Message{
+				MsgType:    specqbft.CommitMsgType,
 				Height:     specqbft.Height(msg.Slot),
 				Identifier: msg.Identifier[:],
 			},

--- a/exporter/api/msg.go
+++ b/exporter/api/msg.go
@@ -99,7 +99,7 @@ func DecidedAPIData(msgs ...qbftstorage.ParticipantsRangeEntry) (interface{}, er
 	apiMsgs := make([]*SignedMessageAPI, 0)
 	for _, msg := range msgs {
 		apiMsg := &SignedMessageAPI{
-			Signers: msg.Operators,
+			Signers: msg.Signers,
 			Message: specqbft.Message{
 				MsgType:    specqbft.CommitMsgType,
 				Height:     specqbft.Height(msg.Slot),
@@ -122,7 +122,7 @@ func ParticipantsAPIData(msgs ...qbftstorage.ParticipantsRangeEntry) (interface{
 	apiMsgs := make([]*ParticipantsAPI, 0)
 	for _, msg := range msgs {
 		apiMsg := &ParticipantsAPI{
-			Operators:   msg.Operators,
+			Operators:   msg.Signers,
 			Slot:        msg.Slot,
 			Identifier:  msg.Identifier[:],
 			ValidatorPK: hex.EncodeToString(msg.Identifier.GetPubKey()),

--- a/exporter/api/msg.go
+++ b/exporter/api/msg.go
@@ -30,7 +30,7 @@ type SignedMessageAPI struct {
 }
 
 type ParticipantsAPI struct {
-	Operators   []spectypes.OperatorID
+	Signers     []spectypes.OperatorID
 	Slot        phase0.Slot
 	Identifier  []byte
 	ValidatorPK string
@@ -124,7 +124,7 @@ func ParticipantsAPIData(msgs ...qbftstorage.ParticipantsRangeEntry) (interface{
 	apiMsgs := make([]*ParticipantsAPI, 0)
 	for _, msg := range msgs {
 		apiMsg := &ParticipantsAPI{
-			Operators:   msg.Signers,
+			Signers:     msg.Signers,
 			Slot:        msg.Slot,
 			Identifier:  msg.Identifier[:],
 			ValidatorPK: hex.EncodeToString(msg.Identifier.GetPubKey()),

--- a/exporter/api/msg.go
+++ b/exporter/api/msg.go
@@ -35,8 +35,8 @@ type ParticipantsAPI struct {
 	Identifier  []byte
 	ValidatorPK string
 	Role        string
-
-	FullData *spectypes.ConsensusData
+	Message     specqbft.Message
+	FullData    *spectypes.ConsensusData
 }
 
 // NewDecidedAPIMsg creates a new message in an old format from the given message.
@@ -131,7 +131,13 @@ func ParticipantsAPIData(msgs ...qbftstorage.ParticipantsRangeEntry) (interface{
 			Identifier:  msg.Identifier[:],
 			ValidatorPK: hex.EncodeToString(msg.Identifier.GetPubKey()),
 			Role:        msg.Identifier.GetRoleType().String(),
-			FullData:    &spectypes.ConsensusData{Duty: spectypes.Duty{Slot: msg.Slot}},
+			Message: specqbft.Message{
+				MsgType:    specqbft.CommitMsgType,
+				Height:     specqbft.Height(msg.Slot),
+				Identifier: msg.Identifier[:],
+				Round:      specqbft.FirstRound,
+			},
+			FullData: &spectypes.ConsensusData{Duty: spectypes.Duty{Slot: msg.Slot}},
 		}
 
 		apiMsgs = append(apiMsgs, apiMsg)

--- a/exporter/api/msg.go
+++ b/exporter/api/msg.go
@@ -105,6 +105,7 @@ func DecidedAPIData(msgs ...qbftstorage.ParticipantsRangeEntry) (interface{}, er
 				Height:     specqbft.Height(msg.Slot),
 				Identifier: msg.Identifier[:],
 			},
+			FullData: &spectypes.ConsensusData{Duty: spectypes.Duty{Slot: msg.Slot}},
 		}
 
 		apiMsgs = append(apiMsgs, apiMsg)

--- a/exporter/api/msg.go
+++ b/exporter/api/msg.go
@@ -35,6 +35,8 @@ type ParticipantsAPI struct {
 	Identifier  []byte
 	ValidatorPK string
 	Role        string
+
+	FullData *spectypes.ConsensusData
 }
 
 // NewDecidedAPIMsg creates a new message in an old format from the given message.
@@ -129,6 +131,7 @@ func ParticipantsAPIData(msgs ...qbftstorage.ParticipantsRangeEntry) (interface{
 			Identifier:  msg.Identifier[:],
 			ValidatorPK: hex.EncodeToString(msg.Identifier.GetPubKey()),
 			Role:        msg.Identifier.GetRoleType().String(),
+			FullData:    &spectypes.ConsensusData{Duty: spectypes.Duty{Slot: msg.Slot}},
 		}
 
 		apiMsgs = append(apiMsgs, apiMsg)

--- a/exporter/api/msg.go
+++ b/exporter/api/msg.go
@@ -37,7 +37,7 @@ type ParticipantsAPI struct {
 	Role        string
 }
 
-// NewDecidedAPIMsg creates a new message from the given message
+// NewDecidedAPIMsg creates a new message in an old format from the given message.
 // TODO: avoid converting to v0 once explorer is upgraded
 // DEPRECATED.
 func NewDecidedAPIMsg(msgs ...qbftstorage.ParticipantsRangeEntry) Message {
@@ -64,7 +64,7 @@ func NewDecidedAPIMsg(msgs ...qbftstorage.ParticipantsRangeEntry) Message {
 	}
 }
 
-// TODO godoc
+// NewParticipantsAPIMsg creates a new message in a new format from the given message.
 func NewParticipantsAPIMsg(msgs ...qbftstorage.ParticipantsRangeEntry) Message {
 	data, err := ParticipantsAPIData(msgs...)
 	if err != nil {
@@ -89,7 +89,7 @@ func NewParticipantsAPIMsg(msgs ...qbftstorage.ParticipantsRangeEntry) Message {
 	}
 }
 
-// DecidedAPIData creates a new message from the given message
+// DecidedAPIData creates a new message from the given message in an old compatible format, which misses some fields.
 // DEPRECATED.
 func DecidedAPIData(msgs ...qbftstorage.ParticipantsRangeEntry) (interface{}, error) {
 	if len(msgs) == 0 {
@@ -113,8 +113,7 @@ func DecidedAPIData(msgs ...qbftstorage.ParticipantsRangeEntry) (interface{}, er
 	return apiMsgs, nil
 }
 
-// ParticipantsAPIData creates a new message from the given participants message
-// TODO: godoc
+// ParticipantsAPIData creates a new message from the given message in a new format.
 func ParticipantsAPIData(msgs ...qbftstorage.ParticipantsRangeEntry) (interface{}, error) {
 	if len(msgs) == 0 {
 		return nil, errors.New("no messages")

--- a/exporter/api/msg.go
+++ b/exporter/api/msg.go
@@ -32,7 +32,7 @@ type SignedMessageAPI struct {
 type ParticipantsAPI struct {
 	Operators   []spectypes.OperatorID
 	Slot        phase0.Slot
-	Identifier  spectypes.MessageID
+	Identifier  []byte
 	ValidatorPK string
 	Role        string
 }
@@ -131,7 +131,7 @@ func ParticipantsAPIData(msgs ...qbftstorage.ParticipantsRangeEntry) (interface{
 		apiMsg := &ParticipantsAPI{
 			Operators:   msg.Operators,
 			Slot:        msg.Slot,
-			Identifier:  msg.Identifier,
+			Identifier:  msg.Identifier[:],
 			ValidatorPK: hex.EncodeToString(msg.Identifier.GetPubKey()),
 			Role:        msg.Identifier.GetRoleType().String(),
 		}

--- a/exporter/api/msg.go
+++ b/exporter/api/msg.go
@@ -104,6 +104,7 @@ func DecidedAPIData(msgs ...qbftstorage.ParticipantsRangeEntry) (interface{}, er
 				MsgType:    specqbft.CommitMsgType,
 				Height:     specqbft.Height(msg.Slot),
 				Identifier: msg.Identifier[:],
+				Round:      specqbft.FirstRound,
 			},
 			FullData: &spectypes.ConsensusData{Duty: spectypes.Duty{Slot: msg.Slot}},
 		}

--- a/exporter/api/msg.go
+++ b/exporter/api/msg.go
@@ -99,17 +99,10 @@ func DecidedAPIData(msgs ...qbftstorage.ParticipantsRangeEntry) (interface{}, er
 	apiMsgs := make([]*SignedMessageAPI, 0)
 	for _, msg := range msgs {
 		apiMsg := &SignedMessageAPI{
-			Signature: []byte{}, // TODO
-			Signers:   msg.Operators,
+			Signers: msg.Operators,
 			Message: specqbft.Message{
-				MsgType:                  specqbft.CommitMsgType,
-				Height:                   specqbft.Height(msg.Slot),
-				Round:                    specqbft.FirstRound,
-				Identifier:               msg.Identifier[:],
-				Root:                     [32]byte{},
-				DataRound:                0,
-				RoundChangeJustification: nil,
-				PrepareJustification:     nil,
+				Height:     specqbft.Height(msg.Slot),
+				Identifier: msg.Identifier[:],
 			},
 		}
 

--- a/exporter/api/query_handlers.go
+++ b/exporter/api/query_handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"go.uber.org/zap"
@@ -103,4 +104,59 @@ func HandleUnknownQuery(logger *zap.Logger, nm *NetworkMessage) {
 		Type: TypeError,
 		Data: []string{fmt.Sprintf("bad request - unknown message type '%s'", nm.Msg.Type)},
 	}
+}
+
+// HandleParticipantsQuery handles TypeParticipants queries.
+func HandleParticipantsQuery(logger *zap.Logger, qbftStorage *storage.QBFTStores, nm *NetworkMessage) {
+	logger.Debug("handles participants request",
+		zap.Uint64("from", nm.Msg.Filter.From),
+		zap.Uint64("to", nm.Msg.Filter.To),
+		zap.String("pk", nm.Msg.Filter.PublicKey),
+		zap.String("role", nm.Msg.Filter.Role))
+	res := Message{
+		Type:   nm.Msg.Type,
+		Filter: nm.Msg.Filter,
+	}
+
+	pkRaw, err := hex.DecodeString(nm.Msg.Filter.PublicKey)
+	if err != nil {
+		logger.Warn("failed to decode validator public key", zap.Error(err))
+		res.Data = []string{"internal error - could not read validator key"}
+		nm.Msg = res
+		return
+	}
+
+	beaconRole, err := message.BeaconRoleFromString(nm.Msg.Filter.Role)
+	if err != nil {
+		logger.Warn("failed to parse role", zap.Error(err))
+		res.Data = []string{"role doesn't exist"}
+		nm.Msg = res
+		return
+	}
+
+	roleStorage := qbftStorage.Get(beaconRole)
+	if roleStorage == nil {
+		logger.Warn("role storage doesn't exist", fields.Role(beaconRole))
+		res.Data = []string{"internal error - role storage doesn't exist"}
+		nm.Msg = res
+		return
+	}
+
+	msgID := spectypes.NewMsgID(types.GetDefaultDomain(), pkRaw, beaconRole)
+	from := phase0.Slot(nm.Msg.Filter.From)
+	to := phase0.Slot(nm.Msg.Filter.To)
+	participantsList, err := roleStorage.GetParticipantsInRange(msgID, from, to)
+	if err != nil {
+		logger.Warn("failed to get participants", zap.Error(err))
+		res.Data = []string{"internal error - could not get participants messages"}
+	} else {
+		data, err := ParticipantsAPIData(participantsList...)
+		if err != nil {
+			res.Data = []string{err.Error()}
+		} else {
+			res.Data = data
+		}
+	}
+
+	nm.Msg = res
 }

--- a/exporter/api/query_handlers_test.go
+++ b/exporter/api/query_handlers_test.go
@@ -4,6 +4,8 @@ import (
 	"math"
 	"testing"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+
 	"github.com/bloxapp/ssv/logging"
 	"github.com/bloxapp/ssv/storage/kv"
 
@@ -117,6 +119,11 @@ func TestHandleDecidedQuery(t *testing.T) {
 	// save decided
 	for _, d := range decided250Seq {
 		require.NoError(t, ibftStorage.Get(role).SaveInstance(d))
+		require.NoError(t, ibftStorage.Get(role).SaveParticipants(
+			spectypes.MessageIDFromBytes(d.DecidedMessage.Message.Identifier),
+			phase0.Slot(d.DecidedMessage.Message.Height),
+			d.DecidedMessage.Signers),
+		)
 	}
 
 	t.Run("valid range", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/herumi/bls-eth-go-binary v1.29.1
+	github.com/holiman/uint256 v1.2.4
 	github.com/ilyakaznacheev/cleanenv v1.4.2
 	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/libp2p/go-libp2p v0.28.2
@@ -38,6 +39,7 @@ require (
 	github.com/rs/zerolog v1.29.1
 	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/cobra v1.7.0
+	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.8.4
 	github.com/wealdtech/go-eth2-types/v2 v2.8.1
 	github.com/wealdtech/go-eth2-util v1.8.1
@@ -112,7 +114,6 @@ require (
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
 	github.com/holiman/billy v0.0.0-20230718173358-1c7e68d277a7 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
-	github.com/holiman/uint256 v1.2.4 // indirect
 	github.com/huandu/go-clone v1.6.0 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -190,7 +191,6 @@ require (
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/status-im/keycard-go v0.2.0 // indirect
 	github.com/supranational/blst v0.3.11 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect

--- a/ibft/storage/store.go
+++ b/ibft/storage/store.go
@@ -206,7 +206,7 @@ func (i *ibftStorage) GetParticipants(identifier spectypes.MessageID, slot phase
 	}
 
 	operators := decodeOperators(val)
-	zap.L().Debug("getting participants: not found", zap.Any("identifier", identifier), zap.Int("slot", int(slot)), zap.Any("operators", operators))
+	zap.L().Debug("getting participants: found", zap.Any("identifier", identifier), zap.Int("slot", int(slot)), zap.Any("operators", operators))
 	return operators, nil
 }
 

--- a/ibft/storage/store.go
+++ b/ibft/storage/store.go
@@ -2,8 +2,11 @@ package storage
 
 import (
 	"encoding/binary"
+	"fmt"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
+	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -17,6 +20,7 @@ import (
 const (
 	highestInstanceKey = "highest_instance"
 	instanceKey        = "instance"
+	participantsKey    = "participants"
 )
 
 var (
@@ -150,6 +154,45 @@ func (i *ibftStorage) CleanAllInstances(logger *zap.Logger, msgID []byte) error 
 	return nil
 }
 
+func (i *ibftStorage) SaveParticipants(identifier spectypes.MessageID, slot phase0.Slot, operators []spectypes.OperatorID) error {
+	if err := i.save(encodeOperators(operators), participantsKey, identifier[:], uInt64ToByteSlice(uint64(slot))); err != nil {
+		return fmt.Errorf("could not save participants: %w", err)
+	}
+
+	return nil
+}
+
+func (i *ibftStorage) GetParticipantsInRange(identifier spectypes.MessageID, from, to phase0.Slot) ([]qbftstorage.ParticipantsRangeEntry, error) {
+	participantsRange := make([]qbftstorage.ParticipantsRangeEntry, 0)
+
+	for slot := from; slot <= to; slot++ {
+		participants, err := i.GetParticipants(identifier, slot)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get instance")
+		}
+
+		participantsRange = append(participantsRange, qbftstorage.ParticipantsRangeEntry{
+			Slot:       slot,
+			Operators:  participants,
+			Identifier: identifier,
+		})
+	}
+
+	return participantsRange, nil
+}
+
+func (i *ibftStorage) GetParticipants(identifier spectypes.MessageID, slot phase0.Slot) ([]spectypes.OperatorID, error) {
+	val, found, err := i.get(participantsKey, identifier[:], uInt64ToByteSlice(uint64(slot)))
+	if !found {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeOperators(val), nil
+}
+
 func (i *ibftStorage) save(value []byte, id string, pk []byte, keyParams ...[]byte) error {
 	prefix := append(i.prefix, pk...)
 	key := i.key(id, keyParams...)
@@ -187,4 +230,26 @@ func uInt64ToByteSlice(n uint64) []byte {
 	b := make([]byte, 8)
 	binary.LittleEndian.PutUint64(b, n)
 	return b
+}
+
+func encodeOperators(operators []spectypes.OperatorID) []byte {
+	encoded := make([]byte, len(operators)*8)
+	for i, v := range operators {
+		binary.BigEndian.PutUint64(encoded[i*8:], v)
+	}
+
+	return encoded
+}
+
+func decodeOperators(encoded []byte) []spectypes.OperatorID {
+	if len(encoded)%8 != 0 {
+		panic("corrupted storage: wrong encoded operators length")
+	}
+
+	decoded := make([]uint64, len(encoded)/8)
+	for i := 0; i < len(decoded); i++ {
+		decoded[i] = binary.BigEndian.Uint64(encoded[i*8 : (i+1)*8])
+	}
+
+	return decoded
 }

--- a/ibft/storage/store.go
+++ b/ibft/storage/store.go
@@ -155,6 +155,8 @@ func (i *ibftStorage) CleanAllInstances(logger *zap.Logger, msgID []byte) error 
 }
 
 func (i *ibftStorage) SaveParticipants(identifier spectypes.MessageID, slot phase0.Slot, operators []spectypes.OperatorID) error {
+	zap.L().Debug("saving participants", zap.Any("identifier", identifier), zap.Int("slot", int(slot)), zap.Any("operators", operators))
+
 	if err := i.save(encodeOperators(operators), participantsKey, identifier[:], uInt64ToByteSlice(uint64(slot))); err != nil {
 		return fmt.Errorf("could not save participants: %w", err)
 	}
@@ -182,15 +184,19 @@ func (i *ibftStorage) GetParticipantsInRange(identifier spectypes.MessageID, fro
 }
 
 func (i *ibftStorage) GetParticipants(identifier spectypes.MessageID, slot phase0.Slot) ([]spectypes.OperatorID, error) {
+
 	val, found, err := i.get(participantsKey, identifier[:], uInt64ToByteSlice(uint64(slot)))
 	if !found {
+		zap.L().Debug("getting participants: not found", zap.Any("identifier", identifier), zap.Int("slot", int(slot)), zap.Any("val", val))
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	return decodeOperators(val), nil
+	operators := decodeOperators(val)
+	zap.L().Debug("getting participants: not found", zap.Any("identifier", identifier), zap.Int("slot", int(slot)), zap.Any("operators", operators))
+	return operators, nil
 }
 
 func (i *ibftStorage) save(value []byte, id string, pk []byte, keyParams ...[]byte) error {

--- a/ibft/storage/store.go
+++ b/ibft/storage/store.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/zap"
 
-	"github.com/bloxapp/ssv/logging/fields"
 	"github.com/bloxapp/ssv/protocol/v2/qbft/instance"
 	qbftstorage "github.com/bloxapp/ssv/protocol/v2/qbft/storage"
 	"github.com/bloxapp/ssv/storage/basedb"
@@ -156,13 +155,6 @@ func (i *ibftStorage) CleanAllInstances(logger *zap.Logger, msgID []byte) error 
 }
 
 func (i *ibftStorage) SaveParticipants(identifier spectypes.MessageID, slot phase0.Slot, operators []spectypes.OperatorID) error {
-	zap.L().Debug("saving participants",
-		zap.Any("identifier", identifier),
-		fields.Validator(identifier.GetPubKey()),
-		fields.Role(identifier.GetRoleType()),
-		zap.Int("slot", int(slot)),
-		zap.Any("operators", operators))
-
 	if err := i.save(encodeOperators(operators), participantsKey, identifier[:], uInt64ToByteSlice(uint64(slot))); err != nil {
 		return fmt.Errorf("could not save participants: %w", err)
 	}
@@ -199,17 +191,10 @@ func (i *ibftStorage) GetParticipants(identifier spectypes.MessageID, slot phase
 		return nil, err
 	}
 	if !found {
-		zap.L().Debug("getting participants: not found",
-			zap.Any("identifier", identifier),
-			fields.Validator(identifier.GetPubKey()),
-			fields.Role(identifier.GetRoleType()),
-			zap.Int("slot", int(slot)),
-			zap.Any("val", val))
 		return nil, nil
 	}
 
 	operators := decodeOperators(val)
-	zap.L().Debug("getting participants: found", zap.Any("identifier", identifier), zap.Int("slot", int(slot)), zap.Any("operators", operators))
 	return operators, nil
 }
 

--- a/ibft/storage/store.go
+++ b/ibft/storage/store.go
@@ -168,7 +168,7 @@ func (i *ibftStorage) GetParticipantsInRange(identifier spectypes.MessageID, fro
 	for slot := from; slot <= to; slot++ {
 		participants, err := i.GetParticipants(identifier, slot)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to get participants")
+			return nil, fmt.Errorf("failed to get participants: %w", err)
 		}
 
 		if len(participants) == 0 {

--- a/ibft/storage/store.go
+++ b/ibft/storage/store.go
@@ -177,7 +177,7 @@ func (i *ibftStorage) GetParticipantsInRange(identifier spectypes.MessageID, fro
 
 		participantsRange = append(participantsRange, qbftstorage.ParticipantsRangeEntry{
 			Slot:       slot,
-			Operators:  participants,
+			Signers:    participants,
 			Identifier: identifier,
 		})
 	}

--- a/ibft/storage/store.go
+++ b/ibft/storage/store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/zap"
 
+	"github.com/bloxapp/ssv/logging/fields"
 	"github.com/bloxapp/ssv/protocol/v2/qbft/instance"
 	qbftstorage "github.com/bloxapp/ssv/protocol/v2/qbft/storage"
 	"github.com/bloxapp/ssv/storage/basedb"
@@ -155,7 +156,12 @@ func (i *ibftStorage) CleanAllInstances(logger *zap.Logger, msgID []byte) error 
 }
 
 func (i *ibftStorage) SaveParticipants(identifier spectypes.MessageID, slot phase0.Slot, operators []spectypes.OperatorID) error {
-	zap.L().Debug("saving participants", zap.Any("identifier", identifier), zap.Int("slot", int(slot)), zap.Any("operators", operators))
+	zap.L().Debug("saving participants",
+		zap.Any("identifier", identifier),
+		fields.Validator(identifier.GetPubKey()),
+		fields.Role(identifier.GetRoleType()),
+		zap.Int("slot", int(slot)),
+		zap.Any("operators", operators))
 
 	if err := i.save(encodeOperators(operators), participantsKey, identifier[:], uInt64ToByteSlice(uint64(slot))); err != nil {
 		return fmt.Errorf("could not save participants: %w", err)
@@ -187,7 +193,12 @@ func (i *ibftStorage) GetParticipants(identifier spectypes.MessageID, slot phase
 
 	val, found, err := i.get(participantsKey, identifier[:], uInt64ToByteSlice(uint64(slot)))
 	if !found {
-		zap.L().Debug("getting participants: not found", zap.Any("identifier", identifier), zap.Int("slot", int(slot)), zap.Any("val", val))
+		zap.L().Debug("getting participants: not found",
+			zap.Any("identifier", identifier),
+			fields.Validator(identifier.GetPubKey()),
+			fields.Role(identifier.GetRoleType()),
+			zap.Int("slot", int(slot)),
+			zap.Any("val", val))
 		return nil, nil
 	}
 	if err != nil {

--- a/ibft/storage/store_test.go
+++ b/ibft/storage/store_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"fmt"
 	"testing"
 
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
@@ -179,4 +180,25 @@ func newTestIbftStorage(logger *zap.Logger, prefix string) (qbftstorage.QBFTStor
 	}
 
 	return New(db, prefix), nil
+}
+
+func TestEncodeDecodeOperators(t *testing.T) {
+	testCases := []struct {
+		input   []uint64
+		encoded []byte
+	}{
+		{[]uint64{0x0123456789ABCDEF, 0xFEDCBA9876543210}, []byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10}},
+		{[]uint64{0, 1, 2, 3}, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3}},
+		{[]uint64{}, []byte{}},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Case %d", i+1), func(t *testing.T) {
+			encoded := encodeOperators(tc.input)
+			require.Equal(t, tc.encoded, encoded)
+
+			decoded := decodeOperators(encoded)
+			require.Equal(t, tc.input, decoded)
+		})
+	}
 }

--- a/operator/node.go
+++ b/operator/node.go
@@ -194,6 +194,8 @@ func (n *operatorNode) handleQueryRequests(logger *zap.Logger, nm *api.NetworkMe
 		api.HandleDecidedQuery(logger, n.qbftStorage, nm)
 	case api.TypeError:
 		api.HandleErrorQuery(logger, nm)
+	case api.TypeParticipants:
+		api.HandleParticipantsQuery(logger, n.qbftStorage, nm)
 	default:
 		api.HandleUnknownQuery(logger, nm)
 	}

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -331,7 +331,7 @@ func (c *controller) handleRouterMessages() {
 			if v, ok := c.validatorsMap.GetValidator(hexPK); ok {
 				v.HandleMessage(c.logger, msg)
 			} else if c.validatorOptions.Exporter {
-				if msg.MsgType != spectypes.SSVPartialSignatureMsgType {
+				if msg.MsgType != spectypes.SSVPartialSignatureMsgType && msg.MsgType != spectypes.SSVConsensusMsgType {
 					continue // not supporting other types
 				}
 				if !c.messageWorker.TryEnqueue(msg) { // start to save non committee decided messages only post fork

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -331,7 +331,7 @@ func (c *controller) handleRouterMessages() {
 			if v, ok := c.validatorsMap.GetValidator(hexPK); ok {
 				v.HandleMessage(c.logger, msg)
 			} else if c.validatorOptions.Exporter {
-				if msg.MsgType != spectypes.SSVPartialSignatureMsgType && msg.MsgType != spectypes.SSVConsensusMsgType {
+				if msg.MsgType != spectypes.SSVPartialSignatureMsgType {
 					continue // not supporting other types
 				}
 				if !c.messageWorker.TryEnqueue(msg) { // start to save non committee decided messages only post fork

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -74,7 +74,6 @@ type ControllerOptions struct {
 	RegistryStorage            nodestorage.Storage
 	RecipientsStorage          Recipients
 	NewDecidedHandler          qbftcontroller.NewDecidedHandler
-	NewParticipantsHandler     qbftcontroller.NewParticipantsHandler
 	DutyRoles                  []spectypes.BeaconRole
 	StorageMap                 *storage.QBFTStores
 	Metrics                    validator.Metrics
@@ -201,15 +200,14 @@ func NewController(logger *zap.Logger, options ControllerOptions) Controller {
 		//Share:   nil,  // set per validator
 		Signer: options.KeyManager,
 		//Mode: validator.ModeRW // set per validator
-		DutyRunners:            nil, // set per validator
-		NewDecidedHandler:      options.NewDecidedHandler,
-		NewParticipantsHandler: options.NewParticipantsHandler,
-		FullNode:               options.FullNode,
-		Exporter:               options.Exporter,
-		BuilderProposals:       options.BuilderProposals,
-		GasLimit:               options.GasLimit,
-		MessageValidator:       options.MessageValidator,
-		Metrics:                options.Metrics,
+		DutyRunners:       nil, // set per validator
+		NewDecidedHandler: options.NewDecidedHandler,
+		FullNode:          options.FullNode,
+		Exporter:          options.Exporter,
+		BuilderProposals:  options.BuilderProposals,
+		GasLimit:          options.GasLimit,
+		MessageValidator:  options.MessageValidator,
+		Metrics:           options.Metrics,
 	}
 
 	// If full node, increase queue size to make enough room

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -330,7 +330,7 @@ func (c *controller) handleRouterMessages() {
 			if v, ok := c.validatorsMap.GetValidator(hexPK); ok {
 				v.HandleMessage(c.logger, msg)
 			} else if c.validatorOptions.Exporter {
-				if msg.MsgType != spectypes.SSVConsensusMsgType {
+				if msg.MsgType != spectypes.SSVPartialSignatureMsgType {
 					continue // not supporting other types
 				}
 				if !c.messageWorker.TryEnqueue(msg) { // start to save non committee decided messages only post fork

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -79,6 +79,7 @@ type ControllerOptions struct {
 	Metrics                    validator.Metrics
 	MessageValidator           validation.MessageValidator
 	ValidatorsMap              *validatorsmap.ValidatorsMap
+	UseNewExporterAPI          bool `yaml:"MsgWorkersCount" env:"MSG_WORKERS_COUNT" env-description:"Use new exporter API which is simpler and has no workarounds"`
 
 	// worker flags
 	WorkersCount    int `yaml:"MsgWorkersCount" env:"MSG_WORKERS_COUNT" env-default:"256" env-description:"Number of goroutines to use for message workers"`

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -74,6 +74,7 @@ type ControllerOptions struct {
 	RegistryStorage            nodestorage.Storage
 	RecipientsStorage          Recipients
 	NewDecidedHandler          qbftcontroller.NewDecidedHandler
+	NewParticipantsHandler     qbftcontroller.NewParticipantsHandler
 	DutyRoles                  []spectypes.BeaconRole
 	StorageMap                 *storage.QBFTStores
 	Metrics                    validator.Metrics

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -893,7 +893,6 @@ func SetupRunners(ctx context.Context, logger *zap.Logger, options validator.Opt
 
 		identifier := spectypes.NewMsgID(ssvtypes.GetDefaultDomain(), options.SSVShare.Share.ValidatorPubKey, role)
 		qbftCtrl := qbftcontroller.NewController(identifier[:], &options.SSVShare.Share, config, options.FullNode)
-		qbftCtrl.NewDecidedHandler = options.NewDecidedHandler
 		return qbftCtrl
 	}
 

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -201,14 +201,15 @@ func NewController(logger *zap.Logger, options ControllerOptions) Controller {
 		//Share:   nil,  // set per validator
 		Signer: options.KeyManager,
 		//Mode: validator.ModeRW // set per validator
-		DutyRunners:       nil, // set per validator
-		NewDecidedHandler: options.NewDecidedHandler,
-		FullNode:          options.FullNode,
-		Exporter:          options.Exporter,
-		BuilderProposals:  options.BuilderProposals,
-		GasLimit:          options.GasLimit,
-		MessageValidator:  options.MessageValidator,
-		Metrics:           options.Metrics,
+		DutyRunners:            nil, // set per validator
+		NewDecidedHandler:      options.NewDecidedHandler,
+		NewParticipantsHandler: options.NewParticipantsHandler,
+		FullNode:               options.FullNode,
+		Exporter:               options.Exporter,
+		BuilderProposals:       options.BuilderProposals,
+		GasLimit:               options.GasLimit,
+		MessageValidator:       options.MessageValidator,
+		Metrics:                options.Metrics,
 	}
 
 	// If full node, increase queue size to make enough room

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -83,7 +83,7 @@ type ControllerOptions struct {
 
 	// worker flags
 	WorkersCount    int `yaml:"MsgWorkersCount" env:"MSG_WORKERS_COUNT" env-default:"256" env-description:"Number of goroutines to use for message workers"`
-	QueueBufferSize int `yaml:"MsgWorkerBufferSize" env:"MSG_WORKER_BUFFER_SIZE" env-default:"1024" env-description:"Buffer size for message workers"`
+	QueueBufferSize int `yaml:"MsgWorkerBufferSize" env:"MSG_WORKER_BUFFER_SIZE" env-default:"65536" env-description:"Buffer size for message workers"`
 	GasLimit        uint64
 }
 

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -79,7 +79,7 @@ type ControllerOptions struct {
 	Metrics                    validator.Metrics
 	MessageValidator           validation.MessageValidator
 	ValidatorsMap              *validatorsmap.ValidatorsMap
-	UseNewExporterAPI          bool `yaml:"MsgWorkersCount" env:"MSG_WORKERS_COUNT" env-description:"Use new exporter API which is simpler and has no workarounds"`
+	UseNewExporterAPI          bool `yaml:"UseNewExporterAPI" env:"USE_NEW_EXPORTER_API" env-description:"Use new exporter API which is simpler and has no workarounds"`
 
 	// worker flags
 	WorkersCount    int `yaml:"MsgWorkersCount" env:"MSG_WORKERS_COUNT" env-default:"256" env-description:"Number of goroutines to use for message workers"`

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -390,7 +390,7 @@ func (c *controller) handleWorkerMessages(msg *queue.DecodedSSVMessage) error {
 
 	// Process the message.
 	defer ncv.Unlock()
-	ncv.ProcessMessage(c.logger, msg)
+	ncv.ProcessMessage(msg)
 
 	return nil
 }

--- a/operator/validator/controller_test.go
+++ b/operator/validator/controller_test.go
@@ -233,7 +233,7 @@ func TestHandleNonCommitteeMessages(t *testing.T) {
 	identifier := spectypes.NewMsgID(networkconfig.TestNetwork.Domain, []byte("pk"), spectypes.BNRoleAttester)
 
 	ctr.messageRouter.Route(context.TODO(), &queue.DecodedSSVMessage{
-		SSVMessage: &spectypes.SSVMessage{
+		SSVMessage: &spectypes.SSVMessage{ // checks that not process unnecessary message
 			MsgType: spectypes.SSVConsensusMsgType,
 			MsgID:   identifier,
 			Data:    generateDecidedMessage(t, identifier),
@@ -241,7 +241,7 @@ func TestHandleNonCommitteeMessages(t *testing.T) {
 	})
 
 	ctr.messageRouter.Route(context.TODO(), &queue.DecodedSSVMessage{
-		SSVMessage: &spectypes.SSVMessage{
+		SSVMessage: &spectypes.SSVMessage{ // checks that not process unnecessary message
 			MsgType: spectypes.SSVConsensusMsgType,
 			MsgID:   identifier,
 			Data:    generateChangeRoundMsg(t, identifier),
@@ -257,10 +257,18 @@ func TestHandleNonCommitteeMessages(t *testing.T) {
 	})
 
 	ctr.messageRouter.Route(context.TODO(), &queue.DecodedSSVMessage{
-		SSVMessage: &spectypes.SSVMessage{ // checks that not process unnecessary message
+		SSVMessage: &spectypes.SSVMessage{
 			MsgType: spectypes.SSVPartialSignatureMsgType,
 			MsgID:   identifier,
 			Data:    []byte("data"),
+		},
+	})
+
+	ctr.messageRouter.Route(context.TODO(), &queue.DecodedSSVMessage{
+		SSVMessage: &spectypes.SSVMessage{
+			MsgType: spectypes.SSVPartialSignatureMsgType,
+			MsgID:   identifier,
+			Data:    []byte("data2"),
 		},
 	})
 

--- a/operator/validator/router.go
+++ b/operator/validator/router.go
@@ -8,7 +8,7 @@ import (
 	"github.com/bloxapp/ssv/protocol/v2/ssv/queue"
 )
 
-const bufSize = 1024
+const bufSize = 65536
 
 func newMessageRouter(logger *zap.Logger) *messageRouter {
 	return &messageRouter{

--- a/protocol/v2/qbft/controller/controller.go
+++ b/protocol/v2/qbft/controller/controller.go
@@ -19,9 +19,7 @@ import (
 
 // NewDecidedHandler handles newly saved decided messages.
 // it will be called in a new goroutine to avoid concurrency issues
-type NewDecidedHandler func(msg *specqbft.SignedMessage)
-
-type NewParticipantsHandler func(msg qbftstorage.ParticipantsRangeEntry)
+type NewDecidedHandler func(msg qbftstorage.ParticipantsRangeEntry)
 
 // Controller is a QBFT coordinator responsible for starting and following the entire life cycle of multiple QBFT InstanceContainer
 type Controller struct {

--- a/protocol/v2/qbft/controller/controller.go
+++ b/protocol/v2/qbft/controller/controller.go
@@ -14,11 +14,14 @@ import (
 	"github.com/bloxapp/ssv/logging/fields"
 	"github.com/bloxapp/ssv/protocol/v2/qbft"
 	"github.com/bloxapp/ssv/protocol/v2/qbft/instance"
+	qbftstorage "github.com/bloxapp/ssv/protocol/v2/qbft/storage"
 )
 
 // NewDecidedHandler handles newly saved decided messages.
 // it will be called in a new goroutine to avoid concurrency issues
 type NewDecidedHandler func(msg *specqbft.SignedMessage)
+
+type NewParticipantsHandler func(msg qbftstorage.ParticipantsRangeEntry)
 
 // Controller is a QBFT coordinator responsible for starting and following the entire life cycle of multiple QBFT InstanceContainer
 type Controller struct {

--- a/protocol/v2/qbft/controller/controller.go
+++ b/protocol/v2/qbft/controller/controller.go
@@ -26,11 +26,10 @@ type Controller struct {
 	Identifier []byte
 	Height     specqbft.Height // incremental Height for InstanceContainer
 	// StoredInstances stores the last HistoricalInstanceCapacity in an array for message processing purposes.
-	StoredInstances   InstanceContainer
-	Share             *spectypes.Share
-	NewDecidedHandler NewDecidedHandler `json:"-"`
-	config            qbft.IConfig
-	fullNode          bool
+	StoredInstances InstanceContainer
+	Share           *spectypes.Share
+	config          qbft.IConfig
+	fullNode        bool
 }
 
 func NewController(

--- a/protocol/v2/qbft/controller/decided.go
+++ b/protocol/v2/qbft/controller/decided.go
@@ -70,9 +70,6 @@ func (c *Controller) UponDecided(logger *zap.Logger, msg *specqbft.SignedMessage
 		// bump height
 		c.Height = msg.Message.Height
 	}
-	if c.NewDecidedHandler != nil {
-		c.NewDecidedHandler(msg)
-	}
 	if !prevDecided {
 		return msg, nil
 	}

--- a/protocol/v2/qbft/storage/ibft_store.go
+++ b/protocol/v2/qbft/storage/ibft_store.go
@@ -55,8 +55,13 @@ type InstanceStore interface {
 	// CleanAllInstances removes all historical and highest instances for the given identifier.
 	CleanAllInstances(logger *zap.Logger, msgID []byte) error
 
+	// SaveParticipants save participants in quorum.
 	SaveParticipants(identifier spectypes.MessageID, slot phase0.Slot, operators []spectypes.OperatorID) error
+
+	// GetParticipantsInRange returns participants in quorum for the given slot range.
 	GetParticipantsInRange(identifier spectypes.MessageID, from, to phase0.Slot) ([]ParticipantsRangeEntry, error)
+
+	// GetParticipants returns participants in quorum for the given slot.
 	GetParticipants(identifier spectypes.MessageID, slot phase0.Slot) ([]spectypes.OperatorID, error)
 }
 

--- a/protocol/v2/qbft/storage/ibft_store.go
+++ b/protocol/v2/qbft/storage/ibft_store.go
@@ -3,6 +3,8 @@ package qbftstorage
 import (
 	"encoding/json"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	spectypes "github.com/bloxapp/ssv-spec/types"
 	"go.uber.org/zap"
 
 	specqbft "github.com/bloxapp/ssv-spec/qbft"
@@ -22,6 +24,12 @@ func (si *StoredInstance) Encode() ([]byte, error) {
 // Decode returns error if decoding failed.
 func (si *StoredInstance) Decode(data []byte) error {
 	return json.Unmarshal(data, &si)
+}
+
+type ParticipantsRangeEntry struct {
+	Slot       phase0.Slot
+	Operators  []spectypes.OperatorID
+	Identifier spectypes.MessageID
 }
 
 // InstanceStore manages instance data.
@@ -46,6 +54,10 @@ type InstanceStore interface {
 
 	// CleanAllInstances removes all historical and highest instances for the given identifier.
 	CleanAllInstances(logger *zap.Logger, msgID []byte) error
+
+	SaveParticipants(identifier spectypes.MessageID, slot phase0.Slot, operators []spectypes.OperatorID) error
+	GetParticipantsInRange(identifier spectypes.MessageID, from, to phase0.Slot) ([]ParticipantsRangeEntry, error)
+	GetParticipants(identifier spectypes.MessageID, slot phase0.Slot) ([]spectypes.OperatorID, error)
 }
 
 // QBFTStore is the store used by QBFT components

--- a/protocol/v2/qbft/storage/ibft_store.go
+++ b/protocol/v2/qbft/storage/ibft_store.go
@@ -28,7 +28,7 @@ func (si *StoredInstance) Decode(data []byte) error {
 
 type ParticipantsRangeEntry struct {
 	Slot       phase0.Slot
-	Operators  []spectypes.OperatorID
+	Signers    []spectypes.OperatorID
 	Identifier spectypes.MessageID
 }
 

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -7,6 +7,7 @@ import (
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/herumi/bls-eth-go-binary/bls"
 	"go.uber.org/zap"
+	"golang.org/x/exp/slices"
 
 	"github.com/bloxapp/ssv/ibft/storage"
 	"github.com/bloxapp/ssv/logging/fields"
@@ -133,6 +134,7 @@ func (ncv *NonCommitteeValidator) processMessage(
 				for signer := range rootSignatures {
 					newSigners = append(newSigners, signer)
 				}
+				slices.Sort(newSigners)
 				quorums[msg.SigningRoot] = newSigners
 			}
 		}

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -52,8 +52,6 @@ func NewNonCommitteeValidator(logger *zap.Logger, identifier spectypes.MessageID
 	}
 }
 
-type loggerCtx struct{}
-
 func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 	logger := ncv.logger.With(fields.PubKey(msg.MsgID.GetPubKey()), fields.Role(msg.MsgID.GetRoleType()))
 
@@ -68,7 +66,7 @@ func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 
 	spsm := &spectypes.SignedPartialSignatureMessage{}
 	if err := spsm.Decode(msg.GetData()); err != nil {
-		logger.Debug("❗ failed to get consensus Message from network Message", zap.Error(err))
+		logger.Debug("❗ failed to get partial signature message from network message", zap.Error(err))
 		return
 	}
 
@@ -85,6 +83,7 @@ func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 			zap.Error(err))
 		return
 	}
+
 	if len(quorums) == 0 {
 		return
 	}

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -173,12 +173,12 @@ func (ncv *NonCommitteeValidator) verifyBeaconPartialSignature(signer uint64, si
 			if err != nil {
 				return fmt.Errorf("could not deserialized pk: %w", err)
 			}
+
 			sig := &bls.Sign{}
 			if err := sig.Deserialize(signature); err != nil {
 				return fmt.Errorf("could not deserialized Signature: %w", err)
 			}
 
-			// verify
 			if !sig.VerifyByte(&pk, root[:]) {
 				return fmt.Errorf("wrong signature")
 			}

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -69,7 +69,6 @@ func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 		return
 	}
 
-	// only supports post consensus msg's
 	if spsm.Message.Type != spectypes.PostConsensusPartialSig {
 		return
 	}
@@ -142,6 +141,7 @@ func (ncv *NonCommitteeValidator) processMessage(
 }
 
 // Stores the container's existing signature or the new one, depending on their validity. If both are invalid, remove the existing one
+// copied from BaseRunner
 func (ncv *NonCommitteeValidator) resolveDuplicateSignature(container *specssv.PartialSigContainer, msg *spectypes.PartialSignatureMessage) {
 	// Check previous signature validity
 	previousSignature, err := container.GetSignature(msg.Signer, msg.SigningRoot)
@@ -163,6 +163,7 @@ func (ncv *NonCommitteeValidator) resolveDuplicateSignature(container *specssv.P
 	}
 }
 
+// copied from BaseRunner
 func (ncv *NonCommitteeValidator) verifyBeaconPartialSignature(signer uint64, signature spectypes.Signature, root [32]byte) error {
 	types.MetricsSignaturesVerifications.WithLabelValues().Inc()
 

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -37,7 +37,6 @@ func NewNonCommitteeValidator(logger *zap.Logger, identifier spectypes.MessageID
 	}
 	ctrl := qbftcontroller.NewController(identifier[:], &opts.SSVShare.Share, config, opts.FullNode)
 	ctrl.StoredInstances = make(qbftcontroller.InstanceContainer, 0, nonCommitteeInstanceContainerCapacity(opts.FullNode))
-	ctrl.NewDecidedHandler = opts.NewDecidedHandler
 	if _, err := ctrl.LoadHighestInstance(identifier[:]); err != nil {
 		logger.Debug("❗ failed to load highest instance", zap.Error(err))
 	}

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -1,22 +1,28 @@
 package validator
 
 import (
-	specqbft "github.com/bloxapp/ssv-spec/qbft"
+	"fmt"
+
+	specssv "github.com/bloxapp/ssv-spec/ssv"
 	spectypes "github.com/bloxapp/ssv-spec/types"
+	"github.com/herumi/bls-eth-go-binary/bls"
 	"go.uber.org/zap"
 
 	"github.com/bloxapp/ssv/ibft/storage"
 	"github.com/bloxapp/ssv/logging/fields"
 	"github.com/bloxapp/ssv/protocol/v2/qbft"
 	qbftcontroller "github.com/bloxapp/ssv/protocol/v2/qbft/controller"
+	qbftstorage "github.com/bloxapp/ssv/protocol/v2/qbft/storage"
 	"github.com/bloxapp/ssv/protocol/v2/ssv/queue"
 	"github.com/bloxapp/ssv/protocol/v2/types"
 )
 
 type NonCommitteeValidator struct {
-	Share          *types.SSVShare
-	Storage        *storage.QBFTStores
-	qbftController *qbftcontroller.Controller
+	Share                  *types.SSVShare
+	Storage                *storage.QBFTStores
+	qbftController         *qbftcontroller.Controller
+	postConsensusContainer *specssv.PartialSigContainer
+	newParticipantsHandler qbftcontroller.NewParticipantsHandler
 }
 
 func NewNonCommitteeValidator(logger *zap.Logger, identifier spectypes.MessageID, opts Options) *NonCommitteeValidator {
@@ -35,9 +41,11 @@ func NewNonCommitteeValidator(logger *zap.Logger, identifier spectypes.MessageID
 	}
 
 	return &NonCommitteeValidator{
-		Share:          opts.SSVShare,
-		Storage:        opts.Storage,
-		qbftController: ctrl,
+		Share:                  opts.SSVShare,
+		Storage:                opts.Storage,
+		qbftController:         ctrl,
+		postConsensusContainer: specssv.NewPartialSigContainer(opts.SSVShare.Share.Quorum),
+		newParticipantsHandler: opts.NewParticipantsHandler,
 	}
 }
 
@@ -49,40 +57,46 @@ func (ncv *NonCommitteeValidator) ProcessMessage(logger *zap.Logger, msg *queue.
 		return
 	}
 
-	switch msg.GetType() {
-	case spectypes.SSVConsensusMsgType:
-		signedMsg := &specqbft.SignedMessage{}
-		if err := signedMsg.Decode(msg.GetData()); err != nil {
-			logger.Debug("❗ failed to get consensus Message from network Message", zap.Error(err))
-			return
-		}
-		// only supports decided msg's
-		if signedMsg.Message.MsgType != specqbft.CommitMsgType || !ncv.Share.HasQuorum(len(signedMsg.Signers)) {
-			return
-		}
-
-		logger = logger.With(fields.Height(signedMsg.Message.Height))
-
-		if decided, err := ncv.qbftController.ProcessMsg(logger, signedMsg); err != nil {
-			logger.Debug("❌ failed to process message",
-				zap.Uint64("msg_height", uint64(signedMsg.Message.Height)),
-				zap.Any("signers", signedMsg.Signers),
-				zap.Error(err))
-		} else if decided != nil {
-			if inst := ncv.qbftController.StoredInstances.FindInstance(signedMsg.Message.Height); inst != nil {
-				logger := logger.With(
-					zap.Uint64("msg_height", uint64(signedMsg.Message.Height)),
-					zap.Uint64("ctrl_height", uint64(ncv.qbftController.Height)),
-					zap.Any("signers", signedMsg.Signers),
-				)
-				if err = ncv.qbftController.SaveInstance(inst, signedMsg); err != nil {
-					logger.Debug("❗failed to save instance", zap.Error(err))
-				} else {
-					logger.Debug("💾 saved instance")
-				}
-			}
-		}
+	if msg.GetType() != spectypes.SSVPartialSignatureMsgType {
 		return
+	}
+	spsm := &spectypes.SignedPartialSignatureMessage{}
+	if err := spsm.Decode(msg.GetData()); err != nil {
+		logger.Debug("❗ failed to get consensus Message from network Message", zap.Error(err))
+		return
+	}
+
+	// only supports post consensus msg's
+	if spsm.Message.Type != spectypes.PostConsensusPartialSig {
+		return
+	}
+
+	logger = logger.With(fields.Slot(spsm.Message.Slot))
+
+	quorums, err := ncv.processMessage(spsm)
+	if err != nil {
+		logger.Debug("❌ could not process SignedPartialSignatureMessage",
+			zap.Error(err))
+		return
+	}
+	if len(quorums) == 0 {
+		logger.Debug("received SignedPartialSignatureMessage, no quorum")
+		return
+	}
+
+	logger.Debug("received SignedPartialSignatureMessage, has quorum", fields.Count(len(quorums)))
+
+	for _, quorum := range quorums {
+		if err := ncv.Storage.Get(msg.GetID().GetRoleType()).SaveParticipants(msg.GetID(), spsm.Message.Slot, quorum); err != nil {
+			logger.Error("❌ could not save participants", zap.Error(err))
+			return
+		}
+
+		ncv.newParticipantsHandler(qbftstorage.ParticipantsRangeEntry{
+			Slot:       spsm.Message.Slot,
+			Operators:  quorum,
+			Identifier: msg.GetID(),
+		})
 	}
 }
 
@@ -93,4 +107,78 @@ func nonCommitteeInstanceContainerCapacity(fullNode bool) int {
 		return 2
 	}
 	return 1
+}
+
+func (ncv *NonCommitteeValidator) processMessage(
+	signedMsg *spectypes.SignedPartialSignatureMessage,
+) (map[[32]byte][]spectypes.OperatorID, error) {
+	quorums := make(map[[32]byte][]spectypes.OperatorID)
+
+	for _, msg := range signedMsg.Message.Messages {
+		if ncv.postConsensusContainer.HasSigner(msg.Signer, msg.SigningRoot) {
+			ncv.resolveDuplicateSignature(ncv.postConsensusContainer, msg)
+		} else {
+			ncv.postConsensusContainer.AddSignature(msg)
+		}
+
+		rootSignatures := ncv.postConsensusContainer.GetSignatures(msg.SigningRoot)
+		if uint64(len(rootSignatures)) >= ncv.Share.Quorum {
+			longestSigners := quorums[msg.SigningRoot]
+			if newLength := len(rootSignatures); newLength > len(longestSigners) {
+				newSigners := make([]spectypes.OperatorID, 0, newLength)
+				for signer := range rootSignatures {
+					newSigners = append(newSigners, signer)
+				}
+				quorums[msg.SigningRoot] = newSigners
+			}
+		}
+	}
+
+	return quorums, nil
+}
+
+// Stores the container's existing signature or the new one, depending on their validity. If both are invalid, remove the existing one
+func (ncv *NonCommitteeValidator) resolveDuplicateSignature(container *specssv.PartialSigContainer, msg *spectypes.PartialSignatureMessage) {
+	// Check previous signature validity
+	previousSignature, err := container.GetSignature(msg.Signer, msg.SigningRoot)
+	if err == nil {
+		err = ncv.verifyBeaconPartialSignature(msg.Signer, previousSignature, msg.SigningRoot)
+		if err == nil {
+			// Keep the previous sigature since it's correct
+			return
+		}
+	}
+
+	// Previous signature is incorrect or doesn't exist
+	container.Remove(msg.Signer, msg.SigningRoot)
+
+	// Hold the new signature, if correct
+	err = ncv.verifyBeaconPartialSignature(msg.Signer, msg.PartialSignature, msg.SigningRoot)
+	if err == nil {
+		container.AddSignature(msg)
+	}
+}
+
+func (ncv *NonCommitteeValidator) verifyBeaconPartialSignature(signer uint64, signature spectypes.Signature, root [32]byte) error {
+	types.MetricsSignaturesVerifications.WithLabelValues().Inc()
+
+	for _, n := range ncv.Share.Committee {
+		if n.GetID() == signer {
+			pk, err := types.DeserializeBLSPublicKey(n.GetPublicKey())
+			if err != nil {
+				return fmt.Errorf("could not deserialized pk: %w", err)
+			}
+			sig := &bls.Sign{}
+			if err := sig.Deserialize(signature); err != nil {
+				return fmt.Errorf("could not deserialized Signature: %w", err)
+			}
+
+			// verify
+			if !sig.VerifyByte(&pk, root[:]) {
+				return fmt.Errorf("wrong signature")
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown signer")
 }

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -24,7 +24,7 @@ type NonCommitteeValidator struct {
 	Storage                *storage.QBFTStores
 	qbftController         *qbftcontroller.Controller
 	postConsensusContainer *specssv.PartialSigContainer
-	newParticipantsHandler qbftcontroller.NewParticipantsHandler
+	newDecidedHandler      qbftcontroller.NewDecidedHandler
 }
 
 func NewNonCommitteeValidator(logger *zap.Logger, identifier spectypes.MessageID, opts Options) *NonCommitteeValidator {
@@ -48,7 +48,7 @@ func NewNonCommitteeValidator(logger *zap.Logger, identifier spectypes.MessageID
 		Storage:                opts.Storage,
 		qbftController:         ctrl,
 		postConsensusContainer: specssv.NewPartialSigContainer(opts.SSVShare.Share.Quorum),
-		newParticipantsHandler: opts.NewParticipantsHandler,
+		newDecidedHandler:      opts.NewDecidedHandler,
 	}
 }
 
@@ -94,8 +94,8 @@ func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 			return
 		}
 
-		if ncv.newParticipantsHandler != nil {
-			ncv.newParticipantsHandler(qbftstorage.ParticipantsRangeEntry{
+		if ncv.newDecidedHandler != nil {
+			ncv.newDecidedHandler(qbftstorage.ParticipantsRangeEntry{
 				Slot:       spsm.Message.Slot,
 				Operators:  quorum,
 				Identifier: msg.GetID(),

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -65,8 +65,6 @@ func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 		return
 	}
 
-	logger.Debug("ncv got a SSVPartialSignatureMsgType message")
-
 	spsm := &spectypes.SignedPartialSignatureMessage{}
 	if err := spsm.Decode(msg.GetData()); err != nil {
 		logger.Debug("❗ failed to get consensus Message from network Message", zap.Error(err))
@@ -87,11 +85,8 @@ func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 		return
 	}
 	if len(quorums) == 0 {
-		logger.Debug("received SignedPartialSignatureMessage, no quorum")
 		return
 	}
-
-	logger.Debug("received SignedPartialSignatureMessage, has quorum", fields.Count(len(quorums)))
 
 	for _, quorum := range quorums {
 		if err := ncv.Storage.Get(msg.GetID().GetRoleType()).SaveParticipants(msg.GetID(), spsm.Message.Slot, quorum); err != nil {

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -67,6 +67,9 @@ func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 	if msg.GetType() != spectypes.SSVPartialSignatureMsgType {
 		return
 	}
+
+	logger.Debug("ncv got a SSVPartialSignatureMsgType message")
+
 	spsm := &spectypes.SignedPartialSignatureMessage{}
 	if err := spsm.Decode(msg.GetData()); err != nil {
 		logger.Debug("❗ failed to get consensus Message from network Message", zap.Error(err))
@@ -77,6 +80,8 @@ func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 	if spsm.Message.Type != spectypes.PostConsensusPartialSig {
 		return
 	}
+
+	logger.Debug("ncv got a PostConsensusPartialSig message")
 
 	logger = logger.With(fields.Slot(spsm.Message.Slot))
 

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -57,8 +57,6 @@ type loggerCtx struct{}
 func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 	logger := ncv.logger.With(fields.PubKey(msg.MsgID.GetPubKey()), fields.Role(msg.MsgID.GetRoleType()))
 
-	logger.Debug("ncv got a message", zap.Any("type", msg.GetType()))
-
 	if err := validateMessage(ncv.Share.Share, msg); err != nil {
 		logger.Debug("❌ got invalid message", zap.Error(err))
 		return

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -96,7 +96,7 @@ func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 		if ncv.newDecidedHandler != nil {
 			ncv.newDecidedHandler(qbftstorage.ParticipantsRangeEntry{
 				Slot:       spsm.Message.Slot,
-				Operators:  quorum,
+				Signers:    quorum,
 				Identifier: msg.GetID(),
 			})
 		}

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -3,7 +3,6 @@ package validator
 import (
 	"fmt"
 
-	specqbft "github.com/bloxapp/ssv-spec/qbft"
 	specssv "github.com/bloxapp/ssv-spec/ssv"
 	spectypes "github.com/bloxapp/ssv-spec/types"
 	"github.com/herumi/bls-eth-go-binary/bls"
@@ -61,79 +60,46 @@ func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 		return
 	}
 
-	switch msg.GetType() {
-	case spectypes.SSVConsensusMsgType: // deprecated, to be removed when explorer is adjusted to the API changes
-		signedMsg := &specqbft.SignedMessage{}
-		if err := signedMsg.Decode(msg.GetData()); err != nil {
-			logger.Debug("❗ failed to get consensus Message from network Message", zap.Error(err))
-			return
-		}
-		// only supports decided msg's
-		if signedMsg.Message.MsgType != specqbft.CommitMsgType || !ncv.Share.HasQuorum(len(signedMsg.Signers)) {
-			return
-		}
-
-		logger = logger.With(fields.Height(signedMsg.Message.Height))
-
-		if decided, err := ncv.qbftController.ProcessMsg(logger, signedMsg); err != nil {
-			logger.Debug("❌ failed to process message",
-				zap.Uint64("msg_height", uint64(signedMsg.Message.Height)),
-				zap.Any("signers", signedMsg.Signers),
-				zap.Error(err))
-		} else if decided != nil {
-			if inst := ncv.qbftController.StoredInstances.FindInstance(signedMsg.Message.Height); inst != nil {
-				logger := logger.With(
-					zap.Uint64("msg_height", uint64(signedMsg.Message.Height)),
-					zap.Uint64("ctrl_height", uint64(ncv.qbftController.Height)),
-					zap.Any("signers", signedMsg.Signers),
-				)
-				if err = ncv.qbftController.SaveInstance(inst, signedMsg); err != nil {
-					logger.Debug("❗failed to save instance", zap.Error(err))
-				} else {
-					logger.Debug("💾 saved instance")
-				}
-			}
-		}
+	if msg.GetType() != spectypes.SSVPartialSignatureMsgType {
 		return
+	}
 
-	case spectypes.SSVPartialSignatureMsgType:
-		spsm := &spectypes.SignedPartialSignatureMessage{}
-		if err := spsm.Decode(msg.GetData()); err != nil {
-			logger.Debug("❗ failed to get partial signature message from network message", zap.Error(err))
+	spsm := &spectypes.SignedPartialSignatureMessage{}
+	if err := spsm.Decode(msg.GetData()); err != nil {
+		logger.Debug("❗ failed to get partial signature message from network message", zap.Error(err))
+		return
+	}
+
+	// only supports post consensus msg's
+	if spsm.Message.Type != spectypes.PostConsensusPartialSig {
+		return
+	}
+
+	logger = logger.With(fields.Slot(spsm.Message.Slot))
+
+	quorums, err := ncv.processMessage(spsm)
+	if err != nil {
+		logger.Debug("❌ could not process SignedPartialSignatureMessage",
+			zap.Error(err))
+		return
+	}
+
+	if len(quorums) == 0 {
+		return
+	}
+
+	for _, quorum := range quorums {
+		if err := ncv.Storage.Get(msg.GetID().GetRoleType()).SaveParticipants(msg.GetID(), spsm.Message.Slot, quorum); err != nil {
+			logger.Error("❌ could not save participants", zap.Error(err))
 			return
 		}
 
-		// only supports post consensus msg's
-		if spsm.Message.Type != spectypes.PostConsensusPartialSig {
-			return
-		}
-
-		logger = logger.With(fields.Slot(spsm.Message.Slot))
-
-		quorums, err := ncv.processPartialSigMessage(spsm)
-		if err != nil {
-			logger.Debug("❌ could not process SignedPartialSignatureMessage",
-				zap.Error(err))
-			return
-		}
-
-		if len(quorums) == 0 {
-			return
-		}
-
-		for _, quorum := range quorums {
-			if err := ncv.Storage.Get(msg.GetID().GetRoleType()).SaveParticipants(msg.GetID(), spsm.Message.Slot, quorum); err != nil {
-				logger.Error("❌ could not save participants", zap.Error(err))
-				return
-			}
-
-			if ncv.newParticipantsHandler != nil {
-				ncv.newParticipantsHandler(qbftstorage.ParticipantsRangeEntry{
-					Slot:       spsm.Message.Slot,
-					Operators:  quorum,
-					Identifier: msg.GetID(),
-				})
-			}
+		if ncv.newParticipantsHandler != nil {
+			ncv.newParticipantsHandler(qbftstorage.ParticipantsRangeEntry{
+				Slot:       spsm.Message.Slot,
+				Operators:  quorum,
+				Identifier: msg.GetID(),
+			})
 		}
 	}
 }
@@ -147,7 +113,7 @@ func nonCommitteeInstanceContainerCapacity(fullNode bool) int {
 	return 1
 }
 
-func (ncv *NonCommitteeValidator) processPartialSigMessage(
+func (ncv *NonCommitteeValidator) processMessage(
 	signedMsg *spectypes.SignedPartialSignatureMessage,
 ) (map[[32]byte][]spectypes.OperatorID, error) {
 	quorums := make(map[[32]byte][]spectypes.OperatorID)

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -57,6 +57,8 @@ type loggerCtx struct{}
 func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 	logger := ncv.logger.With(fields.PubKey(msg.MsgID.GetPubKey()), fields.Role(msg.MsgID.GetRoleType()))
 
+	logger.Debug("ncv got a message")
+
 	if err := validateMessage(ncv.Share.Share, msg); err != nil {
 		logger.Debug("❌ got invalid message", zap.Error(err))
 		return

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -57,7 +57,7 @@ type loggerCtx struct{}
 func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 	logger := ncv.logger.With(fields.PubKey(msg.MsgID.GetPubKey()), fields.Role(msg.MsgID.GetRoleType()))
 
-	logger.Debug("ncv got a message")
+	logger.Debug("ncv got a message", zap.Any("type", msg.GetType()))
 
 	if err := validateMessage(ncv.Share.Share, msg); err != nil {
 		logger.Debug("❌ got invalid message", zap.Error(err))

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -103,11 +103,13 @@ func (ncv *NonCommitteeValidator) ProcessMessage(msg *queue.DecodedSSVMessage) {
 			return
 		}
 
-		ncv.newParticipantsHandler(qbftstorage.ParticipantsRangeEntry{
-			Slot:       spsm.Message.Slot,
-			Operators:  quorum,
-			Identifier: msg.GetID(),
-		})
+		if ncv.newParticipantsHandler != nil {
+			ncv.newParticipantsHandler(qbftstorage.ParticipantsRangeEntry{
+				Slot:       spsm.Message.Slot,
+				Operators:  quorum,
+				Identifier: msg.GetID(),
+			})
+		}
 	}
 }
 

--- a/protocol/v2/ssv/validator/opts.go
+++ b/protocol/v2/ssv/validator/opts.go
@@ -19,22 +19,21 @@ const (
 
 // Options represents options that should be passed to a new instance of Validator.
 type Options struct {
-	Network                specqbft.Network
-	Beacon                 specssv.BeaconNode
-	BeaconNetwork          beacon.BeaconNetwork
-	Storage                *storage.QBFTStores
-	SSVShare               *types.SSVShare
-	Signer                 spectypes.KeyManager
-	DutyRunners            runner.DutyRunners
-	NewDecidedHandler      qbftctrl.NewDecidedHandler
-	NewParticipantsHandler qbftctrl.NewParticipantsHandler
-	FullNode               bool
-	Exporter               bool
-	BuilderProposals       bool
-	QueueSize              int
-	GasLimit               uint64
-	MessageValidator       validation.MessageValidator
-	Metrics                Metrics
+	Network           specqbft.Network
+	Beacon            specssv.BeaconNode
+	BeaconNetwork     beacon.BeaconNetwork
+	Storage           *storage.QBFTStores
+	SSVShare          *types.SSVShare
+	Signer            spectypes.KeyManager
+	DutyRunners       runner.DutyRunners
+	NewDecidedHandler qbftctrl.NewDecidedHandler
+	FullNode          bool
+	Exporter          bool
+	BuilderProposals  bool
+	QueueSize         int
+	GasLimit          uint64
+	MessageValidator  validation.MessageValidator
+	Metrics           Metrics
 }
 
 func (o *Options) defaults() {

--- a/protocol/v2/ssv/validator/opts.go
+++ b/protocol/v2/ssv/validator/opts.go
@@ -19,21 +19,22 @@ const (
 
 // Options represents options that should be passed to a new instance of Validator.
 type Options struct {
-	Network           specqbft.Network
-	Beacon            specssv.BeaconNode
-	BeaconNetwork     beacon.BeaconNetwork
-	Storage           *storage.QBFTStores
-	SSVShare          *types.SSVShare
-	Signer            spectypes.KeyManager
-	DutyRunners       runner.DutyRunners
-	NewDecidedHandler qbftctrl.NewDecidedHandler
-	FullNode          bool
-	Exporter          bool
-	BuilderProposals  bool
-	QueueSize         int
-	GasLimit          uint64
-	MessageValidator  validation.MessageValidator
-	Metrics           Metrics
+	Network                specqbft.Network
+	Beacon                 specssv.BeaconNode
+	BeaconNetwork          beacon.BeaconNetwork
+	Storage                *storage.QBFTStores
+	SSVShare               *types.SSVShare
+	Signer                 spectypes.KeyManager
+	DutyRunners            runner.DutyRunners
+	NewDecidedHandler      qbftctrl.NewDecidedHandler
+	NewParticipantsHandler qbftctrl.NewParticipantsHandler
+	FullNode               bool
+	Exporter               bool
+	BuilderProposals       bool
+	QueueSize              int
+	GasLimit               uint64
+	MessageValidator       validation.MessageValidator
+	Metrics                Metrics
 }
 
 func (o *Options) defaults() {


### PR DESCRIPTION
The PR changes the exporter message handling logic to use partial signature messages instead of decided messages to gather information about consensus participants.

Since decided messages are not used anymore, the old API returning decided messages behaves a bit differently, constructing a "decided" message from information in the partial signature messages, but some fields are not available anymore, however, it's still compatible with the explorer, because it uses just a few fields. So, the old API is just a workaround for compatibility with the explorer.

There's also a new API that is simple/straightforward but requires changes to the explorer.

Examples of API:

Old
```json
{"type":"decided","filter":{"from":1439466,"to":1439500,"role":"ATTESTER","publicKey":"aadcd9e473fa356a10dc14c876d1570d0f9affb39d479b317d39a93393d64b3608bb82220eb7011f659c5adc0275ac96"},"data":[{"Signature":null,"Signers":[29,30,31],"Message":{"MsgType":2,"Height":1439466,"Round":0,"Identifier":"AAAxEqrc2eRz+jVqENwUyHbRVw0Pmv+znUebMX05qTOT1ks2CLuCIg63AR9lnFrcAnWslgAAAAA=","Root":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"DataRound":0,"RoundChangeJustification":null,"PrepareJustification":null},"FullData":{"Duty":{"Type":0,"PubKey":"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","Slot":"1439466","ValidatorIndex":"0","CommitteeIndex":0,"CommitteeLength":0,"CommitteesAtSlot":0,"ValidatorCommitteeIndex":0,"ValidatorSyncCommitteeIndices":null},"Version":"unknown","PreConsensusJustifications":null,"DataSSZ":null}}]}
```

New
```json
{"type":"participants","filter":{"from":1439466,"to":1439500,"role":"ATTESTER","publicKey":"aadcd9e473fa356a10dc14c876d1570d0f9affb39d479b317d39a93393d64b3608bb82220eb7011f659c5adc0275ac96"},"data":[{"Signers":[29,30,31],"Slot":"1439466","Identifier":"AAAxEqrc2eRz+jVqENwUyHbRVw0Pmv+znUebMX05qTOT1ks2CLuCIg63AR9lnFrcAnWslgAAAAA=","ValidatorPK":"aadcd9e473fa356a10dc14c876d1570d0f9affb39d479b317d39a93393d64b3608bb82220eb7011f659c5adc0275ac96","Role":"ATTESTER"}]}
```