### PR TITLE
feature: (alan) bulk submit committee duties

### DIFF
--- a/beacon/goclient/sync_committee.go
+++ b/beacon/goclient/sync_committee.go
@@ -55,3 +55,11 @@ func (gc *goClient) SubmitSyncMessage(msg *altair.SyncCommitteeMessage) error {
 	}
 	return nil
 }
+
+// SubmitSyncMessages submits signed sync committee msgs
+func (gc *goClient) SubmitSyncMessages(msgs []*altair.SyncCommitteeMessage) error {
+	if err := gc.client.SubmitSyncCommitteeMessages(gc.ctx, msgs); err != nil {
+		return err
+	}
+	return nil
+}

--- a/protocol/v2/blockchain/beacon/client.go
+++ b/protocol/v2/blockchain/beacon/client.go
@@ -2,6 +2,7 @@ package beacon
 
 import (
 	"context"
+	"github.com/attestantio/go-eth2-client/spec/altair"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/api"
@@ -65,13 +66,29 @@ type TempSpecProposerCalls interface {
 	SubmitBlindedBeaconBlock(block *api.VersionedBlindedProposal, sig phase0.BLSSignature) error
 }
 
+// AttesterCalls interface has all attester duty specific calls
+type TempSpecAttesterCalls interface {
+	// GetAttestationData returns attestation data by the given slot and committee index
+	GetAttestationData(slot phase0.Slot, committeeIndex phase0.CommitteeIndex) (*phase0.AttestationData, spec.DataVersion, error)
+	// SubmitAttestation submit the attestation to the node
+	SubmitAttestations(attestations []*phase0.Attestation) error
+}
+
+// SyncCommitteeCalls interface has all sync committee duty specific calls
+type TempSpecSyncCommitteeCalls interface {
+	// GetSyncMessageBlockRoot returns beacon block root for sync committee
+	GetSyncMessageBlockRoot(slot phase0.Slot) (phase0.Root, spec.DataVersion, error)
+	// SubmitSyncMessage submits a signed sync committee msg
+	SubmitSyncMessages(msg []*altair.SyncCommitteeMessage) error
+}
+
 type TempSpecBeaconNode interface {
 	// GetBeaconNetwork returns the beacon network the node is on
 	GetBeaconNetwork() spectypes.BeaconNetwork
-	specssv.AttesterCalls
+	TempSpecAttesterCalls
 	TempSpecProposerCalls
 	specssv.AggregatorCalls
-	specssv.SyncCommitteeCalls
+	TempSpecSyncCommitteeCalls
 	specssv.SyncCommitteeContributionCalls
 	specssv.ValidatorRegistrationCalls
 	specssv.VoluntaryExitCalls


### PR DESCRIPTION
### Description 

We suspect sending multiple submit requests to our beacon node might slow some submits down and overload the beacon node. 

This change puts all attestation + sync committee messages agreed on in committee consensus in to a batch and shoots them to the beacon node in 2 requests, one for attestations and one for sync committee.

**NOTE**: the spec interfaces were lacking the batch send beacon functions so until they are updated, we are using our own beacon node interface. 