### PR TITLE
Fix EventHandler flaky tests 

### DIFF
--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -21,9 +21,8 @@ import (
 	"github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest"
 
 	"github.com/ssvlabs/ssv/ekm"
 	"github.com/ssvlabs/ssv/eth/contract"
@@ -56,7 +55,8 @@ var (
 )
 
 func TestHandleBlockEventsStream(t *testing.T) {
-	logger := zaptest.NewLogger(t)
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/eth/executionclient/execution_client_test.go
+++ b/eth/executionclient/execution_client_test.go
@@ -17,6 +17,7 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/ssvlabs/ssv/eth/simulator"
@@ -127,7 +128,8 @@ func TestFetchHistoricalLogs(t *testing.T) {
 }
 
 func TestStreamLogs(t *testing.T) {
-	logger := zaptest.NewLogger(t)
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
 	const testTimeout = 2 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
@@ -412,7 +414,8 @@ func TestChainReorganizationLogs(t *testing.T) {
 
 // TestSimSSV deploys the simplified SSVNetwork contract to generate events and receive at the client
 func TestSimSSV(t *testing.T) {
-	logger := zaptest.NewLogger(t)
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
 	const testTimeout = 1 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()


### PR DESCRIPTION
## Description

Passing *testing.T to logger in `eventhandler` tests is a problem, due we have goroutines spawned inside the tested main logic which use the same logger instance even after the test is finished.

Let's use `zap.NewDevelopment()` instead of `zaptest.NewLogger(t)` at least for tests where we call `StreamLogs()` to prevent flaky panics and data races in unit tests. 

Closes https://github.com/ssvlabs/ssv/issues/1585