### PR TITLE
refactor: pass preset domains instead of functions

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -1358,11 +1358,8 @@ func SetupCommitteeRunners(
 		}
 		config.ValueCheckF = valueCheckF
 
-		identifier := func() []byte {
-			identifier := spectypes.NewMsgID(options.NetworkConfig.AlanDomainType, options.Operator.CommitteeID[:], role)
-			return identifier[:]
-		}
-		qbftCtrl := qbftcontroller.NewController(identifier, options.Operator, config, options.OperatorSigner, options.FullNode)
+		identifier := spectypes.NewMsgID(options.NetworkConfig.AlanDomainType, options.Operator.CommitteeID[:], role)
+		qbftCtrl := qbftcontroller.NewController(identifier[:], options.Operator, config, options.OperatorSigner, options.FullNode)
 		return qbftCtrl
 	}
 
@@ -1420,12 +1417,8 @@ func SetupRunners(
 			CutOffRound: specqbft.Round(specqbft.CutoffRound),
 		}
 		config.ValueCheckF = valueCheckF
-
-		identifier := func() []byte {
-			identifier := spectypes.NewMsgID(options.NetworkConfig.DomainType(), options.SSVShare.Share.ValidatorPubKey[:], role)
-			return identifier[:]
-		}
-		qbftCtrl := qbftcontroller.NewController(identifier, options.Operator, config, options.OperatorSigner, options.FullNode)
+		identifier := spectypes.NewMsgID(options.NetworkConfig.AlanDomainType, options.SSVShare.Share.ValidatorPubKey[:], role)
+		qbftCtrl := qbftcontroller.NewController(identifier[:], options.Operator, config, options.OperatorSigner, options.FullNode)
 		return qbftCtrl
 	}
 

--- a/protocol/v2/qbft/controller/controller.go
+++ b/protocol/v2/qbft/controller/controller.go
@@ -26,7 +26,7 @@ type NewDecidedHandler func(msg qbftstorage.ParticipantsRangeEntry)
 // Controller is a QBFT coordinator responsible for starting and following the entire life cycle of multiple QBFT InstanceContainer
 type Controller struct {
 	Height     specqbft.Height // incremental Height for InstanceContainer
-	Identifier func() []byte   `json:"-"`
+	Identifier []byte          `json:"-"`
 	// StoredInstances stores the last HistoricalInstanceCapacity in an array for message processing purposes.
 	StoredInstances   InstanceContainer
 	CommitteeMember   *spectypes.CommitteeMember
@@ -37,7 +37,7 @@ type Controller struct {
 }
 
 func NewController(
-	Identifier func() []byte,
+	Identifier []byte,
 	committeeMember *spectypes.CommitteeMember,
 	config qbft.IConfig,
 	signer ssvtypes.OperatorSigner,
@@ -161,7 +161,7 @@ func (c *Controller) UponExistingInstanceMsg(logger *zap.Logger, msg *specqbft.P
 // BaseMsgValidation returns error if msg is invalid (base validation)
 func (c *Controller) BaseMsgValidation(msg *specqbft.ProcessingMessage) error {
 	// verify msg belongs to controller
-	if !bytes.Equal(c.Identifier(), msg.QBFTMessage.Identifier) {
+	if !bytes.Equal(c.Identifier, msg.QBFTMessage.Identifier) {
 		return errors.New("message doesn't belong to Identifier")
 	}
 
@@ -178,7 +178,7 @@ func (c *Controller) InstanceForHeight(logger *zap.Logger, height specqbft.Heigh
 	if !c.fullNode {
 		return nil
 	}
-	storedInst, err := c.config.GetStorage().GetInstance(c.Identifier(), height)
+	storedInst, err := c.config.GetStorage().GetInstance(c.Identifier, height)
 	if err != nil {
 		logger.Debug("❗ could not load instance from storage",
 			fields.Height(height),
@@ -189,14 +189,14 @@ func (c *Controller) InstanceForHeight(logger *zap.Logger, height specqbft.Heigh
 	if storedInst == nil {
 		return nil
 	}
-	inst := instance.NewInstance(c.config, c.CommitteeMember, c.Identifier(), storedInst.State.Height, c.OperatorSigner)
+	inst := instance.NewInstance(c.config, c.CommitteeMember, c.Identifier, storedInst.State.Height, c.OperatorSigner)
 	inst.State = storedInst.State
 	return inst
 }
 
 // GetIdentifier returns QBFT Identifier, used to identify messages
 func (c *Controller) GetIdentifier() []byte {
-	return c.Identifier()
+	return c.Identifier
 }
 
 // isFutureMessage returns true if message height is from a future instance.
@@ -211,7 +211,7 @@ func (c *Controller) isFutureMessage(msg *specqbft.ProcessingMessage) (bool, err
 
 // addAndStoreNewInstance returns creates a new QBFT instance, stores it in an array and returns it
 func (c *Controller) addAndStoreNewInstance() *instance.Instance {
-	i := instance.NewInstance(c.GetConfig(), c.CommitteeMember, c.Identifier(), c.Height, c.OperatorSigner)
+	i := instance.NewInstance(c.GetConfig(), c.CommitteeMember, c.Identifier, c.Height, c.OperatorSigner)
 	c.StoredInstances.addNewInstance(i)
 	return i
 }

--- a/protocol/v2/qbft/controller/decided.go
+++ b/protocol/v2/qbft/controller/decided.go
@@ -29,7 +29,7 @@ func (c *Controller) UponDecided(logger *zap.Logger, msg *specqbft.ProcessingMes
 	save := true
 
 	if inst == nil {
-		i := instance.NewInstance(c.GetConfig(), c.CommitteeMember, c.Identifier(), msg.QBFTMessage.Height, c.OperatorSigner)
+		i := instance.NewInstance(c.GetConfig(), c.CommitteeMember, c.Identifier, msg.QBFTMessage.Height, c.OperatorSigner)
 		i.State.Round = msg.QBFTMessage.Round
 		i.State.Decided = true
 		i.State.DecidedValue = msg.SignedMessage.FullData

--- a/protocol/v2/qbft/spectest/controller_type.go
+++ b/protocol/v2/qbft/spectest/controller_type.go
@@ -57,9 +57,7 @@ func RunControllerSpecTest(t *testing.T, test *spectests.ControllerSpecTest) {
 }
 
 func generateController(logger *zap.Logger) *controller.Controller {
-	identifier := func() []byte {
-		return []byte{1, 2, 3, 4}
-	}
+	identifier := []byte{1, 2, 3, 4}
 	config := qbfttesting.TestingConfig(logger, spectestingutils.Testing4SharesSet(), convert.RoleCommittee)
 	return qbfttesting.NewTestingQBFTController(
 		spectestingutils.Testing4SharesSet(),
@@ -111,7 +109,7 @@ func testProcessMsg(
 func testBroadcastedDecided(
 	t *testing.T,
 	config *qbft.Config,
-	identifier func() []byte,
+	identifier []byte,
 	runData *spectests.RunInstanceData,
 	committee []*spectypes.Operator,
 ) {
@@ -125,7 +123,7 @@ func testBroadcastedDecided(
 
 			// a hack for testing non standard messageID identifiers since we copy them into a MessageID this fixes it
 			msgID := spectypes.MessageID{}
-			copy(msgID[:], identifier())
+			copy(msgID[:], identifier)
 
 			if !bytes.Equal(msgID[:], msg.SSVMessage.MsgID[:]) {
 				continue

--- a/protocol/v2/qbft/testing/utils.go
+++ b/protocol/v2/qbft/testing/utils.go
@@ -67,7 +67,7 @@ var baseInstance = func(share *types.CommitteeMember, keySet *testingutils.TestK
 
 func NewTestingQBFTController(
 	keySet *testingutils.TestKeySet,
-	identifier func() []byte,
+	identifier []byte,
 	share *types.CommitteeMember,
 	config qbft.IConfig,
 	fullNode bool,

--- a/protocol/v2/ssv/spectest/ssv_mapping_test.go
+++ b/protocol/v2/ssv/spectest/ssv_mapping_test.go
@@ -418,7 +418,7 @@ func fixInstanceForRun(t *testing.T, ks *spectestingutils.TestKeySet, inst *inst
 	newInst := instance.NewInstance(
 		contr.GetConfig(),
 		share,
-		contr.Identifier(),
+		contr.Identifier,
 		contr.Height,
 		signer,
 	)

--- a/protocol/v2/ssv/testing/runner.go
+++ b/protocol/v2/ssv/testing/runner.go
@@ -62,10 +62,8 @@ var baseRunner = func(
 	keySet *spectestingutils.TestKeySet,
 ) runner.Runner {
 	share := spectestingutils.TestingShare(keySet, spectestingutils.TestingValidatorIndex)
-	identifier := func() []byte {
-		messageID := spectypes.NewMsgID(spectypes.JatoTestnet, spectestingutils.TestingValidatorPubKey[:], role)
-		return messageID[:]
-	}
+	identifier := spectypes.NewMsgID(spectypes.JatoTestnet, spectestingutils.TestingValidatorPubKey[:], role)
+
 	net := spectestingutils.NewTestingNetwork(1, keySet.OperatorKeys[1])
 	km := spectestingutils.NewTestingKeyManager()
 	operator := spectestingutils.TestingCommitteeMember(keySet)
@@ -100,7 +98,7 @@ var baseRunner = func(
 
 	contr := testing.NewTestingQBFTController(
 		spectestingutils.Testing4SharesSet(),
-		identifier,
+		identifier[:],
 		operator,
 		config,
 		false,
@@ -295,10 +293,7 @@ var baseRunnerWithShareMap = func(
 		ownerID = spectestingutils.TestingValidatorPubKey[:]
 	}
 
-	identifier := func() []byte {
-		messageID := spectypes.NewMsgID(spectestingutils.TestingSSVDomainType, ownerID, role)
-		return messageID[:]
-	}
+	identifier := spectypes.NewMsgID(spectestingutils.TestingSSVDomainType, ownerID, role)
 
 	net := spectestingutils.NewTestingNetwork(1, keySetInstance.OperatorKeys[1])
 
@@ -334,7 +329,7 @@ var baseRunnerWithShareMap = func(
 
 	contr := testing.NewTestingQBFTController(
 		spectestingutils.Testing4SharesSet(),
-		identifier,
+		identifier[:],
 		committeeMember,
 		config,
 		false,

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -59,10 +59,7 @@ func NewCommitteeObserver(identifier convert.MessageID, opts CommitteeObserverOp
 
 	// TODO: does the specific operator matters?
 
-	identifierFunc := func() []byte {
-		return identifier[:]
-	}
-	ctrl := qbftcontroller.NewController(identifierFunc, opts.Operator, config, opts.OperatorSigner, opts.FullNode)
+	ctrl := qbftcontroller.NewController(identifier[:], opts.Operator, config, opts.OperatorSigner, opts.FullNode)
 	ctrl.StoredInstances = make(qbftcontroller.InstanceContainer, 0, nonCommitteeInstanceContainerCapacity(opts.FullNode))
 	if _, err := ctrl.LoadHighestInstance(identifier[:]); err != nil {
 		opts.Logger.Debug("❗ failed to load highest instance", zap.Error(err))


### PR DESCRIPTION
### Description

We realized that initializing `Identifier` for post-fork runners with `DomainType()` function creates it once and keeps using the pre-fork domain, resulting in msg validation filtering the messages post-fork and the runners not getting the msg.

@guym-blox's solution was to create a func that creates the identifier on demand each time its called hence the `DomainType` will return the new domain after the fork. 

### Changes

Since we know in advance which runners will use which domaintype (genesis always use genesis and alan will always use alan). we can pre-set the domain and create the identifier just once instead of using a function that will be called many times.