### PR TITLE
fix: (MessageValidation) ignore missing sync duties

### DIFF
--- a/message/validation/consensus_validation.go
+++ b/message/validation/consensus_validation.go
@@ -310,7 +310,7 @@ func (mv *messageValidator) validateBeaconDuty(
 
 		period := mv.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(mv.netCfg.Beacon.EstimatedEpochAtSlot(slot))
 		if mv.dutyStore != nil && mv.dutyStore.SyncCommittee.Duty(period, share.Metadata.BeaconMetadata.Index) == nil {
-			return ErrNoDuty
+			return ErrNoDutyIgnored
 		}
 
 		return nil

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -95,6 +95,7 @@ var (
 	ErrInvalidJustifications               = Error{text: "invalid justifications", reject: true}
 	ErrTooManyDutiesPerEpoch               = Error{text: "too many duties per epoch", reject: true}
 	ErrNoDuty                              = Error{text: "no duty for this epoch", reject: true}
+	ErrNoDutyIgnored                       = Error{text: "no duty for this epoch (ignored)"}
 	ErrDeserializePublicKey                = Error{text: "deserialize public key", reject: true}
 	ErrNoPartialMessages                   = Error{text: "no partial messages", reject: true}
 	ErrDuplicatedPartialSignatureMessage   = Error{text: "duplicated partial signature message", reject: true}


### PR DESCRIPTION
When a validator is registered while in a sync committee, the other operators would not fetch their duties on time.

This bug causes network instability, resulting in reduced attestation rate for the registered validator and their operators.

This PR reduces the impacts of this bug down to at maximum one validator.