### PR TITLE
message validation: replace treemap with an array

### DIFF
--- a/message/validation/common_checks.go
+++ b/message/validation/common_checks.go
@@ -55,19 +55,9 @@ func (mv *messageValidator) validateDutyCount(
 	msgID spectypes.MessageID,
 	msgSlot phase0.Slot,
 	validatorIndices []phase0.ValidatorIndex,
-	signerStateBySlot []*SignerState,
+	signerStateBySlot *OperatorState,
 ) error {
-	msgEpoch := mv.netCfg.Beacon.EstimatedEpochAtSlot(msgSlot)
-	dutyCount := 0
-	for _, state := range signerStateBySlot {
-		if state != nil && mv.netCfg.Beacon.EstimatedEpochAtSlot(state.Slot) == msgEpoch {
-			dutyCount++
-		}
-	}
-
-	if state := signerStateBySlot[msgSlot%mv.maxSlotsInState()]; state == nil || state.Slot != msgSlot {
-		dutyCount++
-	}
+	dutyCount := signerStateBySlot.DutyCount(mv.netCfg.Beacon.EstimatedEpochAtSlot(msgSlot))
 
 	dutyLimit, exists := mv.dutyLimit(msgID, validatorIndices)
 	if !exists {

--- a/message/validation/common_checks.go
+++ b/message/validation/common_checks.go
@@ -64,7 +64,7 @@ func (mv *messageValidator) validateDutyCount(
 		return nil
 	}
 
-	if dutyCount > dutyLimit {
+	if dutyCount >= dutyLimit {
 		err := ErrTooManyDutiesPerEpoch
 		err.got = fmt.Sprintf("%v (role %v)", dutyCount, msgID.GetRoleType())
 		err.want = fmt.Sprintf("less than %v", dutyLimit)

--- a/message/validation/consensus_state.go
+++ b/message/validation/consensus_state.go
@@ -15,18 +15,69 @@ type consensusID struct {
 
 // consensusState keeps track of the signers for a given public key and role.
 type consensusState struct {
-	state           map[spectypes.OperatorID][]*SignerState // the slice index is slot % storedSlotCount
+	state           map[spectypes.OperatorID]*OperatorState
 	storedSlotCount phase0.Slot
 	mu              sync.Mutex
 }
 
-func (cs *consensusState) GetOrCreate(signer spectypes.OperatorID) []*SignerState {
+func (cs *consensusState) GetOrCreate(signer spectypes.OperatorID) *OperatorState {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 
 	if _, ok := cs.state[signer]; !ok {
-		cs.state[signer] = make([]*SignerState, cs.storedSlotCount)
+		cs.state[signer] = newOperatorState(cs.storedSlotCount)
 	}
 
 	return cs.state[signer]
+}
+
+type OperatorState struct {
+	state           []*SignerState // the slice index is slot % storedSlotCount
+	maxSlot         phase0.Slot
+	maxEpoch        phase0.Epoch
+	lastEpochDuties int
+	prevEpochDuties int
+}
+
+func newOperatorState(size phase0.Slot) *OperatorState {
+	return &OperatorState{
+		state: make([]*SignerState, size),
+	}
+}
+
+func (os *OperatorState) Get(slot phase0.Slot) *SignerState {
+	s := os.state[int(slot)%len(os.state)]
+	if s.Slot != slot {
+		return nil
+	}
+
+	return s
+}
+
+func (os *OperatorState) Set(slot phase0.Slot, epoch phase0.Epoch, state *SignerState) {
+	os.state[int(slot)%len(os.state)] = state
+	if slot > os.maxSlot {
+		os.maxSlot = slot
+	}
+	if epoch > os.maxEpoch {
+		os.maxEpoch = epoch
+		os.prevEpochDuties = os.lastEpochDuties
+		os.lastEpochDuties = 1
+	} else {
+		os.lastEpochDuties++
+	}
+}
+
+func (os *OperatorState) MaxSlot() phase0.Slot {
+	return os.maxSlot
+}
+
+func (os *OperatorState) DutyCount(epoch phase0.Epoch) int {
+	if epoch == os.maxEpoch {
+		return os.lastEpochDuties
+	}
+	if epoch == os.maxEpoch-1 {
+		return os.prevEpochDuties
+	}
+	return 0 // unused because messages from too old epochs must be rejected in advance
 }

--- a/message/validation/consensus_state.go
+++ b/message/validation/consensus_state.go
@@ -47,7 +47,7 @@ func newOperatorState(size phase0.Slot) *OperatorState {
 
 func (os *OperatorState) Get(slot phase0.Slot) *SignerState {
 	s := os.state[int(slot)%len(os.state)]
-	if s.Slot != slot {
+	if s == nil || s.Slot != slot {
 		return nil
 	}
 

--- a/message/validation/consensus_state_test.go
+++ b/message/validation/consensus_state_test.go
@@ -1,0 +1,98 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOperatorState(t *testing.T) {
+	t.Run("TestNewOperatorState", func(t *testing.T) {
+		size := phase0.Slot(10)
+		os := newOperatorState(size)
+		assert.NotNil(t, os)
+		assert.Equal(t, len(os.state), int(size))
+	})
+
+	t.Run("TestGetAndSet", func(t *testing.T) {
+		size := phase0.Slot(10)
+		os := newOperatorState(size)
+
+		slot := phase0.Slot(5)
+		epoch := phase0.Epoch(1)
+		signerState := &SignerState{Slot: slot}
+
+		os.Set(slot, epoch, signerState)
+		retrievedState := os.Get(slot)
+
+		assert.NotNil(t, retrievedState)
+		assert.Equal(t, retrievedState.Slot, slot)
+	})
+
+	t.Run("TestGetInvalidSlot", func(t *testing.T) {
+		size := phase0.Slot(10)
+		os := newOperatorState(size)
+
+		slot := phase0.Slot(5)
+		retrievedState := os.Get(slot)
+
+		assert.Nil(t, retrievedState)
+	})
+
+	t.Run("TestMaxSlot", func(t *testing.T) {
+		size := phase0.Slot(10)
+		os := newOperatorState(size)
+
+		slot := phase0.Slot(5)
+		epoch := phase0.Epoch(1)
+		signerState := &SignerState{Slot: slot}
+
+		os.Set(slot, epoch, signerState)
+		assert.Equal(t, os.MaxSlot(), slot)
+	})
+
+	t.Run("TestDutyCount", func(t *testing.T) {
+		size := phase0.Slot(10)
+		os := newOperatorState(size)
+
+		slot := phase0.Slot(5)
+		epoch := phase0.Epoch(1)
+		signerState := &SignerState{Slot: slot}
+
+		os.Set(slot, epoch, signerState)
+
+		assert.Equal(t, os.DutyCount(epoch), 1)
+		assert.Equal(t, os.DutyCount(epoch-1), 0)
+
+		slot2 := phase0.Slot(6)
+		epoch2 := phase0.Epoch(2)
+		signerState2 := &SignerState{Slot: slot2}
+
+		os.Set(slot2, epoch2, signerState2)
+
+		assert.Equal(t, os.DutyCount(epoch2), 1)
+		assert.Equal(t, os.DutyCount(epoch), 1)
+		assert.Equal(t, os.DutyCount(epoch-1), 0)
+	})
+
+	t.Run("TestIncrementLastEpochDuties", func(t *testing.T) {
+		size := phase0.Slot(10)
+		os := newOperatorState(size)
+
+		slot := phase0.Slot(5)
+		epoch := phase0.Epoch(1)
+		signerState := &SignerState{Slot: slot}
+
+		// First set
+		os.Set(slot, epoch, signerState)
+		assert.Equal(t, os.DutyCount(epoch), 1)
+
+		// Second set within the same epoch
+		slot2 := phase0.Slot(6)
+		signerState2 := &SignerState{Slot: slot2}
+		os.Set(slot2, epoch, signerState2)
+
+		assert.Equal(t, os.DutyCount(epoch), 2)
+	})
+}

--- a/message/validation/consensus_state_test.go
+++ b/message/validation/consensus_state_test.go
@@ -4,15 +4,15 @@ import (
 	"testing"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOperatorState(t *testing.T) {
 	t.Run("TestNewOperatorState", func(t *testing.T) {
 		size := phase0.Slot(10)
 		os := newOperatorState(size)
-		assert.NotNil(t, os)
-		assert.Equal(t, len(os.state), int(size))
+		require.NotNil(t, os)
+		require.Equal(t, len(os.state), int(size))
 	})
 
 	t.Run("TestGetAndSet", func(t *testing.T) {
@@ -26,8 +26,8 @@ func TestOperatorState(t *testing.T) {
 		os.Set(slot, epoch, signerState)
 		retrievedState := os.Get(slot)
 
-		assert.NotNil(t, retrievedState)
-		assert.Equal(t, retrievedState.Slot, slot)
+		require.NotNil(t, retrievedState)
+		require.Equal(t, retrievedState.Slot, slot)
 	})
 
 	t.Run("TestGetInvalidSlot", func(t *testing.T) {
@@ -37,7 +37,7 @@ func TestOperatorState(t *testing.T) {
 		slot := phase0.Slot(5)
 		retrievedState := os.Get(slot)
 
-		assert.Nil(t, retrievedState)
+		require.Nil(t, retrievedState)
 	})
 
 	t.Run("TestMaxSlot", func(t *testing.T) {
@@ -49,7 +49,7 @@ func TestOperatorState(t *testing.T) {
 		signerState := &SignerState{Slot: slot}
 
 		os.Set(slot, epoch, signerState)
-		assert.Equal(t, os.MaxSlot(), slot)
+		require.Equal(t, os.MaxSlot(), slot)
 	})
 
 	t.Run("TestDutyCount", func(t *testing.T) {
@@ -62,8 +62,8 @@ func TestOperatorState(t *testing.T) {
 
 		os.Set(slot, epoch, signerState)
 
-		assert.Equal(t, os.DutyCount(epoch), 1)
-		assert.Equal(t, os.DutyCount(epoch-1), 0)
+		require.Equal(t, os.DutyCount(epoch), 1)
+		require.Equal(t, os.DutyCount(epoch-1), 0)
 
 		slot2 := phase0.Slot(6)
 		epoch2 := phase0.Epoch(2)
@@ -71,9 +71,9 @@ func TestOperatorState(t *testing.T) {
 
 		os.Set(slot2, epoch2, signerState2)
 
-		assert.Equal(t, os.DutyCount(epoch2), 1)
-		assert.Equal(t, os.DutyCount(epoch), 1)
-		assert.Equal(t, os.DutyCount(epoch-1), 0)
+		require.Equal(t, os.DutyCount(epoch2), 1)
+		require.Equal(t, os.DutyCount(epoch), 1)
+		require.Equal(t, os.DutyCount(epoch-1), 0)
 	})
 
 	t.Run("TestIncrementLastEpochDuties", func(t *testing.T) {
@@ -84,15 +84,13 @@ func TestOperatorState(t *testing.T) {
 		epoch := phase0.Epoch(1)
 		signerState := &SignerState{Slot: slot}
 
-		// First set
 		os.Set(slot, epoch, signerState)
-		assert.Equal(t, os.DutyCount(epoch), 1)
+		require.Equal(t, os.DutyCount(epoch), 1)
 
-		// Second set within the same epoch
 		slot2 := phase0.Slot(6)
 		signerState2 := &SignerState{Slot: slot2}
 		os.Set(slot2, epoch, signerState2)
 
-		assert.Equal(t, os.DutyCount(epoch), 2)
+		require.Equal(t, os.DutyCount(epoch), 2)
 	})
 }

--- a/message/validation/signer_state.go
+++ b/message/validation/signer_state.go
@@ -5,27 +5,30 @@ package validation
 import (
 	"crypto/sha256"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 )
 
 // SignerState represents the state of a signer, including its start time, slot, round,
 // message counts, proposal data, and the number of duties performed in the current epoch.
 type SignerState struct {
+	Slot          phase0.Slot // index stores slot modulo, so we also need to store slot here
 	Round         specqbft.Round
 	MessageCounts MessageCounts
 	ProposalData  []byte
 	SeenSigners   map[[sha256.Size]byte]struct{}
 }
 
-func NewSignerState(round specqbft.Round) *SignerState {
+func NewSignerState(slot phase0.Slot, round specqbft.Round) *SignerState {
 	s := &SignerState{}
-	s.Reset(round)
+	s.Reset(slot, round)
 	return s
 }
 
 // Reset resets the state's round, message counts, and proposal data to the given values.
 // It also updates the start time to the current time.
-func (s *SignerState) Reset(round specqbft.Round) {
+func (s *SignerState) Reset(slot phase0.Slot, round specqbft.Round) {
+	s.Slot = slot
 	s.Round = round
 	s.MessageCounts = MessageCounts{}
 	s.ProposalData = nil

--- a/message/validation/validation.go
+++ b/message/validation/validation.go
@@ -294,8 +294,8 @@ func (mv *messageValidator) consensusState(messageID spectypes.MessageID) *conse
 
 	if _, ok := mv.consensusStateIndex[id]; !ok {
 		cs := &consensusState{
-			state:           make(map[spectypes.OperatorID][]*SignerState),
-			storedSlotCount: phase0.Slot(mv.netCfg.Beacon.SlotsPerEpoch()) + lateSlotAllowance,
+			state:           make(map[spectypes.OperatorID]*OperatorState),
+			storedSlotCount: phase0.Slot(mv.netCfg.Beacon.SlotsPerEpoch()) * 2, // store last two epochs to calculate duty count
 		}
 		mv.consensusStateIndex[id] = cs
 	}

--- a/message/validation/validation.go
+++ b/message/validation/validation.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/emirpasic/gods/maps/treemap"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
@@ -295,8 +294,8 @@ func (mv *messageValidator) consensusState(messageID spectypes.MessageID) *conse
 
 	if _, ok := mv.consensusStateIndex[id]; !ok {
 		cs := &consensusState{
-			state:    make(map[spectypes.OperatorID]*treemap.Map),
-			maxSlots: phase0.Slot(mv.netCfg.Beacon.SlotsPerEpoch()) + lateSlotAllowance,
+			state:           make(map[spectypes.OperatorID][]*SignerState),
+			storedSlotCount: phase0.Slot(mv.netCfg.Beacon.SlotsPerEpoch()) + lateSlotAllowance,
 		}
 		mv.consensusStateIndex[id] = cs
 	}

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -161,13 +161,12 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		stateBySlot := state.GetOrCreate(1)
 		require.NotNil(t, stateBySlot)
-		require.Equal(t, 1, stateBySlot.Size())
-		stateSlot, signerStateOldSlot := stateBySlot.Min()
-		require.NotNil(t, stateSlot)
-		require.NotNil(t, signerStateOldSlot)
-		require.EqualValues(t, height, stateSlot.(phase0.Slot))
-		require.EqualValues(t, 1, signerStateOldSlot.(*SignerState).Round)
-		require.EqualValues(t, MessageCounts{Proposal: 1}, signerStateOldSlot.(*SignerState).MessageCounts)
+
+		storedState := stateBySlot.Get(slot)
+		require.NotNil(t, storedState)
+		require.EqualValues(t, height, storedState.Slot)
+		require.EqualValues(t, 1, storedState.Round)
+		require.EqualValues(t, MessageCounts{Proposal: 1}, storedState.MessageCounts)
 		for i := spectypes.OperatorID(2); i <= 4; i++ {
 			require.NotNil(t, state.GetOrCreate(i))
 		}
@@ -181,10 +180,11 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, receivedAt)
 		require.NoError(t, err)
 
-		require.NotNil(t, stateBySlot)
-		require.EqualValues(t, height, stateSlot.(phase0.Slot))
-		require.EqualValues(t, 2, signerStateOldSlot.(*SignerState).Round)
-		require.EqualValues(t, MessageCounts{Prepare: 1}, signerStateOldSlot.(*SignerState).MessageCounts)
+		storedState = stateBySlot.Get(slot)
+		require.NotNil(t, storedState)
+		require.EqualValues(t, height, storedState.Slot)
+		require.EqualValues(t, 2, storedState.Round)
+		require.EqualValues(t, MessageCounts{Prepare: 1}, storedState.MessageCounts)
 
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, receivedAt)
 		require.ErrorContains(t, err, ErrDuplicatedMessage.Error())
@@ -195,12 +195,11 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		signedSSVMessage.FullData = nil
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, receivedAt.Add(netCfg.Beacon.SlotDurationSec()))
 		require.NoError(t, err)
-		require.Equal(t, 2, stateBySlot.Size())
 
-		signerStateNewSlot, ok := stateBySlot.Get(phase0.Slot(height) + 1)
-		require.True(t, ok)
-		require.EqualValues(t, 1, signerStateNewSlot.(*SignerState).Round)
-		require.EqualValues(t, MessageCounts{Commit: 1}, signerStateNewSlot.(*SignerState).MessageCounts)
+		storedState = stateBySlot.Get(phase0.Slot(height) + 1)
+		require.NotNil(t, storedState)
+		require.EqualValues(t, 1, storedState.Round)
+		require.EqualValues(t, MessageCounts{Commit: 1}, storedState.MessageCounts)
 
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, receivedAt.Add(netCfg.Beacon.SlotDurationSec()))
 		require.ErrorContains(t, err, ErrDuplicatedMessage.Error())
@@ -209,8 +208,8 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, receivedAt.Add(netCfg.Beacon.SlotDurationSec()))
 		require.NoError(t, err)
 		require.NotNil(t, stateBySlot)
-		require.EqualValues(t, 1, signerStateNewSlot.(*SignerState).Round)
-		require.EqualValues(t, MessageCounts{Commit: 1}, signerStateNewSlot.(*SignerState).MessageCounts)
+		require.EqualValues(t, 1, storedState.Round)
+		require.EqualValues(t, MessageCounts{Commit: 1}, storedState.MessageCounts)
 	})
 
 	// Send a pubsub message with no data should cause an error


### PR DESCRIPTION
The PR adds the new `OperatorState` structure, it has some logic, so we need to consider covering it with unit tests