### PR TITLE
Fix message validation (review)

### DIFF
--- a/message/validation/consensus_validation.go
+++ b/message/validation/consensus_validation.go
@@ -188,7 +188,7 @@ func (mv *messageValidator) validateQBFTLogic(
 			if consensusMessage.Round == signerState.Round {
 				// Rule: Peer must not send two proposals with different data
 				if len(signedSSVMessage.FullData) != 0 && signerState.ProposalData != nil && !bytes.Equal(signerState.ProposalData, signedSSVMessage.FullData) {
-					return ErrDuplicatedProposalWithDifferentData
+					return ErrDifferentProposalData
 				}
 
 				// Rule: Peer must send only 1 proposal, 1 prepare, 1 commit, and 1 round-change per round

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -14,6 +14,7 @@ const (
 	lateSlotAllowance     = 2
 	syncCommitteeSize     = 512
 	rsaSignatureSize      = 256
+	blsSignatureSize      = 96
 	operatorIDSize        = 8 // uint64
 	slotSize              = 8 // uint64
 	validatorIndexSize    = 8 // uint64

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -14,7 +14,6 @@ const (
 	lateSlotAllowance     = 2
 	syncCommitteeSize     = 512
 	rsaSignatureSize      = 256
-	blsSignatureSize      = 96
 	operatorIDSize        = 8 // uint64
 	slotSize              = 8 // uint64
 	validatorIndexSize    = 8 // uint64

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -82,6 +82,7 @@ var (
 	ErrUnexpectedConsensusMessage              = Error{text: "unexpected consensus message for this role", reject: true}
 	ErrNoSigners                               = Error{text: "no signers", reject: true}
 	ErrWrongRSASignatureSize                   = Error{text: "wrong RSA signature size", reject: true}
+	ErrWrongBLSSignatureSize                   = Error{text: "wrong RSA signature size", reject: true}
 	ErrZeroSigner                              = Error{text: "zero signer ID", reject: true}
 	ErrSignerNotInCommittee                    = Error{text: "signer is not in committee", reject: true}
 	ErrDuplicatedSigner                        = Error{text: "signer is duplicated", reject: true}

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -99,7 +99,7 @@ var (
 	ErrPartialSignatureTypeRoleMismatch        = Error{text: "partial signature type and role don't match", reject: true}
 	ErrNonDecidedWithMultipleSigners           = Error{text: "non-decided with multiple signers", reject: true}
 	ErrDecidedNotEnoughSigners                 = Error{text: "not enough signers in decided message", reject: true}
-	ErrDuplicatedProposalWithDifferentData     = Error{text: "duplicated proposal with different data", reject: true}
+	ErrDifferentProposalData                   = Error{text: "different proposal data", reject: true}
 	ErrMalformedPrepareJustifications          = Error{text: "malformed prepare justifications", reject: true}
 	ErrUnexpectedPrepareJustifications         = Error{text: "prepare justifications unexpected for this message type", reject: true}
 	ErrMalformedRoundChangeJustifications      = Error{text: "malformed round change justifications", reject: true}

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -104,7 +104,6 @@ var (
 	ErrUnexpectedPrepareJustifications         = Error{text: "prepare justifications unexpected for this message type", reject: true}
 	ErrMalformedRoundChangeJustifications      = Error{text: "malformed round change justifications", reject: true}
 	ErrUnexpectedRoundChangeJustifications     = Error{text: "round change justifications unexpected for this message type", reject: true}
-	ErrDeserializePublicKey                    = Error{text: "deserialize public key", reject: true}
 	ErrNoPartialSignatureMessages              = Error{text: "no partial signature messages", reject: true}
 	ErrNoValidators                            = Error{text: "no validators for this committee ID", reject: true}
 	ErrNoSignatures                            = Error{text: "no signatures", reject: true}

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -82,7 +82,6 @@ var (
 	ErrUnexpectedConsensusMessage              = Error{text: "unexpected consensus message for this role", reject: true}
 	ErrNoSigners                               = Error{text: "no signers", reject: true}
 	ErrWrongRSASignatureSize                   = Error{text: "wrong RSA signature size", reject: true}
-	ErrWrongBLSSignatureSize                   = Error{text: "wrong RSA signature size", reject: true}
 	ErrZeroSigner                              = Error{text: "zero signer ID", reject: true}
 	ErrSignerNotInCommittee                    = Error{text: "signer is not in committee", reject: true}
 	ErrDuplicatedSigner                        = Error{text: "signer is duplicated", reject: true}

--- a/message/validation/genesis/consensus_validation.go
+++ b/message/validation/genesis/consensus_validation.go
@@ -248,7 +248,7 @@ func (mv *messageValidator) validateSignerBehaviorConsensus(
 
 	if msgSlot == signerState.Slot && msgRound == signerState.Round {
 		if mv.hasFullData(signedMsg) && signerState.ProposalData != nil && !bytes.Equal(signerState.ProposalData, signedMsg.FullData) {
-			return ErrDuplicatedProposalWithDifferentData
+			return ErrDifferentProposalData
 		}
 
 		limits := maxMessageCounts(len(share.Committee))

--- a/message/validation/genesis/consensus_validation.go
+++ b/message/validation/genesis/consensus_validation.go
@@ -206,7 +206,7 @@ func (mv *messageValidator) validateSignerBehaviorConsensus(
 	signerState := state.GetSignerState(signer)
 
 	// If signer state is nil, this is the first message for the signer and
-	// the next rules can't be checked.
+	// it's not necessary to check the next rules.
 	if signerState == nil {
 		return mv.validateJustifications(share, signedMsg)
 	}

--- a/message/validation/genesis/consensus_validation.go
+++ b/message/validation/genesis/consensus_validation.go
@@ -131,6 +131,9 @@ func (mv *messageValidator) validateConsensusMessage(
 			signerState.Reset(msgRound)
 		}
 
+		// Allow to change the state only by proposal to avoid an attack
+		// where any node can send an RC message that changes message validation state.
+		// We could allow proposal or round change quorum, but it's more complex to implement, so just proposal is fine.
 		if signedMsg.Message.MsgType == genesisspecqbft.ProposalMsgType {
 			if mv.hasFullData(signedMsg) && signerState.ProposalData == nil {
 				signerState.ProposalData = signedMsg.FullData

--- a/message/validation/genesis/consensus_validation.go
+++ b/message/validation/genesis/consensus_validation.go
@@ -205,14 +205,14 @@ func (mv *messageValidator) validateSignerBehaviorConsensus(
 ) error {
 	signerState := state.GetSignerState(signer)
 
-	msgSlot := phase0.Slot(signedMsg.Message.Height)
-	msgRound := signedMsg.Message.Round
-
 	// If signer state is nil, this is the first message for the signer and
 	// the next rules can't be checked.
 	if signerState == nil {
 		return mv.validateJustifications(share, signedMsg)
 	}
+
+	msgSlot := phase0.Slot(signedMsg.Message.Height)
+	msgRound := signedMsg.Message.Round
 
 	if msgSlot < signerState.Slot {
 		// Signers aren't allowed to decrease their slot.

--- a/message/validation/genesis/errors.go
+++ b/message/validation/genesis/errors.go
@@ -86,7 +86,7 @@ var (
 	ErrPartialSignatureTypeRoleMismatch    = Error{text: "partial signature type and role don't match", reject: true}
 	ErrNonDecidedWithMultipleSigners       = Error{text: "non-decided with multiple signers", reject: true}
 	ErrWrongSignersLength                  = Error{text: "decided signers size is not between quorum and committee size", reject: true}
-	ErrDuplicatedProposalWithDifferentData = Error{text: "duplicated proposal with different data", reject: true}
+	ErrDifferentProposalData               = Error{text: "different proposal data", reject: true}
 	ErrEventMessage                        = Error{text: "event messages are not broadcast", reject: true}
 	ErrDKGMessage                          = Error{text: "DKG messages are not supported", reject: true}
 	ErrMalformedPrepareJustifications      = Error{text: "malformed prepare justifications", reject: true}

--- a/message/validation/genesis/errors.go
+++ b/message/validation/genesis/errors.go
@@ -81,7 +81,6 @@ var (
 	ErrMalformedMessage                    = Error{text: "message could not be decoded", reject: true}
 	ErrMalformedSignedMessage              = Error{text: "signed message could not be decoded", reject: true}
 	ErrUnknownSSVMessageType               = Error{text: "unknown SSV message type", reject: true}
-	ErrMismatchedIdentifier                = Error{text: "identifier mismatch", reject: true}
 	ErrUnknownQBFTMessageType              = Error{text: "unknown QBFT message type", reject: true}
 	ErrUnknownPartialMessageType           = Error{text: "unknown partial signature message type", reject: true}
 	ErrPartialSignatureTypeRoleMismatch    = Error{text: "partial signature type and role don't match", reject: true}

--- a/message/validation/genesis/errors.go
+++ b/message/validation/genesis/errors.go
@@ -81,6 +81,7 @@ var (
 	ErrMalformedMessage                    = Error{text: "message could not be decoded", reject: true}
 	ErrMalformedSignedMessage              = Error{text: "signed message could not be decoded", reject: true}
 	ErrUnknownSSVMessageType               = Error{text: "unknown SSV message type", reject: true}
+	ErrMismatchedIdentifier                = Error{text: "identifier mismatch", reject: true}
 	ErrUnknownQBFTMessageType              = Error{text: "unknown QBFT message type", reject: true}
 	ErrUnknownPartialMessageType           = Error{text: "unknown partial signature message type", reject: true}
 	ErrPartialSignatureTypeRoleMismatch    = Error{text: "partial signature type and role don't match", reject: true}

--- a/message/validation/genesis/message_counts.go
+++ b/message/validation/genesis/message_counts.go
@@ -56,13 +56,14 @@ func (c *MessageCounts) ValidateConsensusMessage(msg *specqbft.SignedMessage, li
 				err.got = fmt.Sprintf("commit, having %v", c.String())
 				return err
 			}
-		}
-		if len(msg.Signers) > 1 {
+		} else if len(msg.Signers) > 1 {
 			if c.Decided >= limits.Decided {
 				err := ErrTooManySameTypeMessagesPerRound
 				err.got = fmt.Sprintf("decided, having %v", c.String())
 				return err
 			}
+		} else {
+			return ErrNoSigners
 		}
 	case specqbft.RoundChangeMsgType:
 		if c.RoundChange >= limits.RoundChange {
@@ -82,13 +83,13 @@ func (c *MessageCounts) ValidateConsensusMessage(msg *specqbft.SignedMessage, li
 func (c *MessageCounts) ValidatePartialSignatureMessage(m *spectypes.SignedPartialSignatureMessage, limits MessageCounts) error {
 	switch m.Message.Type {
 	case spectypes.RandaoPartialSig, spectypes.SelectionProofPartialSig, spectypes.ContributionProofs, spectypes.ValidatorRegistrationPartialSig, spectypes.VoluntaryExitPartialSig:
-		if c.PreConsensus > limits.PreConsensus {
+		if c.PreConsensus >= limits.PreConsensus {
 			err := ErrTooManySameTypeMessagesPerRound
 			err.got = fmt.Sprintf("pre-consensus, having %v", c.String())
 			return err
 		}
 	case spectypes.PostConsensusPartialSig:
-		if c.PostConsensus > limits.PostConsensus {
+		if c.PostConsensus >= limits.PostConsensus {
 			err := ErrTooManySameTypeMessagesPerRound
 			err.got = fmt.Sprintf("post-consensus, having %v", c.String())
 			return err

--- a/message/validation/genesis/message_counts.go
+++ b/message/validation/genesis/message_counts.go
@@ -62,8 +62,6 @@ func (c *MessageCounts) ValidateConsensusMessage(msg *specqbft.SignedMessage, li
 				err.got = fmt.Sprintf("decided, having %v", c.String())
 				return err
 			}
-		} else {
-			return ErrNoSigners
 		}
 	case specqbft.RoundChangeMsgType:
 		if c.RoundChange >= limits.RoundChange {

--- a/message/validation/genesis/partial_validation.go
+++ b/message/validation/genesis/partial_validation.go
@@ -2,190 +2,180 @@ package validation
 
 // partial_validation.go contains methods for validating partial signature messages
 
-import (
-	"time"
-
-	"github.com/attestantio/go-eth2-client/spec/phase0"
-	genesisspecqbft "github.com/ssvlabs/ssv-spec-pre-cc/qbft"
-	genesisspectypes "github.com/ssvlabs/ssv-spec-pre-cc/types"
-
-	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
-)
-
-func (mv *messageValidator) validatePartialSignatureMessage(
-	share *ssvtypes.SSVShare,
-	signedMsg *genesisspectypes.SignedPartialSignatureMessage,
-	msgID genesisspectypes.MessageID,
-	signatureVerifier func() error,
-	receivedAt time.Time,
-) (phase0.Slot, error) {
-	msgSlot := signedMsg.Message.Slot
-
-	if !mv.validPartialSigMsgType(signedMsg.Message.Type) {
-		e := ErrUnknownPartialMessageType
-		e.got = signedMsg.Message.Type
-		return msgSlot, e
-	}
-
-	role := msgID.GetRoleType()
-	if !mv.partialSignatureTypeMatchesRole(signedMsg.Message.Type, role) {
-		return msgSlot, ErrPartialSignatureTypeRoleMismatch
-	}
-
-	if err := mv.validatePartialMessages(share, signedMsg); err != nil {
-		return msgSlot, err
-	}
-
-	if err := mv.validateSlotTime(msgSlot, role, receivedAt); err != nil {
-		return msgSlot, err
-	}
-
-	state := mv.consensusState(msgID)
-	signerState := state.GetSignerState(signedMsg.Signer)
-	if signerState != nil {
-		if err := mv.validateSignerBehaviorPartial(state, signedMsg.Signer, share, msgID, signedMsg); err != nil {
-			return msgSlot, err
-		}
-	}
-
-	if err := mv.validateSignatureFormat(signedMsg.Signature); err != nil {
-		return msgSlot, err
-	}
-
-	if signatureVerifier != nil {
-		if err := signatureVerifier(); err != nil {
-			return msgSlot, err
-		}
-	}
-
-	if signerState == nil {
-		signerState = state.CreateSignerState(signedMsg.Signer)
-	}
-
-	if msgSlot > signerState.Slot {
-		newEpoch := mv.netCfg.Beacon.EstimatedEpochAtSlot(msgSlot) > mv.netCfg.Beacon.EstimatedEpochAtSlot(signerState.Slot)
-		signerState.ResetSlot(msgSlot, genesisspecqbft.FirstRound, newEpoch)
-	}
-
-	signerState.MessageCounts.RecordPartialSignatureMessage(signedMsg)
-
-	return msgSlot, nil
-}
-
-func (mv *messageValidator) validPartialSigMsgType(msgType genesisspectypes.PartialSigMsgType) bool {
-	switch msgType {
-	case genesisspectypes.PostConsensusPartialSig,
-		genesisspectypes.RandaoPartialSig,
-		genesisspectypes.SelectionProofPartialSig,
-		genesisspectypes.ContributionProofs,
-		genesisspectypes.ValidatorRegistrationPartialSig,
-		genesisspectypes.VoluntaryExitPartialSig:
-		return true
-	default:
-		return false
-	}
-}
-
-func (mv *messageValidator) partialSignatureTypeMatchesRole(msgType genesisspectypes.PartialSigMsgType, role genesisspectypes.BeaconRole) bool {
-	switch role {
-	case genesisspectypes.BNRoleAttester:
-		return msgType == genesisspectypes.PostConsensusPartialSig
-	case genesisspectypes.BNRoleAggregator:
-		return msgType == genesisspectypes.PostConsensusPartialSig || msgType == genesisspectypes.SelectionProofPartialSig
-	case genesisspectypes.BNRoleProposer:
-		return msgType == genesisspectypes.PostConsensusPartialSig || msgType == genesisspectypes.RandaoPartialSig
-	case genesisspectypes.BNRoleSyncCommittee:
-		return msgType == genesisspectypes.PostConsensusPartialSig
-	case genesisspectypes.BNRoleSyncCommitteeContribution:
-		return msgType == genesisspectypes.PostConsensusPartialSig || msgType == genesisspectypes.ContributionProofs
-	case genesisspectypes.BNRoleValidatorRegistration:
-		return msgType == genesisspectypes.ValidatorRegistrationPartialSig
-	case genesisspectypes.BNRoleVoluntaryExit:
-		return msgType == genesisspectypes.VoluntaryExitPartialSig
-	default:
-		panic("invalid role") // role validity should be checked before
-	}
-}
-
-func (mv *messageValidator) validatePartialMessages(share *ssvtypes.SSVShare, m *genesisspectypes.SignedPartialSignatureMessage) error {
-	if err := mv.commonSignerValidation(m.Signer, share); err != nil {
-		return err
-	}
-
-	if len(m.Message.Messages) == 0 {
-		return ErrNoPartialMessages
-	}
-
-	seen := map[[32]byte]struct{}{}
-	for _, message := range m.Message.Messages {
-		if _, ok := seen[message.SigningRoot]; ok {
-			return ErrDuplicatedPartialSignatureMessage
-		}
-		seen[message.SigningRoot] = struct{}{}
-
-		if message.Signer != m.Signer {
-			err := ErrUnexpectedSigner
-			err.want = m.Signer
-			err.got = message.Signer
-			return err
-		}
-
-		if err := mv.commonSignerValidation(message.Signer, share); err != nil {
-			return err
-		}
-
-		if err := mv.validateSignatureFormat(message.PartialSignature); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (mv *messageValidator) validateSignerBehaviorPartial(
-	state *ConsensusState,
-	signer genesisspectypes.OperatorID,
-	share *ssvtypes.SSVShare,
-	msgID genesisspectypes.MessageID,
-	signedMsg *genesisspectypes.SignedPartialSignatureMessage,
-) error {
-	signerState := state.GetSignerState(signer)
-
-	if signerState == nil {
-		return nil
-	}
-
-	msgSlot := signedMsg.Message.Slot
-
-	if msgSlot < signerState.Slot {
-		// Signers aren't allowed to decrease their slot.
-		// If they've sent a future message due to clock error,
-		// this should be caught by the earlyMessage check.
-		err := ErrSlotAlreadyAdvanced
-		err.want = signerState.Slot
-		err.got = msgSlot
-		return err
-	}
-
-	newDutyInSameEpoch := false
-	if msgSlot > signerState.Slot && mv.netCfg.Beacon.EstimatedEpochAtSlot(msgSlot) == mv.netCfg.Beacon.EstimatedEpochAtSlot(signerState.Slot) {
-		newDutyInSameEpoch = true
-	}
-
-	if err := mv.validateBeaconDuty(msgID.GetRoleType(), msgSlot, share); err != nil {
-		return err
-	}
-
-	if err := mv.validateDutyCount(signerState, msgID, newDutyInSameEpoch); err != nil {
-		return err
-	}
-
-	if msgSlot <= signerState.Slot {
-		limits := maxMessageCounts(len(share.Committee))
-		if err := signerState.MessageCounts.ValidatePartialSignatureMessage(signedMsg, limits); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
+//func (mv *messageValidator) validatePartialSignatureMessage(
+//	share *ssvtypes.SSVShare,
+//	signedMsg *genesisspectypes.SignedPartialSignatureMessage,
+//	msgID genesisspectypes.MessageID,
+//	signatureVerifier func() error,
+//	receivedAt time.Time,
+//) (phase0.Slot, error) {
+//	msgSlot := signedMsg.Message.Slot
+//
+//	if !mv.validPartialSigMsgType(signedMsg.Message.Type) {
+//		e := ErrUnknownPartialMessageType
+//		e.got = signedMsg.Message.Type
+//		return msgSlot, e
+//	}
+//
+//	role := msgID.GetRoleType()
+//	if !mv.partialSignatureTypeMatchesRole(signedMsg.Message.Type, role) {
+//		return msgSlot, ErrPartialSignatureTypeRoleMismatch
+//	}
+//
+//	if err := mv.validatePartialMessages(share, signedMsg); err != nil {
+//		return msgSlot, err
+//	}
+//
+//	if err := mv.validateSlotTime(msgSlot, role, receivedAt); err != nil {
+//		return msgSlot, err
+//	}
+//
+//	state := mv.consensusState(msgID)
+//	signerState := state.GetSignerState(signedMsg.Signer)
+//	if signerState != nil {
+//		if err := mv.validateSignerBehaviorPartial(state, signedMsg.Signer, share, msgID, signedMsg); err != nil {
+//			return msgSlot, err
+//		}
+//	}
+//
+//	if err := mv.validateSignatureFormat(signedMsg.Signature); err != nil {
+//		return msgSlot, err
+//	}
+//
+//	if signatureVerifier != nil {
+//		if err := signatureVerifier(); err != nil {
+//			return msgSlot, err
+//		}
+//	}
+//
+//	if signerState == nil {
+//		signerState = state.CreateSignerState(signedMsg.Signer)
+//	}
+//
+//	if msgSlot > signerState.Slot {
+//		newEpoch := mv.netCfg.Beacon.EstimatedEpochAtSlot(msgSlot) > mv.netCfg.Beacon.EstimatedEpochAtSlot(signerState.Slot)
+//		signerState.ResetSlot(msgSlot, genesisspecqbft.FirstRound, newEpoch)
+//	}
+//
+//	signerState.MessageCounts.RecordPartialSignatureMessage(signedMsg)
+//
+//	return msgSlot, nil
+//}
+//
+//func (mv *messageValidator) validPartialSigMsgType(msgType genesisspectypes.PartialSigMsgType) bool {
+//	switch msgType {
+//	case genesisspectypes.PostConsensusPartialSig,
+//		genesisspectypes.RandaoPartialSig,
+//		genesisspectypes.SelectionProofPartialSig,
+//		genesisspectypes.ContributionProofs,
+//		genesisspectypes.ValidatorRegistrationPartialSig,
+//		genesisspectypes.VoluntaryExitPartialSig:
+//		return true
+//	default:
+//		return false
+//	}
+//}
+//
+//func (mv *messageValidator) partialSignatureTypeMatchesRole(msgType genesisspectypes.PartialSigMsgType, role genesisspectypes.BeaconRole) bool {
+//	switch role {
+//	case genesisspectypes.BNRoleAttester:
+//		return msgType == genesisspectypes.PostConsensusPartialSig
+//	case genesisspectypes.BNRoleAggregator:
+//		return msgType == genesisspectypes.PostConsensusPartialSig || msgType == genesisspectypes.SelectionProofPartialSig
+//	case genesisspectypes.BNRoleProposer:
+//		return msgType == genesisspectypes.PostConsensusPartialSig || msgType == genesisspectypes.RandaoPartialSig
+//	case genesisspectypes.BNRoleSyncCommittee:
+//		return msgType == genesisspectypes.PostConsensusPartialSig
+//	case genesisspectypes.BNRoleSyncCommitteeContribution:
+//		return msgType == genesisspectypes.PostConsensusPartialSig || msgType == genesisspectypes.ContributionProofs
+//	case genesisspectypes.BNRoleValidatorRegistration:
+//		return msgType == genesisspectypes.ValidatorRegistrationPartialSig
+//	case genesisspectypes.BNRoleVoluntaryExit:
+//		return msgType == genesisspectypes.VoluntaryExitPartialSig
+//	default:
+//		panic("invalid role") // role validity should be checked before
+//	}
+//}
+//
+//func (mv *messageValidator) validatePartialMessages(share *ssvtypes.SSVShare, m *genesisspectypes.SignedPartialSignatureMessage) error {
+//	if err := mv.commonSignerValidation(m.Signer, share); err != nil {
+//		return err
+//	}
+//
+//	if len(m.Message.Messages) == 0 {
+//		return ErrNoPartialMessages
+//	}
+//
+//	seen := map[[32]byte]struct{}{}
+//	for _, message := range m.Message.Messages {
+//		if _, ok := seen[message.SigningRoot]; ok {
+//			return ErrDuplicatedPartialSignatureMessage
+//		}
+//		seen[message.SigningRoot] = struct{}{}
+//
+//		if message.Signer != m.Signer {
+//			err := ErrUnexpectedSigner
+//			err.want = m.Signer
+//			err.got = message.Signer
+//			return err
+//		}
+//
+//		if err := mv.commonSignerValidation(message.Signer, share); err != nil {
+//			return err
+//		}
+//
+//		if err := mv.validateSignatureFormat(message.PartialSignature); err != nil {
+//			return err
+//		}
+//	}
+//
+//	return nil
+//}
+//
+//func (mv *messageValidator) validateSignerBehaviorPartial(
+//	state *ConsensusState,
+//	signer genesisspectypes.OperatorID,
+//	share *ssvtypes.SSVShare,
+//	msgID genesisspectypes.MessageID,
+//	signedMsg *genesisspectypes.SignedPartialSignatureMessage,
+//) error {
+//	signerState := state.GetSignerState(signer)
+//
+//	if signerState == nil {
+//		return nil
+//	}
+//
+//	msgSlot := signedMsg.Message.Slot
+//
+//	if msgSlot < signerState.Slot {
+//		// Signers aren't allowed to decrease their slot.
+//		// If they've sent a future message due to clock error,
+//		// this should be caught by the earlyMessage check.
+//		err := ErrSlotAlreadyAdvanced
+//		err.want = signerState.Slot
+//		err.got = msgSlot
+//		return err
+//	}
+//
+//	newDutyInSameEpoch := false
+//	if msgSlot > signerState.Slot && mv.netCfg.Beacon.EstimatedEpochAtSlot(msgSlot) == mv.netCfg.Beacon.EstimatedEpochAtSlot(signerState.Slot) {
+//		newDutyInSameEpoch = true
+//	}
+//
+//	if err := mv.validateBeaconDuty(msgID.GetRoleType(), msgSlot, share); err != nil {
+//		return err
+//	}
+//
+//	if err := mv.validateDutyCount(signerState, msgID, newDutyInSameEpoch); err != nil {
+//		return err
+//	}
+//
+//	if msgSlot <= signerState.Slot {
+//		limits := maxMessageCounts(len(share.Committee))
+//		if err := signerState.MessageCounts.ValidatePartialSignatureMessage(signedMsg, limits); err != nil {
+//			return err
+//		}
+//	}
+//
+//	return nil
+//}

--- a/message/validation/genesis/partial_validation.go
+++ b/message/validation/genesis/partial_validation.go
@@ -2,171 +2,190 @@ package validation
 
 // partial_validation.go contains methods for validating partial signature messages
 
-// func (mv *messageValidator) validatePartialSignatureMessage(
-// 	share *ssvtypes.SSVShare,
-// 	signedMsg *genesisspectypes.SignedPartialSignatureMessage,
-// 	msgID genesisspectypes.MessageID,
-// 	signatureVerifier func() error,
-// ) (phase0.Slot, error) {
-// 	msgSlot := signedMsg.Message.Slot
+import (
+	"time"
 
-// 	if !mv.validPartialSigMsgType(signedMsg.Message.Type) {
-// 		e := ErrUnknownPartialMessageType
-// 		e.got = signedMsg.Message.Type
-// 		return msgSlot, e
-// 	}
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	genesisspecqbft "github.com/ssvlabs/ssv-spec-pre-cc/qbft"
+	genesisspectypes "github.com/ssvlabs/ssv-spec-pre-cc/types"
 
-// 	role := msgID.GetRoleType()
-// 	if !mv.partialSignatureTypeMatchesRole(signedMsg.Message.Type, role) {
-// 		return msgSlot, ErrPartialSignatureTypeRoleMismatch
-// 	}
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
+)
 
-// 	if err := mv.validatePartialMessages(share, signedMsg); err != nil {
-// 		return msgSlot, err
-// 	}
+func (mv *messageValidator) validatePartialSignatureMessage(
+	share *ssvtypes.SSVShare,
+	signedMsg *genesisspectypes.SignedPartialSignatureMessage,
+	msgID genesisspectypes.MessageID,
+	signatureVerifier func() error,
+	receivedAt time.Time,
+) (phase0.Slot, error) {
+	msgSlot := signedMsg.Message.Slot
 
-// 	state := mv.consensusState(msgID)
-// 	signerState := state.GetSignerState(signedMsg.Signer)
-// 	if signerState != nil {
-// 		if err := mv.validateSignerBehaviorPartial(state, signedMsg.Signer, share, msgID, signedMsg); err != nil {
-// 			return msgSlot, err
-// 		}
-// 	}
+	if !mv.validPartialSigMsgType(signedMsg.Message.Type) {
+		e := ErrUnknownPartialMessageType
+		e.got = signedMsg.Message.Type
+		return msgSlot, e
+	}
 
-// 	if err := mv.validateSignatureFormat(signedMsg.Signature); err != nil {
-// 		return msgSlot, err
-// 	}
+	role := msgID.GetRoleType()
+	if !mv.partialSignatureTypeMatchesRole(signedMsg.Message.Type, role) {
+		return msgSlot, ErrPartialSignatureTypeRoleMismatch
+	}
 
-// 	if signatureVerifier != nil {
-// 		if err := signatureVerifier(); err != nil {
-// 			return msgSlot, err
-// 		}
-// 	}
+	if err := mv.validatePartialMessages(share, signedMsg); err != nil {
+		return msgSlot, err
+	}
 
-// 	if signerState == nil {
-// 		signerState = state.CreateSignerState(signedMsg.Signer)
-// 	}
+	if err := mv.validateSlotTime(msgSlot, role, receivedAt); err != nil {
+		return msgSlot, err
+	}
 
-// 	if msgSlot > signerState.Slot {
-// 		newEpoch := mv.netCfg.Beacon.EstimatedEpochAtSlot(msgSlot) > mv.netCfg.Beacon.EstimatedEpochAtSlot(signerState.Slot)
-// 		signerState.ResetSlot(msgSlot, genesisspecqbft.FirstRound, newEpoch)
-// 	}
+	state := mv.consensusState(msgID)
+	signerState := state.GetSignerState(signedMsg.Signer)
+	if signerState != nil {
+		if err := mv.validateSignerBehaviorPartial(state, signedMsg.Signer, share, msgID, signedMsg); err != nil {
+			return msgSlot, err
+		}
+	}
 
-// 	signerState.MessageCounts.RecordPartialSignatureMessage(signedMsg)
+	if err := mv.validateSignatureFormat(signedMsg.Signature); err != nil {
+		return msgSlot, err
+	}
 
-// 	return msgSlot, nil
-// }
+	if signatureVerifier != nil {
+		if err := signatureVerifier(); err != nil {
+			return msgSlot, err
+		}
+	}
 
-// func (mv *messageValidator) validPartialSigMsgType(msgType genesisspectypes.PartialSigMsgType) bool {
-// 	switch msgType {
-// 	case genesisspectypes.PostConsensusPartialSig,
-// 		genesisspectypes.RandaoPartialSig,
-// 		genesisspectypes.SelectionProofPartialSig,
-// 		genesisspectypes.ContributionProofs,
-// 		genesisspectypes.ValidatorRegistrationPartialSig,
-// 		genesisspectypes.VoluntaryExitPartialSig:
-// 		return true
-// 	default:
-// 		return false
-// 	}
-// }
+	if signerState == nil {
+		signerState = state.CreateSignerState(signedMsg.Signer)
+	}
 
-// func (mv *messageValidator) partialSignatureTypeMatchesRole(msgType genesisspectypes.PartialSigMsgType, role genesisspectypes.BeaconRole) bool {
-// 	switch role {
-// 	case genesisspectypes.BNRoleAttester:
-// 		return msgType == genesisspectypes.PostConsensusPartialSig
-// 	case genesisspectypes.BNRoleAggregator:
-// 		return msgType == genesisspectypes.PostConsensusPartialSig || msgType == genesisspectypes.SelectionProofPartialSig
-// 	case genesisspectypes.BNRoleProposer:
-// 		return msgType == genesisspectypes.PostConsensusPartialSig || msgType == genesisspectypes.RandaoPartialSig
-// 	case genesisspectypes.BNRoleSyncCommittee:
-// 		return msgType == genesisspectypes.PostConsensusPartialSig
-// 	case genesisspectypes.BNRoleSyncCommitteeContribution:
-// 		return msgType == genesisspectypes.PostConsensusPartialSig || msgType == genesisspectypes.ContributionProofs
-// 	case genesisspectypes.BNRoleValidatorRegistration:
-// 		return msgType == genesisspectypes.ValidatorRegistrationPartialSig
-// 	case genesisspectypes.BNRoleVoluntaryExit:
-// 		return msgType == genesisspectypes.VoluntaryExitPartialSig
-// 	default:
-// 		panic("invalid role") // role validity should be checked before
-// 	}
-// }
+	if msgSlot > signerState.Slot {
+		newEpoch := mv.netCfg.Beacon.EstimatedEpochAtSlot(msgSlot) > mv.netCfg.Beacon.EstimatedEpochAtSlot(signerState.Slot)
+		signerState.ResetSlot(msgSlot, genesisspecqbft.FirstRound, newEpoch)
+	}
 
-// func (mv *messageValidator) validatePartialMessages(share *ssvtypes.SSVShare, m *genesisspectypes.SignedPartialSignatureMessage) error {
-// 	if err := mv.commonSignerValidation(m.Signer, share); err != nil {
-// 		return err
-// 	}
+	signerState.MessageCounts.RecordPartialSignatureMessage(signedMsg)
 
-// 	if len(m.Message.Messages) == 0 {
-// 		return ErrNoPartialMessages
-// 	}
+	return msgSlot, nil
+}
 
-// 	seen := map[[32]byte]struct{}{}
-// 	for _, message := range m.Message.Messages {
-// 		if _, ok := seen[message.SigningRoot]; ok {
-// 			return ErrDuplicatedPartialSignatureMessage
-// 		}
-// 		seen[message.SigningRoot] = struct{}{}
+func (mv *messageValidator) validPartialSigMsgType(msgType genesisspectypes.PartialSigMsgType) bool {
+	switch msgType {
+	case genesisspectypes.PostConsensusPartialSig,
+		genesisspectypes.RandaoPartialSig,
+		genesisspectypes.SelectionProofPartialSig,
+		genesisspectypes.ContributionProofs,
+		genesisspectypes.ValidatorRegistrationPartialSig,
+		genesisspectypes.VoluntaryExitPartialSig:
+		return true
+	default:
+		return false
+	}
+}
 
-// 		if message.Signer != m.Signer {
-// 			err := ErrUnexpectedSigner
-// 			err.want = m.Signer
-// 			err.got = message.Signer
-// 			return err
-// 		}
+func (mv *messageValidator) partialSignatureTypeMatchesRole(msgType genesisspectypes.PartialSigMsgType, role genesisspectypes.BeaconRole) bool {
+	switch role {
+	case genesisspectypes.BNRoleAttester:
+		return msgType == genesisspectypes.PostConsensusPartialSig
+	case genesisspectypes.BNRoleAggregator:
+		return msgType == genesisspectypes.PostConsensusPartialSig || msgType == genesisspectypes.SelectionProofPartialSig
+	case genesisspectypes.BNRoleProposer:
+		return msgType == genesisspectypes.PostConsensusPartialSig || msgType == genesisspectypes.RandaoPartialSig
+	case genesisspectypes.BNRoleSyncCommittee:
+		return msgType == genesisspectypes.PostConsensusPartialSig
+	case genesisspectypes.BNRoleSyncCommitteeContribution:
+		return msgType == genesisspectypes.PostConsensusPartialSig || msgType == genesisspectypes.ContributionProofs
+	case genesisspectypes.BNRoleValidatorRegistration:
+		return msgType == genesisspectypes.ValidatorRegistrationPartialSig
+	case genesisspectypes.BNRoleVoluntaryExit:
+		return msgType == genesisspectypes.VoluntaryExitPartialSig
+	default:
+		panic("invalid role") // role validity should be checked before
+	}
+}
 
-// 		if err := mv.commonSignerValidation(message.Signer, share); err != nil {
-// 			return err
-// 		}
+func (mv *messageValidator) validatePartialMessages(share *ssvtypes.SSVShare, m *genesisspectypes.SignedPartialSignatureMessage) error {
+	if err := mv.commonSignerValidation(m.Signer, share); err != nil {
+		return err
+	}
 
-// 		if err := mv.validateSignatureFormat(message.PartialSignature); err != nil {
-// 			return err
-// 		}
-// 	}
+	if len(m.Message.Messages) == 0 {
+		return ErrNoPartialMessages
+	}
 
-// 	return nil
-// }
+	seen := map[[32]byte]struct{}{}
+	for _, message := range m.Message.Messages {
+		if _, ok := seen[message.SigningRoot]; ok {
+			return ErrDuplicatedPartialSignatureMessage
+		}
+		seen[message.SigningRoot] = struct{}{}
 
-// func (mv *messageValidator) validateSignerBehaviorPartial(
-// 	state *ConsensusState,
-// 	signer genesisspectypes.OperatorID,
-// 	share *ssvtypes.SSVShare,
-// 	msgID genesisspectypes.MessageID,
-// 	signedMsg *genesisspectypes.SignedPartialSignatureMessage,
-// ) error {
-// 	signerState := state.GetSignerState(signer)
+		if message.Signer != m.Signer {
+			err := ErrUnexpectedSigner
+			err.want = m.Signer
+			err.got = message.Signer
+			return err
+		}
 
-// 	if signerState == nil {
-// 		return nil
-// 	}
+		if err := mv.commonSignerValidation(message.Signer, share); err != nil {
+			return err
+		}
 
-// 	msgSlot := signedMsg.Message.Slot
+		if err := mv.validateSignatureFormat(message.PartialSignature); err != nil {
+			return err
+		}
+	}
 
-// 	if msgSlot < signerState.Slot {
-// 		// Signers aren't allowed to decrease their slot.
-// 		// If they've sent a future message due to clock error,
-// 		// this should be caught by the earlyMessage check.
-// 		err := ErrSlotAlreadyAdvanced
-// 		err.want = signerState.Slot
-// 		err.got = msgSlot
-// 		return err
-// 	}
+	return nil
+}
 
-// 	newDutyInSameEpoch := false
-// 	if msgSlot > signerState.Slot && mv.netCfg.Beacon.EstimatedEpochAtSlot(msgSlot) == mv.netCfg.Beacon.EstimatedEpochAtSlot(signerState.Slot) {
-// 		newDutyInSameEpoch = true
-// 	}
+func (mv *messageValidator) validateSignerBehaviorPartial(
+	state *ConsensusState,
+	signer genesisspectypes.OperatorID,
+	share *ssvtypes.SSVShare,
+	msgID genesisspectypes.MessageID,
+	signedMsg *genesisspectypes.SignedPartialSignatureMessage,
+) error {
+	signerState := state.GetSignerState(signer)
 
-// 	if err := mv.validateDutyCount(signerState, msgID, newDutyInSameEpoch); err != nil {
-// 		return err
-// 	}
+	if signerState == nil {
+		return nil
+	}
 
-// 	if msgSlot <= signerState.Slot {
-// 		limits := maxMessageCounts(len(share.Committee))
-// 		if err := signerState.MessageCounts.ValidatePartialSignatureMessage(signedMsg, limits); err != nil {
-// 			return err
-// 		}
-// 	}
+	msgSlot := signedMsg.Message.Slot
 
-// 	return nil
-// }
+	if msgSlot < signerState.Slot {
+		// Signers aren't allowed to decrease their slot.
+		// If they've sent a future message due to clock error,
+		// this should be caught by the earlyMessage check.
+		err := ErrSlotAlreadyAdvanced
+		err.want = signerState.Slot
+		err.got = msgSlot
+		return err
+	}
+
+	newDutyInSameEpoch := false
+	if msgSlot > signerState.Slot && mv.netCfg.Beacon.EstimatedEpochAtSlot(msgSlot) == mv.netCfg.Beacon.EstimatedEpochAtSlot(signerState.Slot) {
+		newDutyInSameEpoch = true
+	}
+
+	if err := mv.validateBeaconDuty(msgID.GetRoleType(), msgSlot, share); err != nil {
+		return err
+	}
+
+	if err := mv.validateDutyCount(signerState, msgID, newDutyInSameEpoch); err != nil {
+		return err
+	}
+
+	if msgSlot <= signerState.Slot {
+		limits := maxMessageCounts(len(share.Committee))
+		if err := signerState.MessageCounts.ValidatePartialSignatureMessage(signedMsg, limits); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/message/validation/genesis/signer_state.go
+++ b/message/validation/genesis/signer_state.go
@@ -16,7 +16,7 @@ type SignerState struct {
 	Slot          phase0.Slot
 	Round         specqbft.Round
 	MessageCounts MessageCounts
-	ProposalData  []byte
+	ProposalData  []byte // used only to check different proposal data
 	EpochDuties   int
 }
 

--- a/message/validation/genesis/validation.go
+++ b/message/validation/genesis/validation.go
@@ -478,7 +478,7 @@ func (mv *messageValidator) validateSSVMessage(msg *genesisqueue.GenesisSSVMessa
 
 			partialSignatureMessage := msg.Body.(*spectypes.SignedPartialSignatureMessage)
 			// TODO fix this
-			//slot, err := mv.validatePartialSignatureMessage(share, partialSignatureMessage, msg.GetID(), signatureVerifier)
+			//slot, err := mv.validatePartialSignatureMessage(share, partialSignatureMessage, msg.GetID(), signatureVerifier, receivedAt)
 			descriptor.Slot = partialSignatureMessage.Message.Slot
 			if err != nil {
 				return nil, descriptor, err
@@ -489,6 +489,9 @@ func (mv *messageValidator) validateSSVMessage(msg *genesisqueue.GenesisSSVMessa
 
 		case spectypes.DKGMsgType:
 			return nil, descriptor, ErrDKGMessage
+
+		default:
+			return nil, descriptor, ErrUnknownSSVMessageType
 		}
 	}
 

--- a/message/validation/genesis/validation_test.go
+++ b/message/validation/genesis/validation_test.go
@@ -1052,6 +1052,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 								Signer:           1,
 							},
 						},
+						Slot: slot,
 					}
 
 					sig, err := spectestingutils.NewTestingKeyManager().SignRoot(innerMsg, spectypes.PartialSignatureType, ks.Shares[1].GetPublicKey().Serialize())

--- a/message/validation/genesis/validation_test.go
+++ b/message/validation/genesis/validation_test.go
@@ -1760,7 +1760,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		_, _, err = validator.validateSSVMessage(message2, receivedAt, nil)
-		expectedErr := ErrDuplicatedProposalWithDifferentData
+		expectedErr := ErrDifferentProposalData
 		require.ErrorIs(t, err, expectedErr)
 	})
 

--- a/message/validation/partial_validation.go
+++ b/message/validation/partial_validation.go
@@ -104,6 +104,11 @@ func (mv *messageValidator) validatePartialSignatureMessageSemantics(
 	}
 
 	for _, message := range partialSignatureMessages.Messages {
+		// Rule: Partial signature must have expected length
+		if len(message.PartialSignature) != blsSignatureSize {
+			return ErrWrongBLSSignatureSize
+		}
+
 		// Rule: Partial signature signer must be consistent
 		if message.Signer != signer {
 			err := ErrInconsistentSigners
@@ -112,12 +117,16 @@ func (mv *messageValidator) validatePartialSignatureMessageSemantics(
 			return err
 		}
 
-		// Rule: Validator index must match with validatorPK or one of CommitteeID's validators
-		if !slices.Contains(validatorIndices, message.ValidatorIndex) {
-			e := ErrValidatorIndexMismatch
-			e.got = message.ValidatorIndex
-			e.want = validatorIndices
-			return e
+		// Rule: (only for Validator duties) Validator index must match with validatorPK
+		// For Committee duties, we don't assume that operators are synced on the validators set
+		// So, we can't make this assertion
+		if !mv.committeeRole(signedSSVMessage.SSVMessage.GetID().GetRoleType()) {
+			if !slices.Contains(validatorIndices, message.ValidatorIndex) {
+				e := ErrValidatorIndexMismatch
+				e.got = message.ValidatorIndex
+				e.want = validatorIndices
+				return e
+			}
 		}
 	}
 

--- a/message/validation/partial_validation.go
+++ b/message/validation/partial_validation.go
@@ -104,10 +104,7 @@ func (mv *messageValidator) validatePartialSignatureMessageSemantics(
 	}
 
 	for _, message := range partialSignatureMessages.Messages {
-		// Rule: Partial signature must have expected length
-		if len(message.PartialSignature) != blsSignatureSize {
-			return ErrWrongBLSSignatureSize
-		}
+		// Rule: Partial signature must have expected length. Already enforced by ssz.
 
 		// Rule: Partial signature signer must be consistent
 		if message.Signer != signer {

--- a/message/validation/validation.go
+++ b/message/validation/validation.go
@@ -232,6 +232,8 @@ func (mv *messageValidator) getCommitteeAndValidatorIndices(msgID spectypes.Mess
 		}, nil
 	}
 
+	// NOTE: do we have to deserialize the public key here? we already check for existence in the validator store.
+	// 	Attacker could send a message with a valid public key that doesn't exist in the validator store.
 	publicKey, err := ssvtypes.DeserializeBLSPublicKey(msgID.GetDutyExecutorID())
 	if err != nil {
 		e := ErrDeserializePublicKey

--- a/message/validation/validation.go
+++ b/message/validation/validation.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
-	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 	"github.com/ssvlabs/ssv/registry/storage"
 )
 
@@ -232,19 +231,10 @@ func (mv *messageValidator) getCommitteeAndValidatorIndices(msgID spectypes.Mess
 		}, nil
 	}
 
-	// NOTE: do we have to deserialize the public key here? we already check for existence in the validator store.
-	// 	Attacker could send a message with a valid public key that doesn't exist in the validator store.
-	publicKey, err := ssvtypes.DeserializeBLSPublicKey(msgID.GetDutyExecutorID())
-	if err != nil {
-		e := ErrDeserializePublicKey
-		e.innerErr = err
-		return CommitteeInfo{}, e
-	}
-
-	validator := mv.validatorStore.Validator(publicKey.Serialize())
+	validator := mv.validatorStore.Validator(msgID.GetDutyExecutorID())
 	if validator == nil {
 		e := ErrUnknownValidator
-		e.got = publicKey.SerializeToHexStr()
+		e.got = hex.EncodeToString(msgID.GetDutyExecutorID())
 		return CommitteeInfo{}, e
 	}
 

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -1176,7 +1176,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		signedSSVMessage.FullData = anotherFullData
 
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, receivedAt)
-		expectedErr := ErrDuplicatedProposalWithDifferentData
+		expectedErr := ErrDifferentProposalData
 		require.ErrorIs(t, err, expectedErr)
 	})
 

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -364,21 +364,6 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		require.ErrorContains(t, err, ErrUnknownSSVMessageType.Error())
 	})
 
-	// Empty validator public key returns an error
-	t.Run("empty validator public key", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
-
-		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
-
-		badPK := spectypes.ValidatorPK{}
-		badIdentifier := spectypes.NewMsgID(netCfg.DomainType(), badPK[:], nonCommitteeRole)
-		signedSSVMessage := generateSignedMessage(ks, badIdentifier, slot)
-
-		topicID := commons.ValidatorTopicID(signedSSVMessage.SSVMessage.GetID().GetDutyExecutorID())[0]
-		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, time.Now())
-		require.ErrorContains(t, err, ErrDeserializePublicKey.Error())
-	})
-
 	// Generate random validator and validate it is unknown to the network
 	t.Run("unknown validator", func(t *testing.T) {
 		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)


### PR DESCRIPTION
# Overview

This PR applies the suggestions of the message validation review: https://github.com/ssvlabs/ssv/pull/1482

### Changes

#### Alan
- Update the "validator index match ValidatorPK or CommitteeID" rule to be checked only for validator duties.

#### Genesis
- Add the `ProposalMsgType` check before updating `ProposalData` in the state.
- Add slot time and beacon duty checks in PartialSignatureMessages validation.
- Fix > to >= in `MessageCount`.
- Add assertion and `ErrNoSigners` error in `MessageCount` for completeness.
- Add default check for a wrong message type in `ValidateSSVMessage`.