### PR TITLE
fix: (alan) don't submit empty attestation or sc messages

### DIFF
--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -419,8 +419,6 @@ func (cr *CommitteeRunner) ProcessPostConsensus(logger *zap.Logger, signedMsg *t
 		}
 	}
 
-	var submissionStart time.Time
-
 	logger = logger.With(durationFields...)
 	// Submit multiple attestations
 	attestations := make([]*phase0.Attestation, 0, len(attestationsToSubmit))
@@ -429,7 +427,7 @@ func (cr *CommitteeRunner) ProcessPostConsensus(logger *zap.Logger, signedMsg *t
 	}
 
 	if len(attestations) > 0 {
-		submissionStart = time.Now()
+		submissionStart := time.Now()
 		if err := cr.beacon.SubmitAttestations(attestations); err != nil {
 			logger.Error("❌ failed to submit attestation", zap.Error(err))
 			return errors.Wrap(err, "could not submit to Beacon chain reconstructed attestation")
@@ -451,7 +449,7 @@ func (cr *CommitteeRunner) ProcessPostConsensus(logger *zap.Logger, signedMsg *t
 		syncCommitteeMessages = append(syncCommitteeMessages, syncMsg)
 	}
 	if len(syncCommitteeMessages) > 0 {
-		submissionStart = time.Now()
+		submissionStart := time.Now()
 		if err := cr.beacon.SubmitSyncMessages(syncCommitteeMessages); err != nil {
 			logger.Error("❌ failed to submit sync committee", zap.Error(err))
 			return errors.Wrap(err, "could not submit to Beacon chain reconstructed signed sync committee")

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -418,44 +418,52 @@ func (cr *CommitteeRunner) ProcessPostConsensus(logger *zap.Logger, signedMsg *t
 			}
 		}
 	}
+
+	var submissionStart time.Time
+
 	logger = logger.With(durationFields...)
 	// Submit multiple attestations
-	attestations := make([]*phase0.Attestation, 0)
+	attestations := make([]*phase0.Attestation, 0, len(attestationsToSubmit))
 	for _, att := range attestationsToSubmit {
 		attestations = append(attestations, att)
 	}
-	submmitionStart := time.Now()
-	if err := cr.beacon.SubmitAttestations(attestations); err != nil {
-		logger.Error("❌ failed to submit attestation", zap.Error(err))
-		return errors.Wrap(err, "could not submit to Beacon chain reconstructed attestation")
-	}
 
-	logger.Info("✅ successfully submitted attestations",
-		fields.SubmissionTime(time.Since(submmitionStart)),
-		fields.Height(cr.BaseRunner.QBFTController.Height),
-		fields.Round(cr.BaseRunner.State.RunningInstance.State.Round))
-	// Record successful submissions
-	for validator := range attestationsToSubmit {
-		cr.RecordSubmission(types.BNRoleAttester, validator)
+	if len(attestations) > 0 {
+		submissionStart = time.Now()
+		if err := cr.beacon.SubmitAttestations(attestations); err != nil {
+			logger.Error("❌ failed to submit attestation", zap.Error(err))
+			return errors.Wrap(err, "could not submit to Beacon chain reconstructed attestation")
+		}
+
+		logger.Info("✅ successfully submitted attestations",
+			fields.SubmissionTime(time.Since(submissionStart)),
+			fields.Height(cr.BaseRunner.QBFTController.Height),
+			fields.Round(cr.BaseRunner.State.RunningInstance.State.Round))
+		// Record successful submissions
+		for validator := range attestationsToSubmit {
+			cr.RecordSubmission(types.BNRoleAttester, validator)
+		}
 	}
 
 	// Submit multiple sync committee
-	syncCommitteeMessages := make([]*altair.SyncCommitteeMessage, 0)
+	syncCommitteeMessages := make([]*altair.SyncCommitteeMessage, 0, len(syncCommitteeMessagesToSubmit))
 	for _, syncMsg := range syncCommitteeMessagesToSubmit {
 		syncCommitteeMessages = append(syncCommitteeMessages, syncMsg)
 	}
-	submmitionStart = time.Now()
-	if err := cr.beacon.SubmitSyncMessages(syncCommitteeMessages); err != nil {
-		logger.Error("❌ failed to submit sync committee", zap.Error(err))
-		return errors.Wrap(err, "could not submit to Beacon chain reconstructed signed sync committee")
-	}
-	logger.Info("✅ successfully submitted sync committee",
-		fields.SubmissionTime(time.Since(submmitionStart)),
-		fields.Height(cr.BaseRunner.QBFTController.Height),
-		fields.Round(cr.BaseRunner.State.RunningInstance.State.Round))
-	// Record successful submissions
-	for validator := range syncCommitteeMessagesToSubmit {
-		cr.RecordSubmission(types.BNRoleSyncCommittee, validator)
+	if len(syncCommitteeMessages) > 0 {
+		submissionStart = time.Now()
+		if err := cr.beacon.SubmitSyncMessages(syncCommitteeMessages); err != nil {
+			logger.Error("❌ failed to submit sync committee", zap.Error(err))
+			return errors.Wrap(err, "could not submit to Beacon chain reconstructed signed sync committee")
+		}
+		logger.Info("✅ successfully submitted sync committee",
+			fields.SubmissionTime(time.Since(submissionStart)),
+			fields.Height(cr.BaseRunner.QBFTController.Height),
+			fields.Round(cr.BaseRunner.State.RunningInstance.State.Round))
+		// Record successful submissions
+		for validator := range syncCommitteeMessagesToSubmit {
+			cr.RecordSubmission(types.BNRoleSyncCommittee, validator)
+		}
 	}
 
 	if anyErr != nil {


### PR DESCRIPTION
### Description 

We saw a few cases where a response from the beacon node indicated an empty message sent.

### Fix

Don't submit if there is no data to send.