### PR TITLE
remove fake Alan version

### DIFF
--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ssvlabs/ssv/network/records"
 	"github.com/ssvlabs/ssv/network/streams"
 	"github.com/ssvlabs/ssv/network/topics"
+	"github.com/ssvlabs/ssv/utils/commons"
 )
 
 const (
@@ -172,9 +173,7 @@ func (n *p2pNetwork) setupPeerServices(logger *zap.Logger) error {
 	domain := "0x" + hex.EncodeToString(n.cfg.Network.Domain[:])
 	self := records.NewNodeInfo(domain)
 	self.Metadata = &records.NodeMetadata{
-		// TODO: (Alan) revert
-		// NodeVersion: commons.GetNodeVersion(),
-		NodeVersion: "ALANTEST",
+		NodeVersion: commons.GetNodeVersion(),
 		Subnets:     records.Subnets(n.subnets).String(),
 	}
 	getPrivKey := func() crypto.PrivKey {

--- a/network/peers/connections/handshaker.go
+++ b/network/peers/connections/handshaker.go
@@ -2,7 +2,6 @@ package connections
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
@@ -152,11 +151,6 @@ func (h *handshaker) verifyTheirNodeInfo(logger *zap.Logger, sender peer.ID, ni 
 		zap.Any("metadata", ni.GetNodeInfo().Metadata),
 		zap.String("networkID", ni.GetNodeInfo().NetworkID),
 	)
-
-	// TODO: (Alan) revert
-	if !strings.Contains(ni.Metadata.NodeVersion, "ALANTEST") {
-		return errors.New("non Alan node version is not supported")
-	}
 
 	return nil
 }


### PR DESCRIPTION
Fake version should be unnecessary given domain type has changed and peers with mismatching domain type should be rejected anyway.