### PR TITLE
Update config.example.yaml

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -25,7 +25,8 @@ eth2:
 
 eth1:
   # WebSocket URL of the Eth1 node to connect to.
-  ETH1Addr: ws://example.url:8546/ws
+  # using ETH1Addr: ws://example.url:8546/ws results in Bad handshake with Geth
+  ETH1Addr: ws://example.url:8546
 
 p2p:
   # Optionally specify the external IP address of the node, if it cannot be determined automatically.


### PR DESCRIPTION
Fix issue using Geth Eth1 client: 
FATAL	could not connect to execution client	{"error": "failed to connect to execution client: websocket: bad handshake (HTTP status 200 OK)"}

Error reported by SSV client when using:
eth1:
  # WebSocket URL of the Eth1 node to connect to.
  ETH1Addr: ws://myhost:8546/ws

Error resolved by using:
eth1:
  # WebSocket URL of the Eth1 node to connect to.
  ETH1Addr: ws://myhost:8546