### PR TITLE
fix: (differ) bug in package name reduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,3 @@ bin/
 /scripts/spec_align_report/ssv-spec
 .vscode/
 patches/
-
-differ

--- a/scripts/differ/transformers.go
+++ b/scripts/differ/transformers.go
@@ -30,8 +30,8 @@ func NoPackageNames(packages []string) Transformer {
 	if len(packages) == 0 {
 		return NopTransformer()
 	}
-	expr := regexp.MustCompile(`\b(?:` + strings.Join(packages, "|") + `)\.([a-zA-Z_][a-zA-Z0-9_]*)\b`)
-	return func(code string) string { return expr.ReplaceAllString(code, "$1") }
+	expr := regexp.MustCompile(`(?m)([ \t()\[\]\{\}*&]|^)(?:` + strings.Join(packages, "|") + `)\.([a-zA-Z_][a-zA-Z0-9_]*)([ \t()\[\]\{\}*&,:]|$)`)
+	return func(code string) string { return expr.ReplaceAllString(code, "$1$2$3") }
 }
 
 func NoEmptyLines() Transformer {

--- a/scripts/differ/transformers_test.go
+++ b/scripts/differ/transformers_test.go
@@ -17,6 +17,8 @@ mtypes.One
 mqbft.Two
 typesm.One
 qbftm.Two
+types, One, spectypes, Two
+types+One, spectypes+Two
 types.One qbft.Two`
 	expected :=
 		`One
@@ -28,6 +30,8 @@ mtypes.One
 mqbft.Two
 typesm.One
 qbftm.Two
+types, One, spectypes, Two
+types+One, spectypes+Two
 One qbft.Two`
 	actual := NoPackageNames([]string{"types", "qbft"})(input)
 	require.Equal(t, expected, actual)

--- a/scripts/differ/transformers_test.go
+++ b/scripts/differ/transformers_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoPackageNames(t *testing.T) {
+	input :=
+		`types.One
+*qbft.Two
+types.One, qbft.Two
+(types.One, &qbft.Two)
+
+mtypes.One
+mqbft.Two
+typesm.One
+qbftm.Two
+types.One qbft.Two`
+	expected :=
+		`One
+*Two
+One, Two
+(One, &Two)
+
+mtypes.One
+mqbft.Two
+typesm.One
+qbftm.Two
+One qbft.Two`
+	actual := NoPackageNames([]string{"types", "qbft"})(input)
+	require.Equal(t, expected, actual)
+
+	input2 := `msgToBroadcast := &spectypes.SignedSSVMessage{
+		Signatures:  [][]byte{sig},
+		OperatorIDs: []spectypes.OperatorID{r.operatorSigner.GetOperatorID()},
+		SSVMessage:  ssvMsg,
+	}`
+	expected2 := `msgToBroadcast := &SignedSSVMessage{
+		Signatures:  [][]byte{sig},
+		OperatorIDs: []OperatorID{r.operatorSigner.GetOperatorID()},
+		SSVMessage:  ssvMsg,
+	}`
+	actual2 := NoPackageNames([]string{"spectypes"})(input2)
+	require.Equal(t, expected2, actual2)
+}


### PR DESCRIPTION
Apparently a regex using `\b` is unsafe in some scenarios. We've seen it match and therefore replace more than just package names.

This PR refactors the regex to match package names more precisely and thus safely.