### PR TITLE
logs: (alan) add dutyID to msg validation ignore/rejects

### DIFF
--- a/logging/fields/fields.go
+++ b/logging/fields/fields.go
@@ -352,27 +352,23 @@ func FeeRecipient(pubKey []byte) zap.Field {
 	return zap.Stringer(FieldFeeRecipient, stringer.HexStringer{Val: pubKey})
 }
 
-func FormatDutyID(epoch phase0.Epoch, duty *spectypes.ValidatorDuty) string {
-	return fmt.Sprintf("%v-e%v-s%v-v%v", duty.Type.String(), epoch, duty.Slot, duty.ValidatorIndex)
+func FormatDutyID(epoch phase0.Epoch, slot phase0.Slot, role spectypes.RunnerRole, index phase0.ValidatorIndex) string {
+	return fmt.Sprintf("%v-e%v-s%v-v%v", role.String(), epoch, slot, index)
 }
 
-func GenesisFormatDutyID(epoch phase0.Epoch, duty *genesisspectypes.Duty) string {
-	return fmt.Sprintf("%v-e%v-s%v-v%v", duty.Type.String(), epoch, duty.Slot, duty.ValidatorIndex)
+func GenesisFormatDutyID(epoch phase0.Epoch, slot phase0.Slot, role genesisspectypes.BeaconRole, index phase0.ValidatorIndex) string {
+	return fmt.Sprintf("%v-e%v-s%v-v%v", role.String(), epoch, slot, index)
 }
 
-func FormatGenesisDutyID(epoch phase0.Epoch, duty *genesisspectypes.Duty) string {
-	return fmt.Sprintf("%v-e%v-s%v-v%v", duty.Type.String(), epoch, duty.Slot, duty.ValidatorIndex)
-}
-
-func FormatCommittee(operators []*spectypes.Operator) string {
+func FormatCommittee(operators []spectypes.OperatorID) string {
 	var opids []string
 	for _, op := range operators {
-		opids = append(opids, fmt.Sprint(op.OperatorID))
+		opids = append(opids, fmt.Sprint(op))
 	}
 	return strings.Join(opids, "_")
 }
 
-func FormatCommitteeDutyID(operators []*spectypes.Operator, epoch phase0.Epoch, slot phase0.Slot) string {
+func FormatCommitteeDutyID(operators []spectypes.OperatorID, epoch phase0.Epoch, slot phase0.Slot) string {
 	return fmt.Sprintf("COMMITTEE-%s-e%d-s%d", FormatCommittee(operators), epoch, slot)
 }
 
@@ -382,7 +378,7 @@ func Duties(epoch phase0.Epoch, duties []*spectypes.ValidatorDuty) zap.Field {
 		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString(FormatDutyID(epoch, duty))
+		b.WriteString(FormatDutyID(epoch, duty.Slot, duty.RunnerRole(), duty.ValidatorIndex))
 	}
 	return zap.String(FieldDuties, b.String())
 }

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -126,6 +126,11 @@ func (mv *messageValidator) handleValidationError(peerID peer.ID, decodedMessage
 		With(loggerFields.AsZapFields()...).
 		With(fields.PeerID(peerID))
 
+	// Only on debug level is enabled to avoid  unnecessary calls to ValidatorStore.
+	if logger.Level() == zap.DebugLevel {
+		mv.addDutyIDField(loggerFields)
+	}
+
 	var valErr Error
 	if !errors.As(err, &valErr) {
 		mv.metrics.MessageIgnored(err.Error(), loggerFields.Role, loggerFields.Consensus.Round)

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -126,11 +126,6 @@ func (mv *messageValidator) handleValidationError(peerID peer.ID, decodedMessage
 		With(loggerFields.AsZapFields()...).
 		With(fields.PeerID(peerID))
 
-	// Only on debug level is enabled to avoid  unnecessary calls to ValidatorStore.
-	if logger.Level() == zap.DebugLevel {
-		mv.addDutyIDField(loggerFields)
-	}
-
 	var valErr Error
 	if !errors.As(err, &valErr) {
 		mv.metrics.MessageIgnored(err.Error(), loggerFields.Role, loggerFields.Consensus.Round)

--- a/message/validation/logger_fields.go
+++ b/message/validation/logger_fields.go
@@ -95,15 +95,6 @@ func (mv *messageValidator) addDutyIDField(lf *LoggerFields) {
 	lf.DutyID = dutyId
 }
 
-func (mv *messageValidator) addGenesisDutyIDField(lf *GenesisLoggerFields) {
-	var dutyId string
-	msgid := genesisspectypes.MessageIDFromBytes(lf.DutyExecutorID)
-	idx := mv.validatorStore.Validator(msgid.GetPubKey()).ValidatorIndex
-	dutyId = fields.GenesisFormatDutyID(mv.netCfg.Beacon.EstimatedEpochAtSlot(lf.Slot), lf.Slot, lf.Role, idx)
-
-	lf.DutyID = dutyId
-}
-
 // LoggerFields provides details about a message. It's used for logging and metrics.
 type GenesisLoggerFields struct {
 	DutyExecutorID []byte
@@ -111,7 +102,6 @@ type GenesisLoggerFields struct {
 	SSVMessageType genesisspectypes.MsgType
 	Slot           phase0.Slot
 	Consensus      *ConsensusFields
-	DutyID         string
 }
 
 // AsZapFields returns zap logging fields for the descriptor.

--- a/message/validation/logger_fields.go
+++ b/message/validation/logger_fields.go
@@ -65,6 +65,10 @@ func (mv *messageValidator) buildLoggerFields(decodedMessage *queue.SSVMessage) 
 	descriptor.Role = decodedMessage.GetID().GetRoleType()
 	descriptor.SSVMessageType = decodedMessage.GetType()
 
+	if mv.logger.Level() == zap.DebugLevel {
+		mv.addDutyIDField(descriptor)
+	}
+
 	switch m := decodedMessage.Body.(type) {
 	case *specqbft.Message:
 		if m != nil {
@@ -85,7 +89,7 @@ func (mv *messageValidator) addDutyIDField(lf *LoggerFields) {
 	var dutyId string
 	// make dutyid
 	if lf.Role == spectypes.RoleCommittee {
-		c := mv.validatorStore.Committee(spectypes.CommitteeID(lf.DutyExecutorID))
+		c := mv.validatorStore.Committee(spectypes.CommitteeID(lf.DutyExecutorID[16:]))
 		dutyId = fields.FormatCommitteeDutyID(c.Operators, mv.netCfg.Beacon.EstimatedEpochAtSlot(lf.Slot), lf.Slot)
 	} else {
 		// get the validator index from the msgid

--- a/message/validation/logger_fields.go
+++ b/message/validation/logger_fields.go
@@ -1,11 +1,10 @@
 package validation
 
 import (
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	genesisspectypes "github.com/ssvlabs/ssv-spec-pre-cc/types"
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
-
-	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -27,6 +26,7 @@ type LoggerFields struct {
 	SSVMessageType spectypes.MsgType
 	Slot           phase0.Slot
 	Consensus      *ConsensusFields
+	DutyID         string
 }
 
 // AsZapFields returns zap logging fields for the descriptor.
@@ -36,6 +36,10 @@ func (d LoggerFields) AsZapFields() []zapcore.Field {
 		fields.Role(d.Role),
 		zap.String("ssv_message_type", ssvmessage.MsgTypeToString(d.SSVMessageType)),
 		fields.Slot(d.Slot),
+	}
+
+	if d.DutyID != "" {
+		result = append(result, fields.DutyID(d.DutyID))
 	}
 
 	if d.Consensus != nil {
@@ -77,6 +81,29 @@ func (mv *messageValidator) buildLoggerFields(decodedMessage *queue.SSVMessage) 
 	return descriptor
 }
 
+func (mv *messageValidator) addDutyIDField(lf *LoggerFields) {
+	var dutyId string
+	// make dutyid
+	if lf.Role == spectypes.RoleCommittee {
+		c := mv.validatorStore.Committee(spectypes.CommitteeID(lf.DutyExecutorID))
+		dutyId = fields.FormatCommitteeDutyID(c.Operators, mv.netCfg.Beacon.EstimatedEpochAtSlot(lf.Slot), lf.Slot)
+	} else {
+		// get the validator index from the msgid
+		idx := mv.validatorStore.Validator(lf.DutyExecutorID).ValidatorIndex
+		dutyId = fields.FormatDutyID(mv.netCfg.Beacon.EstimatedEpochAtSlot(lf.Slot), lf.Slot, lf.Role, idx)
+	}
+	lf.DutyID = dutyId
+}
+
+func (mv *messageValidator) addGenesisDutyIDField(lf *GenesisLoggerFields) {
+	var dutyId string
+	msgid := genesisspectypes.MessageIDFromBytes(lf.DutyExecutorID)
+	idx := mv.validatorStore.Validator(msgid.GetPubKey()).ValidatorIndex
+	dutyId = fields.GenesisFormatDutyID(mv.netCfg.Beacon.EstimatedEpochAtSlot(lf.Slot), lf.Slot, lf.Role, idx)
+
+	lf.DutyID = dutyId
+}
+
 // LoggerFields provides details about a message. It's used for logging and metrics.
 type GenesisLoggerFields struct {
 	DutyExecutorID []byte
@@ -84,6 +111,7 @@ type GenesisLoggerFields struct {
 	SSVMessageType genesisspectypes.MsgType
 	Slot           phase0.Slot
 	Consensus      *ConsensusFields
+	DutyID         string
 }
 
 // AsZapFields returns zap logging fields for the descriptor.

--- a/message/validation/logger_fields.go
+++ b/message/validation/logger_fields.go
@@ -86,17 +86,18 @@ func (mv *messageValidator) buildLoggerFields(decodedMessage *queue.SSVMessage) 
 }
 
 func (mv *messageValidator) addDutyIDField(lf *LoggerFields) {
-	var dutyId string
-	// make dutyid
 	if lf.Role == spectypes.RoleCommittee {
 		c := mv.validatorStore.Committee(spectypes.CommitteeID(lf.DutyExecutorID[16:]))
-		dutyId = fields.FormatCommitteeDutyID(c.Operators, mv.netCfg.Beacon.EstimatedEpochAtSlot(lf.Slot), lf.Slot)
+		if c != nil {
+			lf.DutyID = fields.FormatCommitteeDutyID(c.Operators, mv.netCfg.Beacon.EstimatedEpochAtSlot(lf.Slot), lf.Slot)
+		}
 	} else {
 		// get the validator index from the msgid
-		idx := mv.validatorStore.Validator(lf.DutyExecutorID).ValidatorIndex
-		dutyId = fields.FormatDutyID(mv.netCfg.Beacon.EstimatedEpochAtSlot(lf.Slot), lf.Slot, lf.Role, idx)
+		v := mv.validatorStore.Validator(lf.DutyExecutorID)
+		if v != nil {
+			lf.DutyID = fields.FormatDutyID(mv.netCfg.Beacon.EstimatedEpochAtSlot(lf.Slot), lf.Slot, lf.Role, v.ValidatorIndex)
+		}
 	}
-	lf.DutyID = dutyId
 }
 
 // LoggerFields provides details about a message. It's used for logging and metrics.

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -969,8 +969,10 @@ func (c *controller) onShareInit(share *ssvtypes.SSVShare) (*validators.Validato
 		opts.SSVShare = share
 		opts.Operator = operator
 
+		committeeOpIDs := types.OperatorIDsFromOperators(operator.Committee)
+
 		logger := c.logger.With([]zap.Field{
-			zap.String("committee", fields.FormatCommittee(operator.Committee)),
+			zap.String("committee", fields.FormatCommittee(committeeOpIDs)),
 			zap.String("committee_id", hex.EncodeToString(operator.CommitteeID[:])),
 		}...)
 

--- a/protocol/genesis/ssv/validator/validator.go
+++ b/protocol/genesis/ssv/validator/validator.go
@@ -98,7 +98,7 @@ func (v *Validator) StartDuty(logger *zap.Logger, duty *genesisspectypes.Duty) e
 
 	// Log with duty ID.
 	baseRunner := dutyRunner.GetBaseRunner()
-	v.dutyIDs.Set(duty.Type, fields.GenesisFormatDutyID(baseRunner.BeaconNetwork.EstimatedEpochAtSlot(duty.Slot), duty))
+	v.dutyIDs.Set(duty.Type, fields.GenesisFormatDutyID(baseRunner.BeaconNetwork.EstimatedEpochAtSlot(duty.Slot), duty.Slot, duty.Type, duty.ValidatorIndex))
 	logger = trySetDutyID(logger, v.dutyIDs, duty.Type)
 
 	// Log with height.

--- a/protocol/v2/ssv/validator/committee.go
+++ b/protocol/v2/ssv/validator/committee.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/ssvlabs/ssv/protocol/v2/types"
 	"sync"
 	"time"
 
@@ -210,7 +211,7 @@ func (c *Committee) StartDuty(logger *zap.Logger, duty *spectypes.CommitteeDuty)
 func (c *Committee) stopValidator(logger *zap.Logger, validator spectypes.ValidatorPK) {
 	for slot, runner := range c.Runners {
 		logger.Debug("trying to stop duty for validator",
-			fields.DutyID(fields.FormatCommitteeDutyID(c.Operator.Committee, c.BeaconNetwork.EstimatedEpochAtSlot(slot), slot)),
+			fields.DutyID(fields.FormatCommitteeDutyID(types.OperatorIDsFromOperators(c.Operator.Committee), c.BeaconNetwork.EstimatedEpochAtSlot(slot), slot)),
 			zap.Uint64("slot", uint64(slot)), zap.String("validator", hex.EncodeToString(validator[:])),
 		)
 		runner.StopDuty(validator)

--- a/protocol/v2/ssv/validator/committee.go
+++ b/protocol/v2/ssv/validator/committee.go
@@ -3,7 +3,6 @@ package validator
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -216,7 +215,7 @@ func (c *Committee) stopValidator(logger *zap.Logger, validator spectypes.Valida
 
 		logger.Debug("trying to stop duty for validator",
 			fields.DutyID(committeeDutyID),
-			fields.Slot(slot), zap.String("validator", hex.EncodeToString(validator[:])),
+			fields.Slot(slot), fields.Validator(validator[:]),
 		)
 		runner.StopDuty(validator)
 	}

--- a/protocol/v2/ssv/validator/committee.go
+++ b/protocol/v2/ssv/validator/committee.go
@@ -210,9 +210,13 @@ func (c *Committee) StartDuty(logger *zap.Logger, duty *spectypes.CommitteeDuty)
 // NOT threadsafe
 func (c *Committee) stopValidator(logger *zap.Logger, validator spectypes.ValidatorPK) {
 	for slot, runner := range c.Runners {
+		opIds := types.OperatorIDsFromOperators(c.Operator.Committee)
+		epoch := c.BeaconNetwork.EstimatedEpochAtSlot(slot)
+		committeeDutyID := fields.FormatCommitteeDutyID(opIds, epoch, slot)
+
 		logger.Debug("trying to stop duty for validator",
-			fields.DutyID(fields.FormatCommitteeDutyID(types.OperatorIDsFromOperators(c.Operator.Committee), c.BeaconNetwork.EstimatedEpochAtSlot(slot), slot)),
-			zap.Uint64("slot", uint64(slot)), zap.String("validator", hex.EncodeToString(validator[:])),
+			fields.DutyID(committeeDutyID),
+			fields.Slot(slot), zap.String("validator", hex.EncodeToString(validator[:])),
 		)
 		runner.StopDuty(validator)
 	}

--- a/protocol/v2/ssv/validator/committee.go
+++ b/protocol/v2/ssv/validator/committee.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/ssvlabs/ssv/protocol/v2/types"
 	"sync"
 	"time"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/ssvlabs/ssv/protocol/v2/message"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/runner"
+	"github.com/ssvlabs/ssv/protocol/v2/types"
 )
 
 var (

--- a/protocol/v2/ssv/validator/duty_executer.go
+++ b/protocol/v2/ssv/validator/duty_executer.go
@@ -2,7 +2,6 @@ package validator
 
 import (
 	"fmt"
-
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/logging/fields"
@@ -34,7 +33,9 @@ func (c *Committee) OnExecuteDuty(logger *zap.Logger, msg *types.EventMsg) error
 		return fmt.Errorf("failed to get execute committee duty data: %w", err)
 	}
 
-	logger = logger.With(fields.DutyID(fields.FormatCommitteeDutyID(c.Operator.Committee, c.BeaconNetwork.EstimatedEpochAtSlot(executeDutyData.Duty.Slot), executeDutyData.Duty.Slot)))
+	ids := types.OperatorIDsFromOperators(c.Operator.Committee)
+
+	logger = logger.With(fields.DutyID(fields.FormatCommitteeDutyID(ids, c.BeaconNetwork.EstimatedEpochAtSlot(executeDutyData.Duty.Slot), executeDutyData.Duty.Slot)))
 
 	if err := c.StartDuty(logger, executeDutyData.Duty); err != nil {
 		return fmt.Errorf("could not start committee duty: %w", err)

--- a/protocol/v2/ssv/validator/duty_executer.go
+++ b/protocol/v2/ssv/validator/duty_executer.go
@@ -33,9 +33,10 @@ func (c *Committee) OnExecuteDuty(logger *zap.Logger, msg *types.EventMsg) error
 		return fmt.Errorf("failed to get execute committee duty data: %w", err)
 	}
 
-	ids := types.OperatorIDsFromOperators(c.Operator.Committee)
-
-	logger = logger.With(fields.DutyID(fields.FormatCommitteeDutyID(ids, c.BeaconNetwork.EstimatedEpochAtSlot(executeDutyData.Duty.Slot), executeDutyData.Duty.Slot)))
+	opIds := types.OperatorIDsFromOperators(c.Operator.Committee)
+	epoch := c.BeaconNetwork.EstimatedEpochAtSlot(executeDutyData.Duty.Slot)
+	committeeDutyID := fields.FormatCommitteeDutyID(opIds, epoch, executeDutyData.Duty.Slot)
+	logger = logger.With(fields.DutyID(committeeDutyID))
 
 	if err := c.StartDuty(logger, executeDutyData.Duty); err != nil {
 		return fmt.Errorf("could not start committee duty: %w", err)

--- a/protocol/v2/ssv/validator/validator.go
+++ b/protocol/v2/ssv/validator/validator.go
@@ -109,7 +109,7 @@ func (v *Validator) StartDuty(logger *zap.Logger, iduty spectypes.Duty) error {
 
 	// Log with duty ID.
 	baseRunner := dutyRunner.GetBaseRunner()
-	v.dutyIDs.Set(spectypes.MapDutyToRunnerRole(duty.Type), fields.FormatDutyID(baseRunner.BeaconNetwork.EstimatedEpochAtSlot(duty.Slot), duty))
+	v.dutyIDs.Set(spectypes.MapDutyToRunnerRole(duty.Type), fields.FormatDutyID(baseRunner.BeaconNetwork.EstimatedEpochAtSlot(duty.Slot), duty.Slot, duty.RunnerRole(), duty.ValidatorIndex))
 	logger = trySetDutyID(logger, v.dutyIDs, spectypes.MapDutyToRunnerRole(duty.Type))
 
 	// Log with height.

--- a/protocol/v2/types/operator.go
+++ b/protocol/v2/types/operator.go
@@ -1,0 +1,11 @@
+package types
+
+import spectypes "github.com/ssvlabs/ssv-spec/types"
+
+func OperatorIDsFromOperators(operators []*spectypes.Operator) []spectypes.OperatorID {
+	ids := make([]spectypes.OperatorID, len(operators))
+	for i, op := range operators {
+		ids[i] = op.OperatorID
+	}
+	return ids
+}


### PR DESCRIPTION
### Description

In debugging we a missed duty we use DutyID as a way to look on all logs related to this duty, we know that sometimes messages are dropped in the P2P layer but currently its not easy to connect the consensus process messages to the p2p layer logs about rejecting/ignoring messages.

### Change

This change adds a duty ID field to msg validation logs about ignores/rejects, it checks whether the logger is on debug level to do so, since to make up the duty id, a call to validatorStore is required and we want to prevent it if not necessary. 