### PR TITLE
Improve p2p scoring log

### DIFF
--- a/network/topics/pubsub.go
+++ b/network/topics/pubsub.go
@@ -149,18 +149,29 @@ func NewPubSub(ctx context.Context, logger *zap.Logger, cfg *PubSubConfig, metri
 	if cfg.ScoreIndex != nil || inspector != nil {
 		cfg.initScoring()
 
+		// TODO: put this code back in the end of this "if" scope
+		// Get topic score params factory
+		if cfg.GetValidatorStats == nil {
+			cfg.GetValidatorStats = func() (uint64, uint64, uint64, error) {
+				// default in case it was not injected
+				return 100, 100, 10, nil
+			}
+		}
+		topicScoreFactory = topicScoreParams(logger, cfg, committeesProvider)
+
+		peerScoreParams := params.PeerScoreParams(cfg.Scoring.OneEpochDuration, cfg.MsgIDCacheTTL, cfg.DisableIPRateLimit, cfg.Scoring.IPWhilelist...)
+
 		if inspector == nil {
 			peerConnected := func(pid peer.ID) bool {
 				return cfg.Host.Network().Connectedness(pid) == libp2pnetwork.Connected
 			}
-			inspector = scoreInspector(logger, cfg.ScoreIndex, scoreInspectLogFrequency, metrics, peerConnected)
+			inspector = scoreInspector(logger, cfg.ScoreIndex, scoreInspectLogFrequency, metrics, peerConnected, peerScoreParams, topicScoreFactory)
 		}
 
 		if inspectInterval == 0 {
 			inspectInterval = defaultScoreInspectInterval
 		}
 
-		peerScoreParams := params.PeerScoreParams(cfg.Scoring.OneEpochDuration, cfg.MsgIDCacheTTL, cfg.DisableIPRateLimit, cfg.Scoring.IPWhilelist...)
 		psOpts = append(psOpts, pubsub.WithPeerScore(peerScoreParams, params.PeerScoreThresholds()),
 			pubsub.WithPeerScoreInspect(inspector, inspectInterval))
 		if cfg.GetValidatorStats == nil {

--- a/network/topics/scoring.go
+++ b/network/topics/scoring.go
@@ -25,108 +25,128 @@ func DefaultScoringConfig() *ScoringConfig {
 
 // scoreInspector inspects scores and updates the score index accordingly
 // TODO: finalize once validation is in place
-// TODO: remove the peerScoreParams and topicScoreParamsFactory arguments
 func scoreInspector(logger *zap.Logger, scoreIdx peers.ScoreIndex, logFrequency int, metrics Metrics, peerConnected func(pid peer.ID) bool, peerScoreParams *pubsub.PeerScoreParams, topicScoreParamsFactory func(string) *pubsub.TopicScoreParams) pubsub.ExtendedPeerScoreInspectFn {
 	inspections := 0
 
 	return func(scores map[peer.ID]*pubsub.PeerScoreSnapshot) {
+
+		if inspections%logFrequency != 0 {
+			// Don't log yet.
+			inspections++
+			return
+		}
+
 		// Reset metrics before updating them.
 		metrics.ResetPeerScores()
 
-		for pid, peerScores := range scores {
-			// Compute score-related stats for this peer.
-			filtered := make(map[string]*pubsub.TopicScoreSnapshot)
+		// Use a "scope cache" for getting a topic's score parameters
+		// otherwise, the factory method would be called multiple times for the same topic
+		topicScoreParamsCache := make(map[string]*pubsub.TopicScoreParams)
+		getScoreParamsForTopic := func(topic string) *pubsub.TopicScoreParams {
+			if topicParams, exists := topicScoreParamsCache[topic]; exists {
+				return topicParams
+			}
+			topicScoreParamsCache[topic] = topicScoreParamsFactory(topic)
+			return topicScoreParamsCache[topic]
+		}
 
-			var totalLowMeshDeliveries int
+		// Log score for each peer
+		for pid, peerScores := range scores {
+
+			// Store topic snapshot for topics with invalid messages
+			filtered := make(map[string]*pubsub.TopicScoreSnapshot)
 			for topic, snapshot := range peerScores.Topics {
-				// Topics stats with invalid messages
 				if snapshot.InvalidMessageDeliveries != 0 {
 					filtered[topic] = snapshot
 				}
-				// Total topics with low mesh delivery
-				if snapshot.MeshMessageDeliveries < 107 {
-					totalLowMeshDeliveries++
-				}
 			}
 
-			// Compute p1, p2, p4, p6 and p7. The subscores p3 and p5 are unused.
+			// Compute p4 impact in final score for metrics
+			p4Impact := float64(0)
 
-			// Parameters to compute the p1 counter
-			p1 := float64(0)
+			// Compute counters and weights for p1, p2, p4, p6 and p7.
+			// The subscores p3 and p5 are unused.
 
+			// P1 - Time in mesh
+			// The weight should be equal for all topics. So, we can just sum up the counters.
+			p1CounterSum := float64(0)
+
+			// P2 - First message deliveries
 			// The weight for the p2 score (w2) may be different through topics
-			// So we store a list of counters P2c and the associated weight W2
+			// So, we store a list of counters P2c and their associated weights W2
+			// Note: if necessary, we may reduce the size of the log by summing P2c * W2 for all topics and logging this result
 			type P2Score struct {
 				P2Counter float64
 				W2        float64
 			}
 			p2 := make([]*P2Score, 0)
-			p2Total := float64(0)
 
-			// P4. The weight should be equal for all topics. So we can just sum up the counters squared.
-			p4 := float64(0)
+			// P4 - InvalidMessageDeliveries
+			// The weight should be equal for all topics. So, we can just sum up the counters squared.
+			p4CounterSum := float64(0)
 
+			// Get counters for each topic
 			for topic, snapshot := range peerScores.Topics {
 
-				topicScoreParams := topicScoreParamsFactory(topic)
+				topicScoreParams := getScoreParamsForTopic(topic)
 
-				// The weight should be equal for all topics. So we can just compute the counter and sum it
+				// Cap p1 as done in GossipSub
 				p1Counter := float64(snapshot.TimeInMesh / topicScoreParams.TimeInMeshQuantum)
 				if p1Counter > topicScoreParams.TimeInMeshCap {
 					p1Counter = topicScoreParams.TimeInMeshCap
 				}
-				p1 += p1Counter
+				p1CounterSum += p1Counter
 
-				p4 += snapshot.InvalidMessageDeliveries * snapshot.InvalidMessageDeliveries
+				// Square the P4 counter as done in GossipSub
+				p4CounterSquaredForTopic := snapshot.InvalidMessageDeliveries * snapshot.InvalidMessageDeliveries
+				p4CounterSum += p4CounterSquaredForTopic
 
+				// Update p4 impact on final score
+				p4Impact += topicScoreParams.TopicWeight * topicScoreParams.InvalidMessageDeliveriesWeight * p4CounterSquaredForTopic
+
+				// Store the counter and weight for P2
 				w2 := topicScoreParams.FirstMessageDeliveriesWeight
 				p2 = append(p2, &P2Score{
 					P2Counter: snapshot.FirstMessageDeliveries,
 					W2:        w2,
 				})
-				p2Total += snapshot.FirstMessageDeliveries * w2
 			}
 
-			p6 := peerScores.IPColocationFactor
-			w6 := peerScoreParams.IPColocationFactorWeight
-
-			p7 := peerScores.BehaviourPenalty
-			w7 := peerScoreParams.BehaviourPenaltyWeight
-
-			// Take w1 and w4 (which should be the same for all topics)
+			// Get weights for P1 and P4 (w1 and w4), which should be equal for all topics
 			w1 := float64(0)
 			w4 := float64(0)
 			for topic := range peerScores.Topics {
-				topicScoreParams := topicScoreParamsFactory(topic)
+				topicScoreParams := getScoreParamsForTopic(topic)
 				w1 = topicScoreParams.TimeInMeshWeight
 				w4 = topicScoreParams.InvalidMessageDeliveriesWeight
 				break
 			}
 
+			// P6 - IP Colocation factor
+			p6 := peerScores.IPColocationFactor
+			w6 := peerScoreParams.IPColocationFactorWeight
+
+			// P7 - Behaviour penalty
+			p7 := peerScores.BehaviourPenalty
+			w7 := peerScoreParams.BehaviourPenaltyWeight
+
 			// Update metrics.
 			metrics.PeerScore(pid, peerScores.Score)
-			metrics.PeerP4Score(pid, p4)
-
-			if inspections%logFrequency != 0 {
-				// Don't log yet.
-				continue
-			}
+			metrics.PeerP4Score(pid, p4Impact)
 
 			// Log.
 			fields := []zap.Field{
 				fields.PeerID(pid),
 				fields.PeerScore(peerScores.Score),
-				zap.Float64("p1_time_in_mesh", p1),
+				zap.Float64("p1_time_in_mesh", p1CounterSum),
 				zap.Float64("w1_time_in_mesh", w1),
 				zap.Any("p2_first_message_deliveries", p2),
-				zap.Any("p2_total", p2Total),
-				zap.Float64("p4_invalid_message_deliveries", p4),
+				zap.Float64("p4_invalid_message_deliveries", p4CounterSum),
 				zap.Float64("w4_invalid_message_deliveries", w4),
 				zap.Float64("p6_ip_colocation_factor", p6),
 				zap.Float64("w6_ip_colocation_factor", w6),
 				zap.Float64("p7_behaviour_penalty", p7),
 				zap.Float64("w7_behaviour_penalty", w7),
-				zap.Float64("total_low_mesh_deliveries", float64(totalLowMeshDeliveries)),
 				zap.Any("invalid_messages", filtered),
 			}
 			if peerConnected(pid) {


### PR DESCRIPTION
# Overview

This PR improves the p2p scoring log. Namely, it adds the explicit counters for p1, p2, p4, p6 and p7.

In the `network/topics/pubsub.go:NewPubSub` function, the order of some initialization calls was changed so that `scoreInspector` could access topics' parameters and overall score parameters.