### PR TITLE
fix: (alan) don't return on unhandled message types in exporter

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -357,7 +357,7 @@ func (c *controller) handleRouterMessages() {
 				vc.HandleMessage(c.logger, msg)
 			} else if c.validatorOptions.Exporter {
 				if msg.MsgType != spectypes.SSVConsensusMsgType && msg.MsgType != spectypes.SSVPartialSignatureMsgType {
-					return
+					continue
 				}
 				if !c.messageWorker.TryEnqueue(msg) { // start to save non committee decided messages only post fork
 					c.logger.Warn("Failed to enqueue post consensus message: buffer is full")


### PR DESCRIPTION
### Description 

A bug that managed to get through the CR process, was stopping handling messages in exporter if it received a message that wasn't consensus or partial sig. (could be EventMsg like Timeout or ExecuteDuty).

## Fix

`continue` instead of `return`