### PR TITLE
fix: (queue) nil return condition in Pop

### DIFF
--- a/protocol/genesis/ssv/genesisqueue/queue.go
+++ b/protocol/genesis/ssv/genesisqueue/queue.go
@@ -157,11 +157,14 @@ func (q *priorityQueue) pop(prioritizer MessagePrioritizer, filter Filter) *Gene
 	// Remove the highest priority message and return it.
 	var (
 		prior   *item
-		highest = q.head
+		highest *item
 		current = q.head
 	)
+	if filter(current.message) {
+		highest = current
+	}
 	for {
-		if prioritizer.Prior(current.next.message, highest.message) && filter(current.next.message) {
+		if (highest == nil || prioritizer.Prior(current.next.message, highest.message)) && filter(current.next.message) {
 			highest = current.next
 			prior = current
 		}
@@ -170,15 +173,15 @@ func (q *priorityQueue) pop(prioritizer MessagePrioritizer, filter Filter) *Gene
 			break
 		}
 	}
+	if highest == nil {
+		return nil
+	}
 	if prior == nil {
 		q.head = highest.next
 	} else {
 		prior.next = highest.next
 	}
-	if filter(highest.message) {
-		return highest.message
-	}
-	return nil
+	return highest.message
 }
 
 func (q *priorityQueue) Empty() bool {

--- a/protocol/v2/ssv/queue/queue.go
+++ b/protocol/v2/ssv/queue/queue.go
@@ -157,11 +157,14 @@ func (q *priorityQueue) pop(prioritizer MessagePrioritizer, filter Filter) *SSVM
 	// Remove the highest priority message and return it.
 	var (
 		prior   *item
-		highest = q.head
+		highest *item
 		current = q.head
 	)
+	if filter(current.message) {
+		highest = current
+	}
 	for {
-		if prioritizer.Prior(current.next.message, highest.message) && filter(current.next.message) {
+		if (highest == nil || prioritizer.Prior(current.next.message, highest.message)) && filter(current.next.message) {
 			highest = current.next
 			prior = current
 		}
@@ -170,15 +173,15 @@ func (q *priorityQueue) pop(prioritizer MessagePrioritizer, filter Filter) *SSVM
 			break
 		}
 	}
+	if highest == nil {
+		return nil
+	}
 	if prior == nil {
 		q.head = highest.next
 	} else {
 		prior.next = highest.next
 	}
-	if filter(highest.message) {
-		return highest.message
-	}
-	return nil
+	return highest.message
 }
 
 func (q *priorityQueue) Empty() bool {

--- a/protocol/v2/ssv/queue/queue_test.go
+++ b/protocol/v2/ssv/queue/queue_test.go
@@ -184,6 +184,89 @@ func TestPriorityQueue_Order(t *testing.T) {
 	}
 }
 
+func TestPriorityQueue_Pop_NothingThenSomething(t *testing.T) {
+	queue := NewDefault()
+	require.True(t, queue.Empty())
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	state := &State{
+		HasRunningInstance: true,
+		Height:             1,
+		Slot:               1,
+		Round:              1,
+		Quorum:             4,
+	}
+
+	decodeAndPush(t, queue, mockConsensusMessage{Height: qbft.Height(1), Type: qbft.CommitMsgType}, state)
+	decodeAndPush(t, queue, mockConsensusMessage{Height: qbft.Height(1), Type: qbft.CommitMsgType}, state)
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, 2, queue.Len())
+	expectedMsg := decodeAndPush(t, queue, mockConsensusMessage{Height: qbft.Height(2), Type: qbft.CommitMsgType}, state)
+
+	go func() {
+		defer wg.Done()
+		matchHeight2 := func(msg *SSVMessage) bool {
+			return msg.Body.(*qbft.Message).Height == 2
+		}
+		popped := queue.Pop(context.Background(), NewMessagePrioritizer(state), matchHeight2)
+		require.Equal(t, expectedMsg, popped)
+	}()
+
+	wg.Wait()
+
+	// Ensure that the queue still contains the non-matching messages.
+	require.Equal(t, queue.Len(), 2)
+}
+
+func TestPriorityQueue_Pop_WithLoopForNonMatchingAndMatchingMessages(t *testing.T) {
+	queue := NewDefault()
+	require.True(t, queue.Empty())
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	state := &State{
+		HasRunningInstance: true,
+		Height:             1,
+		Slot:               1,
+		Round:              1,
+		Quorum:             4,
+	}
+
+	// Pop in a separate goroutine. The first two pops should get the matching messages, and the third should return nil.
+	go func() {
+		defer wg.Done()
+		popped := queue.Pop(context.Background(), NewMessagePrioritizer(state), func(msg *SSVMessage) bool {
+			_, ok := msg.Body.(*qbft.Message)
+			if !ok {
+				return true
+			}
+			return msg.Body.(*qbft.Message).MsgType != qbft.CommitMsgType
+		})
+		require.NotNil(t, popped)
+
+	}()
+
+	// Simulate delay before pushing messages.
+	time.Sleep(100 * time.Millisecond)
+
+	// Push non-matching message.
+	decodeAndPush(t, queue, mockConsensusMessage{Height: qbft.Height(1), Type: qbft.CommitMsgType}, state)
+
+	// Push one matching message.
+	decodeAndPush(t, queue, mockNonConsensusMessage{Slot: 1, Type: spectypes.PostConsensusPartialSig}, state)
+
+	// Push non-matching message.
+	decodeAndPush(t, queue, mockConsensusMessage{Height: qbft.Height(1), Type: qbft.CommitMsgType}, state)
+
+	wg.Wait()
+
+	// Ensure that the queue still contains the non-matching messages.
+	require.False(t, queue.Empty())
+}
+
 type testMetrics struct {
 	dropped atomic.Uint64
 }


### PR DESCRIPTION
There is currently bug in queue that returns nil even though queue has more msg inside.
So basic flow is:
- we receive msgA into the queue that's not matching filter
- we now receive another one msgB that's will match the filer
- after breaking from main loop in `Pop` we read msg again
- we get again non filter matching one msgC
- in `pop` if msgB is true on filter but doesn't have prio over msgC we will return nil

There is test simulating this scenario 