### PR TITLE
fix: (alan) bring back slashing check from spec

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -1211,10 +1211,10 @@ func SetupCommitteeRunners(
 		return qbftCtrl
 	}
 
-	return func(slot phase0.Slot, shares map[phase0.ValidatorIndex]*spectypes.Share, attestingValidators []spectypes.ShareValidatorPK) *runner.CommitteeRunner {
+	return func(slot phase0.Slot, shares map[phase0.ValidatorIndex]*spectypes.Share, slashableValidators []spectypes.ShareValidatorPK) *runner.CommitteeRunner {
 		// Create a committee runner.
 		epoch := options.NetworkConfig.Beacon.GetBeaconNetwork().EstimatedEpochAtSlot(slot)
-		valCheck := specssv.BeaconVoteValueCheckF(options.Signer, slot, attestingValidators, epoch)
+		valCheck := specssv.BeaconVoteValueCheckF(options.Signer, slot, slashableValidators, epoch)
 		crunner := runner.NewCommitteeRunner(
 			options.NetworkConfig,
 			shares,

--- a/protocol/v2/ssv/validator/committee.go
+++ b/protocol/v2/ssv/validator/committee.go
@@ -21,6 +21,8 @@ import (
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/runner"
 )
 
+type CommitteeRunnerFunc func(slot phase0.Slot, shares map[phase0.ValidatorIndex]*spectypes.Share, attestingValidators []spectypes.ShareValidatorPK) *runner.CommitteeRunner
+
 type Committee struct {
 	logger *zap.Logger
 	ctx    context.Context
@@ -40,7 +42,7 @@ type Committee struct {
 	Operator *spectypes.CommitteeMember
 
 	SignatureVerifier       spectypes.SignatureVerifier
-	CreateRunnerFn          func(slot phase0.Slot, shares map[phase0.ValidatorIndex]*spectypes.Share) *runner.CommitteeRunner
+	CreateRunnerFn          CommitteeRunnerFunc
 	HighestAttestingSlotMap map[spectypes.ValidatorPK]phase0.Slot
 }
 
@@ -51,7 +53,7 @@ func NewCommittee(
 	beaconNetwork spectypes.BeaconNetwork,
 	operator *spectypes.CommitteeMember,
 	verifier spectypes.SignatureVerifier,
-	createRunnerFn func(slot phase0.Slot, shares map[phase0.ValidatorIndex]*spectypes.Share) *runner.CommitteeRunner,
+	createRunnerFn CommitteeRunnerFunc,
 	// share map[phase0.ValidatorIndex]*spectypes.Share, // TODO Shouldn't we pass the shares map here the same way we do in spec?
 ) *Committee {
 	return &Committee{
@@ -98,6 +100,7 @@ func (c *Committee) StartDuty(logger *zap.Logger, duty *spectypes.CommitteeDuty)
 		return errors.New(fmt.Sprintf("CommitteeRunner for slot %d already exists", duty.Slot))
 	}
 
+	attestingValidators := make([]spectypes.ShareValidatorPK, 0, len(duty.BeaconDuties))
 	validatorShares := make(map[phase0.ValidatorIndex]*spectypes.Share, len(duty.BeaconDuties))
 	toRemove := make([]int, 0)
 	// Remove beacon duties that don't have a share
@@ -106,6 +109,9 @@ func (c *Committee) StartDuty(logger *zap.Logger, duty *spectypes.CommitteeDuty)
 		if !ok {
 			toRemove = append(toRemove, i)
 			continue
+		}
+		if bd.Type == spectypes.BNRoleAttester {
+			attestingValidators = append(attestingValidators, share.SharePubKey)
 		}
 		validatorShares[bd.ValidatorIndex] = share
 	}
@@ -123,7 +129,7 @@ func (c *Committee) StartDuty(logger *zap.Logger, duty *spectypes.CommitteeDuty)
 		return errors.New("CommitteeDuty has no valid beacon duties")
 	}
 
-	r := c.CreateRunnerFn(duty.Slot, validatorShares)
+	r := c.CreateRunnerFn(duty.Slot, validatorShares, attestingValidators)
 	// Set timeout function.
 	r.GetBaseRunner().TimeoutF = c.onTimeout
 	c.Runners[duty.Slot] = r


### PR DESCRIPTION
### Description 

On `validator/controller.go` we were creating the functions to start a new `committeeRunner`, like before every runner uses a value check to make sure its running consensus on valid and non slashable value. We commented this part out and used our own version that doesn't use slashing check, this was because value check are usually implemented in the spec and the spec wasn't ready when this code was written.

### Changes

Now that the spec is ready, the code is aligned to use the `beaconVoteValCheck` from the spec which includes a value check for all the provided shares.