### PR TITLE
fix: pass only relevant duty validator shares into the slot committee runner

### DIFF
--- a/protocol/v2/ssv/validator/committee.go
+++ b/protocol/v2/ssv/validator/committee.go
@@ -119,6 +119,10 @@ func (c *Committee) StartDuty(logger *zap.Logger, duty *spectypes.CommitteeDuty)
 		}
 	}
 
+	if len(duty.BeaconDuties) == 0 {
+		return errors.New("CommitteeDuty has no valid beacon duties")
+	}
+
 	r := c.CreateRunnerFn(duty.Slot, validatorShares)
 	// Set timeout function.
 	r.GetBaseRunner().TimeoutF = c.onTimeout

--- a/protocol/v2/ssv/validator/committee.go
+++ b/protocol/v2/ssv/validator/committee.go
@@ -98,12 +98,12 @@ func (c *Committee) StartDuty(logger *zap.Logger, duty *spectypes.CommitteeDuty)
 		return errors.New(fmt.Sprintf("CommitteeRunner for slot %d already exists", duty.Slot))
 	}
 
-	var sharesCopy = make(map[phase0.ValidatorIndex]*spectypes.Share, len(c.Shares))
-	for k, v := range c.Shares {
-		sharesCopy[k] = v
+	validatorShares := make(map[phase0.ValidatorIndex]*spectypes.Share, len(duty.BeaconDuties))
+	for _, bd := range duty.BeaconDuties {
+		validatorShares[bd.ValidatorIndex] = c.Shares[bd.ValidatorIndex]
 	}
 
-	r := c.CreateRunnerFn(duty.Slot, sharesCopy)
+	r := c.CreateRunnerFn(duty.Slot, validatorShares)
 	// Set timeout function.
 	r.GetBaseRunner().TimeoutF = c.onTimeout
 	c.Runners[duty.Slot] = r


### PR DESCRIPTION
We were copying all shares when only the shares that are relevant for this slot duty should go into the runner.