### PR TITLE
feat: disable ip rate limit

### DIFF
--- a/.k8/hetzner-stage/ssv-exporter-holesky.yml
+++ b/.k8/hetzner-stage/ssv-exporter-holesky.yml
@@ -132,6 +132,8 @@ spec:
               value: "false"
             - name: PUBSUB_TRACE
               value: "false"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-exporter-holesky

--- a/.k8/hetzner-stage/ssv-node-1-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-1-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-1

--- a/.k8/hetzner-stage/ssv-node-10-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-10-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-10

--- a/.k8/hetzner-stage/ssv-node-11-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-11-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-11

--- a/.k8/hetzner-stage/ssv-node-12-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-12-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-12

--- a/.k8/hetzner-stage/ssv-node-13-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-13-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-13

--- a/.k8/hetzner-stage/ssv-node-14-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-14-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-14

--- a/.k8/hetzner-stage/ssv-node-15-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-15-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-15

--- a/.k8/hetzner-stage/ssv-node-16-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-16-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-16

--- a/.k8/hetzner-stage/ssv-node-17-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-17-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-17

--- a/.k8/hetzner-stage/ssv-node-18-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-18-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-18

--- a/.k8/hetzner-stage/ssv-node-19-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-19-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-19

--- a/.k8/hetzner-stage/ssv-node-2-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-2-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-2

--- a/.k8/hetzner-stage/ssv-node-20-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-20-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-20

--- a/.k8/hetzner-stage/ssv-node-21-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-21-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-21

--- a/.k8/hetzner-stage/ssv-node-22-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-22-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-22

--- a/.k8/hetzner-stage/ssv-node-23-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-23-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-23

--- a/.k8/hetzner-stage/ssv-node-24-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-24-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-24

--- a/.k8/hetzner-stage/ssv-node-25-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-25-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-25

--- a/.k8/hetzner-stage/ssv-node-26-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-26-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-26

--- a/.k8/hetzner-stage/ssv-node-27-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-27-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-27

--- a/.k8/hetzner-stage/ssv-node-28-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-28-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-28

--- a/.k8/hetzner-stage/ssv-node-29-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-29-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-29

--- a/.k8/hetzner-stage/ssv-node-3-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-3-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-3

--- a/.k8/hetzner-stage/ssv-node-30-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-30-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-30

--- a/.k8/hetzner-stage/ssv-node-31-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-31-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-31

--- a/.k8/hetzner-stage/ssv-node-32-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-32-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-32

--- a/.k8/hetzner-stage/ssv-node-33-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-33-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-33

--- a/.k8/hetzner-stage/ssv-node-34-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-34-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-34

--- a/.k8/hetzner-stage/ssv-node-35-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-35-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-35

--- a/.k8/hetzner-stage/ssv-node-36-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-36-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-36

--- a/.k8/hetzner-stage/ssv-node-37-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-37-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-37

--- a/.k8/hetzner-stage/ssv-node-38-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-38-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-38

--- a/.k8/hetzner-stage/ssv-node-39-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-39-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-39

--- a/.k8/hetzner-stage/ssv-node-4-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-4-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-4

--- a/.k8/hetzner-stage/ssv-node-40-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-40-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-40

--- a/.k8/hetzner-stage/ssv-node-41-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-41-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-41

--- a/.k8/hetzner-stage/ssv-node-42-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-42-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-42

--- a/.k8/hetzner-stage/ssv-node-43-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-43-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-43

--- a/.k8/hetzner-stage/ssv-node-44-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-44-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-44

--- a/.k8/hetzner-stage/ssv-node-45-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-45-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-45

--- a/.k8/hetzner-stage/ssv-node-46-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-46-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-46

--- a/.k8/hetzner-stage/ssv-node-47-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-47-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-47

--- a/.k8/hetzner-stage/ssv-node-48-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-48-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-48

--- a/.k8/hetzner-stage/ssv-node-49-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-49-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-49

--- a/.k8/hetzner-stage/ssv-node-5-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-5-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-5

--- a/.k8/hetzner-stage/ssv-node-50-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-50-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-50

--- a/.k8/hetzner-stage/ssv-node-51-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-51-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-51

--- a/.k8/hetzner-stage/ssv-node-52-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-52-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-52

--- a/.k8/hetzner-stage/ssv-node-53-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-53-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-53

--- a/.k8/hetzner-stage/ssv-node-54-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-54-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-54

--- a/.k8/hetzner-stage/ssv-node-55-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-55-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-55

--- a/.k8/hetzner-stage/ssv-node-56-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-56-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-56

--- a/.k8/hetzner-stage/ssv-node-57-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-57-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-57

--- a/.k8/hetzner-stage/ssv-node-58-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-58-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-58

--- a/.k8/hetzner-stage/ssv-node-59-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-59-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-59

--- a/.k8/hetzner-stage/ssv-node-6-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-6-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-6

--- a/.k8/hetzner-stage/ssv-node-60-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-60-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-60

--- a/.k8/hetzner-stage/ssv-node-61-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-61-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-61

--- a/.k8/hetzner-stage/ssv-node-62-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-62-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-62

--- a/.k8/hetzner-stage/ssv-node-63-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-63-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-63

--- a/.k8/hetzner-stage/ssv-node-64-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-64-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-64

--- a/.k8/hetzner-stage/ssv-node-65-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-65-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-65

--- a/.k8/hetzner-stage/ssv-node-66-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-66-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-66

--- a/.k8/hetzner-stage/ssv-node-67-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-67-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-67

--- a/.k8/hetzner-stage/ssv-node-68-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-68-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-68

--- a/.k8/hetzner-stage/ssv-node-69-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-69-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-69

--- a/.k8/hetzner-stage/ssv-node-7-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-7-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-7

--- a/.k8/hetzner-stage/ssv-node-70-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-70-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-70

--- a/.k8/hetzner-stage/ssv-node-71-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-71-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-71

--- a/.k8/hetzner-stage/ssv-node-72-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-72-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-72

--- a/.k8/hetzner-stage/ssv-node-8-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-8-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-8

--- a/.k8/hetzner-stage/ssv-node-9-deployment.yml
+++ b/.k8/hetzner-stage/ssv-node-9-deployment.yml
@@ -116,6 +116,8 @@ spec:
               value: 'false'
             - name: BUILDER_PROPOSALS
               value: "true"
+            - name: DISABLE_IP_RATE_LIMIT
+              value: "true"
           volumeMounts:
             - mountPath: /data
               name: ssv-node-9

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -86,6 +86,8 @@ type Config struct {
 	// If false, SyncDecidedByRange becomes a no-op.
 	FullNode bool
 
+	DisableIPRateLimit bool `yaml:"DisableIPRateLimit" env:"DISABLE_IP_RATE_LIMIT" default:"false" env-description:"Flag to turn on/off IP rate limiting"`
+
 	GetValidatorStats network.GetValidatorStats
 
 	// PeerScoreInspector is called periodically to inspect the peer scores.

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -121,7 +121,7 @@ func (n *p2pNetwork) SetupHost(logger *zap.Logger) error {
 	if err != nil {
 		return errors.Wrap(err, "could not create resource manager")
 	}
-	n.connGater = connections.NewConnectionGater(logger, n.connectionsAtLimit)
+	n.connGater = connections.NewConnectionGater(logger, n.cfg.DisableIPRateLimit, n.connectionsAtLimit)
 	opts = append(opts, libp2p.ResourceManager(rmgr), libp2p.ConnectionGater(n.connGater))
 	host, err := libp2p.New(opts...)
 	if err != nil {
@@ -276,6 +276,7 @@ func (n *p2pNetwork) setupPubsub(logger *zap.Logger) error {
 		ValidationQueueSize: n.cfg.PubsubValidationQueueSize,
 		ValidateThrottle:    n.cfg.PubsubValidateThrottle,
 		MsgIDCacheTTL:       n.cfg.PubsubMsgCacheTTL,
+		DisableIPRateLimit:  n.cfg.DisableIPRateLimit,
 		GetValidatorStats:   n.cfg.GetValidatorStats,
 	}
 

--- a/network/topics/params/peer_score.go
+++ b/network/topics/params/peer_score.go
@@ -45,7 +45,7 @@ func PeerScoreThresholds() *pubsub.PeerScoreThresholds {
 }
 
 // PeerScoreParams returns peer score params according to the given options
-func PeerScoreParams(oneEpoch, msgIDCacheTTL time.Duration, disableCoLocation bool, ipWhilelist ...*net.IPNet) *pubsub.PeerScoreParams {
+func PeerScoreParams(oneEpoch, msgIDCacheTTL time.Duration, disableColocation bool, ipWhilelist ...*net.IPNet) *pubsub.PeerScoreParams {
 	if oneEpoch == 0 {
 		oneEpoch = oneEpochDuration
 	}
@@ -57,9 +57,9 @@ func PeerScoreParams(oneEpoch, msgIDCacheTTL time.Duration, disableCoLocation bo
 	targetVal = targetVal - behaviourPenaltyThreshold
 	behaviourPenaltyWeight := gossipThreshold / (targetVal * targetVal)
 
-	localIPColocationFactorWeight := ipColocationFactorWeight
-	if disableCoLocation {
-		localIPColocationFactorWeight = 0
+	finalIPColocationFactorWeight := ipColocationFactorWeight
+	if disableColocation {
+		finalIPColocationFactorWeight = 0
 	}
 
 	return &pubsub.PeerScoreParams{
@@ -78,7 +78,7 @@ func PeerScoreParams(oneEpoch, msgIDCacheTTL time.Duration, disableCoLocation bo
 		AppSpecificWeight: appSpecificWeight,
 
 		// P6
-		IPColocationFactorWeight:    localIPColocationFactorWeight,
+		IPColocationFactorWeight:    finalIPColocationFactorWeight,
 		IPColocationFactorThreshold: ipColocationFactorThreshold,
 		IPColocationFactorWhitelist: ipWhilelist,
 

--- a/network/topics/params/peer_score.go
+++ b/network/topics/params/peer_score.go
@@ -45,7 +45,7 @@ func PeerScoreThresholds() *pubsub.PeerScoreThresholds {
 }
 
 // PeerScoreParams returns peer score params according to the given options
-func PeerScoreParams(oneEpoch, msgIDCacheTTL time.Duration, ipWhilelist ...*net.IPNet) *pubsub.PeerScoreParams {
+func PeerScoreParams(oneEpoch, msgIDCacheTTL time.Duration, disableCoLocation bool, ipWhilelist ...*net.IPNet) *pubsub.PeerScoreParams {
 	if oneEpoch == 0 {
 		oneEpoch = oneEpochDuration
 	}
@@ -56,6 +56,11 @@ func PeerScoreParams(oneEpoch, msgIDCacheTTL time.Duration, ipWhilelist ...*net.
 	targetVal, _ := decayConvergence(behaviourPenaltyDecay, maxAllowedRatePerDecayInterval)
 	targetVal = targetVal - behaviourPenaltyThreshold
 	behaviourPenaltyWeight := gossipThreshold / (targetVal * targetVal)
+
+	localIPColocationFactorWeight := ipColocationFactorWeight
+	if disableCoLocation {
+		localIPColocationFactorWeight = 0
+	}
 
 	return &pubsub.PeerScoreParams{
 		Topics: make(map[string]*pubsub.TopicScoreParams),
@@ -73,7 +78,7 @@ func PeerScoreParams(oneEpoch, msgIDCacheTTL time.Duration, ipWhilelist ...*net.
 		AppSpecificWeight: appSpecificWeight,
 
 		// P6
-		IPColocationFactorWeight:    ipColocationFactorWeight,
+		IPColocationFactorWeight:    localIPColocationFactorWeight,
 		IPColocationFactorThreshold: ipColocationFactorThreshold,
 		IPColocationFactorWhitelist: ipWhilelist,
 

--- a/network/topics/params/scores_test.go
+++ b/network/topics/params/scores_test.go
@@ -63,7 +63,7 @@ func TestTopicScoreParams(t *testing.T) {
 }
 
 func TestPeerScoreParams(t *testing.T) {
-	peerScoreParams := PeerScoreParams(oneEpochDuration, 550*(time.Millisecond*700))
+	peerScoreParams := PeerScoreParams(oneEpochDuration, 550*(time.Millisecond*700), false)
 	raw, err := peerScoreParamsString(peerScoreParams)
 	require.NoError(t, err)
 	require.NotNil(t, raw)

--- a/network/topics/pubsub.go
+++ b/network/topics/pubsub.go
@@ -61,6 +61,7 @@ type PubSubConfig struct {
 	OutboundQueueSize   int
 	MsgIDCacheTTL       time.Duration
 
+	DisableIPRateLimit     bool
 	GetValidatorStats      network.GetValidatorStats
 	ScoreInspector         pubsub.ExtendedPeerScoreInspectFn
 	ScoreInspectorInterval time.Duration
@@ -154,7 +155,7 @@ func NewPubSub(ctx context.Context, logger *zap.Logger, cfg *PubSubConfig, metri
 			inspectInterval = defaultScoreInspectInterval
 		}
 
-		peerScoreParams := params.PeerScoreParams(cfg.Scoring.OneEpochDuration, cfg.MsgIDCacheTTL, cfg.Scoring.IPWhilelist...)
+		peerScoreParams := params.PeerScoreParams(cfg.Scoring.OneEpochDuration, cfg.MsgIDCacheTTL, cfg.DisableIPRateLimit, cfg.Scoring.IPWhilelist...)
 		psOpts = append(psOpts, pubsub.WithPeerScore(peerScoreParams, params.PeerScoreThresholds()),
 			pubsub.WithPeerScoreInspect(inspector, inspectInterval))
 		if cfg.GetValidatorStats == nil {


### PR DESCRIPTION
### Changes

This PR adds a config option to disable IP rate limiting and IP-Colocation scoring. this is used mainly in local and testing environments where we want to enable entities to use the same IP without being banned. (In a cloud environment or a single machine running multiple nodes for example).

### How to use

As added in the stage yamls, you can just set `DISABLE_IP_RATE_LIMIT` env var to `true`, of course this is `false` by default.