### PR TITLE
fix validator index in spec share

### DIFF
--- a/operator/duties/committee.go
+++ b/operator/duties/committee.go
@@ -139,7 +139,7 @@ func (h *CommitteeHandler) processExecution(period uint64, epoch phase0.Epoch, s
 	vsmap := make(map[phase0.ValidatorIndex]spectypes.CommitteeID, 0)
 	vs := h.validatorProvider.SelfParticipatingValidators(epoch)
 	for _, v := range vs {
-		vsmap[v.ValidatorIndex] = v.CommitteeID()
+		vsmap[v.BeaconMetadata.Index] = v.CommitteeID()
 	}
 
 	committeeMap := make(map[[32]byte]*spectypes.CommitteeDuty)

--- a/registry/storage/shares.go
+++ b/registry/storage/shares.go
@@ -332,6 +332,8 @@ func (s *sharesStorage) UpdateValidatorMetadata(pk spectypes.ValidatorPK, metada
 	}
 
 	share.BeaconMetadata = metadata
+	share.Share.ValidatorIndex = metadata.Index
+
 	return s.Save(nil, share)
 }
 
@@ -345,6 +347,7 @@ func (s *sharesStorage) UpdateValidatorsMetadata(data map[spectypes.ValidatorPK]
 			continue
 		}
 		share.BeaconMetadata = metadata
+		share.Share.ValidatorIndex = metadata.Index
 		shares = append(shares, share)
 	}
 	s.mu.RUnlock()


### PR DESCRIPTION
This change resolves issue when new validator are registered and index in spectypes share is not updated from metadata. 