### PR TITLE
fix: find host address using dig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update                                                        && \
   gcc-aarch64-linux-gnu=4:12.2.0-3 \
   bzip2=1.0.8-5+b1 \
   make=4.3-4.1 \
-  dnsutils \
+  dnsutils=1:9.18.24-1 \
   && rm -rf /var/lib/apt/lists/*
 
 RUN go version

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update                                                        && \
   gcc-aarch64-linux-gnu=4:12.2.0-3 \
   bzip2=1.0.8-5+b1 \
   make=4.3-4.1 \
+  dnsutils \
   && rm -rf /var/lib/apt/lists/*
 
 RUN go version


### PR DESCRIPTION
### Fix

In our Makefile we are setting HOST_ADDRESS env to pass to the node in order to advertise itself in discovery. when we introduced #1358 , we switched to using a different image in docker and this image lacks `dig` which is the utility we use to resolve our address against a dns service.

this installs dnsutils which has dig so we could get our address.