### PR TITLE
fix: replace `cornelk/hashmap` with `sync.Map`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/bloxapp/eth2-key-manager v1.4.1-0.20240829091006-b5848884a7a5
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/cespare/xxhash/v2 v2.3.0
-	github.com/cornelk/hashmap v1.0.8
 	github.com/dgraph-io/badger/v4 v4.2.0
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/ethereum/go-ethereum v1.13.15

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,6 @@ github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/cornelk/hashmap v1.0.8 h1:nv0AWgw02n+iDcawr5It4CjQIAcdMMKRrs10HOJYlrc=
-github.com/cornelk/hashmap v1.0.8/go.mod h1:RfZb7JO3RviW/rT6emczVuC/oxpdz4UsSB2LJSclR1k=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=

--- a/ibft/genesisstorage/stores.go
+++ b/ibft/genesisstorage/stores.go
@@ -1,7 +1,7 @@
 package genesisstorage
 
 import (
-	"github.com/cornelk/hashmap"
+	"github.com/ssvlabs/ssv/utils/hashmap"
 
 	genesisqbftstorage "github.com/ssvlabs/ssv/protocol/genesis/qbft/storage"
 	"github.com/ssvlabs/ssv/storage/basedb"

--- a/ibft/storage/stores.go
+++ b/ibft/storage/stores.go
@@ -1,7 +1,7 @@
 package storage
 
 import (
-	"github.com/cornelk/hashmap"
+	"github.com/ssvlabs/ssv/utils/hashmap"
 
 	"github.com/ssvlabs/ssv/exporter/convert"
 	qbftstorage "github.com/ssvlabs/ssv/protocol/v2/qbft/storage"

--- a/message/validation/genesis/consensus_state.go
+++ b/message/validation/genesis/consensus_state.go
@@ -2,8 +2,9 @@ package validation
 
 import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/cornelk/hashmap"
 	spectypes "github.com/ssvlabs/ssv-spec-pre-cc/types"
+
+	"github.com/ssvlabs/ssv/utils/hashmap"
 )
 
 // ConsensusID uniquely identifies a public key and role pair to keep track of state.

--- a/message/validation/genesis/validation.go
+++ b/message/validation/genesis/validation.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/cornelk/hashmap"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
@@ -25,6 +24,8 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/ssvlabs/ssv/utils/hashmap"
+
 	"github.com/ssvlabs/ssv/logging/fields"
 	"github.com/ssvlabs/ssv/monitoring/metricsreporter"
 	"github.com/ssvlabs/ssv/network/commons"
@@ -32,7 +33,7 @@ import (
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"
 	"github.com/ssvlabs/ssv/operator/keys"
 	operatorstorage "github.com/ssvlabs/ssv/operator/storage"
-	genesisqueue "github.com/ssvlabs/ssv/protocol/genesis/ssv/genesisqueue"
+	"github.com/ssvlabs/ssv/protocol/genesis/ssv/genesisqueue"
 	ssvmessage "github.com/ssvlabs/ssv/protocol/v2/message"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 )

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -10,7 +10,6 @@ import (
 
 	ma "github.com/multiformats/go-multiaddr"
 
-	"github.com/cornelk/hashmap"
 	"github.com/libp2p/go-libp2p/core/connmgr"
 	connmgrcore "github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -18,7 +17,10 @@ import (
 	libp2pdiscbackoff "github.com/libp2p/go-libp2p/p2p/discovery/backoff"
 	"go.uber.org/zap"
 
+	"github.com/ssvlabs/ssv/utils/hashmap"
+
 	spectypes "github.com/ssvlabs/ssv-spec/types"
+
 	"github.com/ssvlabs/ssv/logging"
 	"github.com/ssvlabs/ssv/logging/fields"
 	"github.com/ssvlabs/ssv/message/validation"

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -141,7 +141,7 @@ func (n *p2pNetwork) Subscribe(pk spectypes.ValidatorPK) error {
 // subscribeCommittee handles the subscription logic for committee subnets
 func (n *p2pNetwork) subscribeCommittee(cid spectypes.CommitteeID) error {
 	n.interfaceLogger.Debug("subscribing to committee", fields.CommitteeID(cid))
-	status, found := n.activeCommittees.GetOrInsert(string(cid[:]), validatorStatusSubscribing)
+	status, found := n.activeCommittees.GetOrSet(string(cid[:]), validatorStatusSubscribing)
 	if found && status != validatorStatusInactive {
 		return nil
 	}
@@ -159,7 +159,7 @@ func (n *p2pNetwork) subscribeCommittee(cid spectypes.CommitteeID) error {
 func (n *p2pNetwork) subscribeValidator(pk spectypes.ValidatorPK) error {
 	pkHex := hex.EncodeToString(pk[:])
 	n.interfaceLogger.Debug("subscribing to validator", zap.String("validator", pkHex))
-	status, found := n.activeValidators.GetOrInsert(pkHex, validatorStatusSubscribing)
+	status, found := n.activeValidators.GetOrSet(pkHex, validatorStatusSubscribing)
 	if found && status != validatorStatusInactive {
 		return nil
 	}
@@ -196,7 +196,7 @@ func (n *p2pNetwork) Unsubscribe(logger *zap.Logger, pk spectypes.ValidatorPK) e
 		if status, _ := n.activeValidators.Get(pkHex); status != validatorStatusSubscribed {
 			return nil
 		}
-		n.activeValidators.Del(pkHex)
+		n.activeValidators.Delete(pkHex)
 	}
 
 	cmtid := n.nodeStorage.ValidatorStore().Validator(pk[:]).CommitteeID()
@@ -206,7 +206,7 @@ func (n *p2pNetwork) Unsubscribe(logger *zap.Logger, pk spectypes.ValidatorPK) e
 			return err
 		}
 	}
-	n.activeCommittees.Del(string(cmtid[:]))
+	n.activeCommittees.Delete(string(cmtid[:]))
 	return nil
 }
 

--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -361,7 +361,7 @@ func CreateVirtualNet(
 			}
 
 			node.PeerScores.Range(func(index NodeIndex, snapshot *pubsub.PeerScoreSnapshot) bool {
-				node.PeerScores.Del(index)
+				node.PeerScores.Delete(index)
 				return true
 			})
 			for peerID, peerScore := range peerMap {

--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aquasecurity/table"
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/cornelk/hashmap"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/sourcegraph/conc/pool"
@@ -25,6 +24,8 @@ import (
 	spectestingutils "github.com/ssvlabs/ssv-spec/types/testingutils"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
+
+	"github.com/ssvlabs/ssv/utils/hashmap"
 
 	"github.com/ssvlabs/ssv/message/validation"
 	beaconprotocol "github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"

--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -360,14 +360,10 @@ func CreateVirtualNet(
 				return
 			}
 
-			var idsToDelete []NodeIndex
 			node.PeerScores.Range(func(index NodeIndex, snapshot *pubsub.PeerScoreSnapshot) bool {
-				idsToDelete = append(idsToDelete, index)
+				node.PeerScores.Del(index)
 				return true
 			})
-			for _, id := range idsToDelete {
-				node.PeerScores.Del(id)
-			}
 			for peerID, peerScore := range peerMap {
 				peerNode := vn.NodeByPeerID(peerID)
 				if peerNode == nil {

--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -360,10 +360,14 @@ func CreateVirtualNet(
 				return
 			}
 
+			var idsToDelete []NodeIndex
 			node.PeerScores.Range(func(index NodeIndex, snapshot *pubsub.PeerScoreSnapshot) bool {
-				node.PeerScores.Del(index)
+				idsToDelete = append(idsToDelete, index)
 				return true
 			})
+			for _, id := range idsToDelete {
+				node.PeerScores.Del(id)
+			}
 			for peerID, peerScore := range peerMap {
 				peerNode := vn.NodeByPeerID(peerID)
 				if peerNode == nil {

--- a/network/topics/sub_filter.go
+++ b/network/topics/sub_filter.go
@@ -1,11 +1,12 @@
 package topics
 
 import (
-	"github.com/cornelk/hashmap"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	ps_pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/utils/hashmap"
 
 	"github.com/ssvlabs/ssv/network/commons"
 )

--- a/network/topics/sub_filter.go
+++ b/network/topics/sub_filter.go
@@ -97,7 +97,7 @@ func (wl *dynamicWhitelist) Register(name string) {
 
 // Deregister removes the given topic from the whitelist
 func (wl *dynamicWhitelist) Deregister(name string) {
-	wl.whitelist.Del(name)
+	wl.whitelist.Delete(name)
 }
 
 // Whitelisted checks if the given name was whitelisted

--- a/operator/duties/attester_genesis_test.go
+++ b/operator/duties/attester_genesis_test.go
@@ -7,11 +7,12 @@ import (
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/cornelk/hashmap"
 	genesisspectypes "github.com/ssvlabs/ssv-spec-pre-cc/types"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	"github.com/ssvlabs/ssv/utils/hashmap"
 
 	"github.com/ssvlabs/ssv/beacon/goclient"
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"

--- a/operator/duties/attester_test.go
+++ b/operator/duties/attester_test.go
@@ -7,10 +7,11 @@ import (
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/cornelk/hashmap"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	"github.com/ssvlabs/ssv/utils/hashmap"
 
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"
 	"github.com/ssvlabs/ssv/protocol/v2/types"

--- a/operator/duties/committee_test.go
+++ b/operator/duties/committee_test.go
@@ -794,7 +794,7 @@ func TestScheduler_Committee_Reorg_Previous_Epoch_Transition_Indices_Changed_Att
 	// STEP 5: trigger indices change
 	scheduler.indicesChg <- struct{}{}
 	waitForNoActionCommittee(t, logger, fetchDutiesCall, executeDutiesCall, timeout)
-	attDuties.Del(phase0.Epoch(2))
+	attDuties.Delete(phase0.Epoch(2))
 
 	// STEP 6: wait for attester duties to be fetched again for the current epoch
 	currentSlot.Set(phase0.Slot(65))

--- a/operator/duties/committee_test.go
+++ b/operator/duties/committee_test.go
@@ -7,10 +7,11 @@ import (
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/cornelk/hashmap"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	"github.com/ssvlabs/ssv/utils/hashmap"
 
 	"github.com/ssvlabs/ssv/operator/duties/dutystore"
 	mocknetwork "github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon/mocks"

--- a/operator/duties/proposer_genesis_test.go
+++ b/operator/duties/proposer_genesis_test.go
@@ -6,10 +6,11 @@ import (
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/cornelk/hashmap"
 	genesisspectypes "github.com/ssvlabs/ssv-spec-pre-cc/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	"github.com/ssvlabs/ssv/utils/hashmap"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 

--- a/operator/duties/proposer_test.go
+++ b/operator/duties/proposer_test.go
@@ -6,9 +6,10 @@ import (
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/cornelk/hashmap"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	"github.com/ssvlabs/ssv/utils/hashmap"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 

--- a/operator/duties/sync_committee_genesis_test.go
+++ b/operator/duties/sync_committee_genesis_test.go
@@ -7,10 +7,11 @@ import (
 
 	v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/cornelk/hashmap"
 	genesisspectypes "github.com/ssvlabs/ssv-spec-pre-cc/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	"github.com/ssvlabs/ssv/utils/hashmap"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 

--- a/operator/duties/sync_committee_test.go
+++ b/operator/duties/sync_committee_test.go
@@ -7,9 +7,10 @@ import (
 
 	v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/cornelk/hashmap"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	"github.com/ssvlabs/ssv/utils/hashmap"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 

--- a/operator/slotticker/slotticker_test.go
+++ b/operator/slotticker/slotticker_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/cornelk/hashmap/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -74,7 +73,7 @@ func TestTickerInitialization(t *testing.T) {
 	buffer := 10 * time.Millisecond
 
 	elapsed := time.Since(start)
-	assert.True(t, elapsed+buffer >= slotDuration, "First tick occurred too soon: %v", elapsed.String())
+	require.True(t, elapsed+buffer >= slotDuration, "First tick occurred too soon: %v", elapsed.String())
 	require.Equal(t, phase0.Slot(1), slot)
 }
 
@@ -110,7 +109,7 @@ func TestGenesisInFuture(t *testing.T) {
 	// Allow a small buffer (e.g., 10ms) due to code execution overhead
 	buffer := 10 * time.Millisecond
 
-	assert.True(t, actualFirstTickDuration+buffer >= expectedFirstTickDuration, "First tick occurred too soon. Expected at least: %v, but got: %v", expectedFirstTickDuration.String(), actualFirstTickDuration.String())
+	require.True(t, actualFirstTickDuration+buffer >= expectedFirstTickDuration, "First tick occurred too soon. Expected at least: %v, but got: %v", expectedFirstTickDuration.String(), actualFirstTickDuration.String())
 }
 
 func TestBoundedDrift(t *testing.T) {
@@ -129,7 +128,7 @@ func TestBoundedDrift(t *testing.T) {
 
 	// We'll allow a small buffer for drift, say 1%
 	buffer := expectedDuration * 1 / 100
-	assert.True(t, elapsed >= expectedDuration-buffer && elapsed <= expectedDuration+buffer, "Drifted too far from expected time. Expected: %v, Actual: %v", expectedDuration.String(), elapsed.String())
+	require.True(t, elapsed >= expectedDuration-buffer && elapsed <= expectedDuration+buffer, "Drifted too far from expected time. Expected: %v, Actual: %v", expectedDuration.String(), elapsed.String())
 }
 
 func TestMultipleSlotTickers(t *testing.T) {
@@ -165,7 +164,7 @@ func TestMultipleSlotTickers(t *testing.T) {
 
 	// We'll allow a small buffer for drift, say 5%
 	buffer := expectedDuration * 5 / 100
-	assert.True(t, elapsed <= expectedDuration+buffer, "Expected all tickers to complete within", expectedDuration.String(), "but took", elapsed.String())
+	require.True(t, elapsed <= expectedDuration+buffer, "Expected all tickers to complete within", expectedDuration.String(), "but took", elapsed.String())
 }
 
 func TestSlotSkipping(t *testing.T) {

--- a/protocol/genesis/ssv/validator/validator.go
+++ b/protocol/genesis/ssv/validator/validator.go
@@ -5,18 +5,19 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/cornelk/hashmap"
 	"github.com/pkg/errors"
 	genesisspecqbft "github.com/ssvlabs/ssv-spec-pre-cc/qbft"
 	genesisspectypes "github.com/ssvlabs/ssv-spec-pre-cc/types"
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 	"go.uber.org/zap"
 
+	"github.com/ssvlabs/ssv/utils/hashmap"
+
 	"github.com/ssvlabs/ssv/ibft/genesisstorage"
 	"github.com/ssvlabs/ssv/logging/fields"
 	"github.com/ssvlabs/ssv/message/validation"
 	"github.com/ssvlabs/ssv/protocol/genesis/message"
-	genesisqueue "github.com/ssvlabs/ssv/protocol/genesis/ssv/genesisqueue"
+	"github.com/ssvlabs/ssv/protocol/genesis/ssv/genesisqueue"
 	"github.com/ssvlabs/ssv/protocol/genesis/ssv/runner"
 	"github.com/ssvlabs/ssv/protocol/genesis/types"
 )

--- a/protocol/v2/ssv/validator/signature_verifier.go
+++ b/protocol/v2/ssv/validator/signature_verifier.go
@@ -2,10 +2,12 @@ package validator
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 
-	"github.com/cornelk/hashmap"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
+
+	"github.com/ssvlabs/ssv/utils/hashmap"
 
 	"github.com/ssvlabs/ssv/operator/keys"
 )

--- a/protocol/v2/ssv/validator/validator.go
+++ b/protocol/v2/ssv/validator/validator.go
@@ -6,11 +6,12 @@ import (
 	"sync"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/cornelk/hashmap"
 	"github.com/pkg/errors"
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/utils/hashmap"
 
 	"github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/logging/fields"

--- a/utils/hashmap/hashmap.go
+++ b/utils/hashmap/hashmap.go
@@ -54,6 +54,9 @@ func (m *Map[Key, Value]) Len() int {
 }
 
 func (m *Map[Key, Value]) Range(f func(Key, Value) bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	for k, v := range m.m {
 		if !f(k, v) {
 			break

--- a/utils/hashmap/hashmap.go
+++ b/utils/hashmap/hashmap.go
@@ -1,0 +1,73 @@
+package hashmap
+
+import (
+	"sync"
+)
+
+type Map[Key comparable, Value any] struct {
+	m  map[Key]Value
+	mu sync.RWMutex
+}
+
+func New[Key comparable, Value any]() *Map[Key, Value] {
+	return &Map[Key, Value]{
+		m:  make(map[Key]Value),
+		mu: sync.RWMutex{},
+	}
+}
+
+func (m *Map[Key, Value]) Get(key Key) (Value, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	v, ok := m.m[key]
+	return v, ok
+}
+
+func (m *Map[Key, Value]) GetOrInsert(key Key, value Value) (Value, bool) {
+	m.mu.RLock()
+	v, ok := m.m[key]
+	m.mu.RUnlock()
+
+	if !ok {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		m.m[key] = value
+		v = value
+	}
+	return v, ok
+}
+
+func (m *Map[Key, Value]) Set(key Key, value Value) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.m[key] = value
+}
+
+func (m *Map[Key, Value]) Len() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return len(m.m)
+}
+
+func (m *Map[Key, Value]) Range(f func(Key, Value) bool) {
+	for k, v := range m.m {
+		if !f(k, v) {
+			break
+		}
+	}
+}
+
+func (m *Map[Key, Value]) Del(key Key) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	_, found := m.m[key]
+	if found {
+		delete(m.m, key)
+	}
+	return found
+}

--- a/utils/hashmap/hashmap.go
+++ b/utils/hashmap/hashmap.go
@@ -1,9 +1,12 @@
 package hashmap
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 )
 
+// Map implements a thread-safe map with a sync.Map under the hood.
 type Map[Key comparable, Value any] struct {
 	m sync.Map
 }
@@ -21,7 +24,7 @@ func (m *Map[Key, Value]) Get(key Key) (Value, bool) {
 	return v.(Value), true
 }
 
-func (m *Map[Key, Value]) GetOrInsert(key Key, value Value) (Value, bool) {
+func (m *Map[Key, Value]) GetOrSet(key Key, value Value) (Value, bool) {
 	actual, loaded := m.m.LoadOrStore(key, value)
 	return actual.(Value), loaded
 }
@@ -45,10 +48,26 @@ func (m *Map[Key, Value]) Range(f func(Key, Value) bool) {
 	})
 }
 
-func (m *Map[Key, Value]) Del(key Key) bool {
+func (m *Map[Key, Value]) Delete(key Key) bool {
 	_, found := m.m.Load(key)
 	if found {
 		m.m.Delete(key)
 	}
 	return found
+}
+
+func (m *Map[Key, Value]) String() string {
+	var b strings.Builder
+	i := 0
+	b.WriteString("[")
+	m.m.Range(func(k, v any) bool {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(fmt.Sprintf("%v=%v", k, v))
+		i++
+		return true
+	})
+	b.WriteString("]")
+	return b.String()
 }

--- a/utils/hashmap/hashmap_test.go
+++ b/utils/hashmap/hashmap_test.go
@@ -1,0 +1,201 @@
+package hashmap
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type validatorStatus int
+
+const (
+	validatorStatusSubscribing validatorStatus = 1
+	validatorStatusSubscribed  validatorStatus = 2
+)
+
+func TestRaceCondition(t *testing.T) {
+	cmtIDsHex := []string{
+		"9576fdcd4cfd9e563a5ce54e1a2e8a2950a94d8d0db49696f37889929ad813fd",
+		"b9492d60036f93841da23f7ee49f987ace6cb7d07170b9e9aaa2be54f4fceaf7",
+		"e2394daed1f3bfc1714dea43d0aaf663a10af88ed985aed5564e3d027d961b89",
+	}
+	var cmtIDs []string
+	for _, cmtIDHex := range cmtIDsHex {
+		cmtID, err := hex.DecodeString(cmtIDHex)
+		require.NoError(t, err)
+		cmtIDs = append(cmtIDs, string(cmtID))
+	}
+
+	var wwg sync.WaitGroup
+	var errs []error
+	var mu sync.Mutex
+	for i := 0; i < 100; i++ {
+		wwg.Add(1)
+		go func() {
+			defer wwg.Done()
+
+			m := New[string, validatorStatus]()
+			var wg sync.WaitGroup
+			for _, cmtID := range cmtIDs {
+				cmtID := cmtID
+				n := 50 + rand.Intn(200)
+				for j := 0; j < n; j++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						time.Sleep(time.Duration(rand.Intn(2000)) * time.Millisecond)
+						_, found := m.GetOrInsert(cmtID, validatorStatusSubscribing)
+						if !found {
+							time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
+							m.Set(cmtID, validatorStatusSubscribed)
+						} else {
+							time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
+						}
+					}()
+				}
+			}
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				wg.Wait()
+			}()
+
+			ticker := time.NewTicker(1 * time.Millisecond)
+			var keys []string
+			defer ticker.Stop()
+		Loop:
+			for {
+				keys = []string{}
+				m.Range(func(key string, value validatorStatus) bool {
+					keys = append(keys, key)
+					return true
+				})
+				select {
+				case <-done:
+					keys = []string{}
+					m.Range(func(key string, value validatorStatus) bool {
+						keys = append(keys, key)
+						return true
+					})
+					keysHex := []string{}
+					for _, key := range keys {
+						keysHex = append(keysHex, hex.EncodeToString([]byte(key)))
+					}
+					t.Logf("iteration %d: %d keys, %d expected", i, len(keys), len(cmtIDs))
+					if len(keys) != len(cmtIDs) {
+						t.Logf("expected %d keys, got %d (%v)", len(cmtIDs), len(keys), keysHex)
+						mu.Lock()
+						errs = append(errs, fmt.Errorf("expected %d keys, got %d (%v)", len(cmtIDs), len(keys), keysHex))
+						mu.Unlock()
+					}
+					break Loop
+				case <-ticker.C:
+				}
+			}
+		}()
+	}
+	wwg.Wait()
+	require.Empty(t, errs)
+}
+
+func TestRaceConditionGoMap(t *testing.T) {
+	cmtIDsHex := []string{
+		"9576fdcd4cfd9e563a5ce54e1a2e8a2950a94d8d0db49696f37889929ad813fd",
+		"b9492d60036f93841da23f7ee49f987ace6cb7d07170b9e9aaa2be54f4fceaf7",
+		"e2394daed1f3bfc1714dea43d0aaf663a10af88ed985aed5564e3d027d961b89",
+	}
+	var cmtIDs []string
+	for _, cmtIDHex := range cmtIDsHex {
+		cmtID, err := hex.DecodeString(cmtIDHex)
+		require.NoError(t, err)
+		cmtIDs = append(cmtIDs, string(cmtID))
+	}
+
+	var wwg sync.WaitGroup
+	var errs []error
+	var mu sync.Mutex
+	for i := 0; i < 100; i++ {
+		wwg.Add(1)
+		go func() {
+			defer wwg.Done()
+
+			m := make(map[string]validatorStatus)
+			var mtx sync.Mutex
+			var wg sync.WaitGroup
+			for _, cmtID := range cmtIDs {
+				cmtID := cmtID
+				n := 50 + rand.Intn(200)
+				for j := 0; j < n; j++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						time.Sleep(time.Duration(rand.Intn(2000)) * time.Millisecond)
+						mtx.Lock()
+						_, found := m[cmtID]
+						if !found {
+							m[cmtID] = validatorStatusSubscribing
+						}
+						mtx.Unlock()
+						if !found {
+							time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
+							mtx.Lock()
+							m[cmtID] = validatorStatusSubscribed
+							mtx.Unlock()
+						} else {
+							time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
+						}
+					}()
+				}
+			}
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				wg.Wait()
+			}()
+
+			ticker := time.NewTicker(1 * time.Millisecond)
+			var keys []string
+			defer ticker.Stop()
+		Loop:
+			for {
+				keys = []string{}
+				mtx.Lock()
+				for key := range m {
+					keys = append(keys, key)
+				}
+				mtx.Unlock()
+				select {
+				case <-done:
+					keys = []string{}
+					mtx.Lock()
+					for key := range m {
+						keys = append(keys, key)
+					}
+					mtx.Unlock()
+					keysHex := []string{}
+					for _, key := range keys {
+						keysHex = append(keysHex, hex.EncodeToString([]byte(key)))
+					}
+					t.Logf("iteration %d: %d keys, %d expected", i, len(keys), len(cmtIDs))
+					if len(keys) != len(cmtIDs) {
+						t.Logf("expected %d keys, got %d (%v)", len(cmtIDs), len(keys), keysHex)
+						mu.Lock()
+						errs = append(errs, fmt.Errorf("expected %d keys, got %d (%v)", len(cmtIDs), len(keys), keysHex))
+						mu.Unlock()
+					}
+					break Loop
+				case <-ticker.C:
+				}
+			}
+		}()
+	}
+	wwg.Wait()
+	require.Empty(t, errs)
+}

--- a/utils/hashmap/hashmap_test.go
+++ b/utils/hashmap/hashmap_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Credit: most of the tests here are borrowed from the hashmap package.
+// https://github.com/cornelk/hashmap/blob/28d6fb92c67132d1bf08a5e07c81fdc5855bb460/hashmap_test.go
+
 func TestNew(t *testing.T) {
 	t.Parallel()
 	m := New[uintptr, uintptr]()

--- a/utils/hashmap/hashmap_test.go
+++ b/utils/hashmap/hashmap_test.go
@@ -355,15 +355,13 @@ func TestConcurrentInsertDelete(t *testing.T) {
 		wg.Add(2)
 
 		go func() {
-			rand.Seed(int64(time.Now().Nanosecond()))
-			time.Sleep(time.Duration(rand.Intn(10)))
+			time.Sleep(time.Duration(randSeed().Intn(10)))
 			l.Delete(222)
 			wg.Done()
 		}()
 		go func() {
 			defer wg.Done()
-			rand.Seed(int64(time.Now().Nanosecond()))
-			time.Sleep(time.Duration(rand.Intn(10)))
+			time.Sleep(time.Duration(randSeed().Intn(10)))
 			l.GetOrSet(223, 223)
 		}()
 		wg.Wait()
@@ -442,18 +440,18 @@ func TestIssue1682(t *testing.T) {
 			var wg sync.WaitGroup
 			for _, cmtID := range cmtIDs {
 				cmtID := cmtID
-				n := 50 + rand.Intn(200)
+				n := 50 + randSeed().Intn(200)
 				for j := 0; j < n; j++ {
 					wg.Add(1)
 					go func() {
 						defer wg.Done()
-						time.Sleep(time.Duration(rand.Intn(2000)) * time.Millisecond)
+						time.Sleep(time.Duration(randSeed().Intn(2000)) * time.Millisecond)
 						_, found := m.GetOrSet(cmtID, validatorStatusSubscribing)
 						if !found {
-							time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
+							time.Sleep(time.Duration(randSeed().Intn(200)) * time.Millisecond)
 							m.Set(cmtID, validatorStatusSubscribed)
 						} else {
-							time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
+							time.Sleep(time.Duration(randSeed().Intn(200)) * time.Millisecond)
 						}
 					}()
 				}
@@ -501,4 +499,8 @@ func TestIssue1682(t *testing.T) {
 	}
 	wwg.Wait()
 	require.Empty(t, errs)
+}
+
+func randSeed() *rand.Rand {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
 }

--- a/utils/hashmap/hashmap_test.go
+++ b/utils/hashmap/hashmap_test.go
@@ -4,21 +4,417 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type validatorStatus int
+func TestNew(t *testing.T) {
+	t.Parallel()
+	m := New[uintptr, uintptr]()
+	assert.Equal(t, 0, m.Len())
+}
 
-const (
-	validatorStatusSubscribing validatorStatus = 1
-	validatorStatusSubscribed  validatorStatus = 2
-)
+func TestSetString(t *testing.T) {
+	t.Parallel()
+	m := New[int, string]()
+	elephant := "elephant"
+	monkey := "monkey"
 
-func TestRaceCondition(t *testing.T) {
+	m.Set(1, elephant) // insert
+	value, ok := m.Get(1)
+	assert.True(t, ok)
+	assert.Equal(t, elephant, value)
+
+	m.Set(1, monkey) // overwrite
+	value, ok = m.Get(1)
+	assert.True(t, ok)
+	assert.Equal(t, monkey, value)
+
+	assert.Equal(t, 1, m.Len())
+
+	m.Set(2, elephant) // insert
+	assert.Equal(t, 2, m.Len())
+	value, ok = m.Get(2)
+	assert.True(t, ok)
+	assert.Equal(t, elephant, value)
+}
+
+func TestSetUint8(t *testing.T) {
+	t.Parallel()
+	m := New[uint8, int]()
+
+	m.Set(1, 128) // insert
+	value, ok := m.Get(1)
+	assert.True(t, ok)
+	assert.Equal(t, 128, value)
+
+	m.Set(2, 200) // insert
+	assert.Equal(t, 2, m.Len())
+	value, ok = m.Get(2)
+	assert.True(t, ok)
+	assert.Equal(t, 200, value)
+}
+
+func TestSetInt16(t *testing.T) {
+	t.Parallel()
+	m := New[int16, int]()
+
+	m.Set(1, 128) // insert
+	value, ok := m.Get(1)
+	assert.True(t, ok)
+	assert.Equal(t, 128, value)
+
+	m.Set(2, 200) // insert
+	assert.Equal(t, 2, m.Len())
+	value, ok = m.Get(2)
+	assert.True(t, ok)
+	assert.Equal(t, 200, value)
+}
+
+func TestSetFloat32(t *testing.T) {
+	t.Parallel()
+	m := New[float32, int]()
+
+	m.Set(1.1, 128) // insert
+	value, ok := m.Get(1.1)
+	assert.True(t, ok)
+	assert.Equal(t, 128, value)
+
+	m.Set(2.2, 200) // insert
+	assert.Equal(t, 2, m.Len())
+	value, ok = m.Get(2.2)
+	assert.True(t, ok)
+	assert.Equal(t, 200, value)
+}
+
+func TestSetFloat64(t *testing.T) {
+	t.Parallel()
+	m := New[float64, int]()
+
+	m.Set(1.1, 128) // insert
+	value, ok := m.Get(1.1)
+	assert.True(t, ok)
+	assert.Equal(t, 128, value)
+
+	m.Set(2.2, 200) // insert
+	assert.Equal(t, 2, m.Len())
+	value, ok = m.Get(2.2)
+	assert.True(t, ok)
+	assert.Equal(t, 200, value)
+}
+
+func TestSetInt64(t *testing.T) {
+	t.Parallel()
+	m := New[int64, int]()
+
+	m.Set(1, 128) // insert
+	value, ok := m.Get(1)
+	assert.True(t, ok)
+	assert.Equal(t, 128, value)
+
+	m.Set(2, 200) // insert
+	assert.Equal(t, 2, m.Len())
+	value, ok = m.Get(2)
+	assert.True(t, ok)
+	assert.Equal(t, 200, value)
+}
+
+func TestByteArray(t *testing.T) {
+	t.Parallel()
+	m := New[[4]byte, int]()
+
+	m.Set([4]byte{1, 2, 3, 4}, 128) // insert
+	value, ok := m.Get([4]byte{1, 2, 3, 4})
+	assert.True(t, ok)
+	assert.Equal(t, 128, value)
+
+	m.Delete([4]byte{1, 2, 3, 4})
+	assert.Equal(t, 0, m.Len())
+	_, ok = m.Get([4]byte{1, 2, 3, 4})
+	assert.False(t, ok)
+	assert.Equal(t, 0, m.Len())
+}
+
+func TestGetNonExistingItem(t *testing.T) {
+	t.Parallel()
+	m := New[int, string]()
+	value, ok := m.Get(1)
+	assert.False(t, ok)
+	assert.Equal(t, "", value)
+}
+
+func TestStringer(t *testing.T) {
+	t.Parallel()
+	m := New[int, string]()
+
+	// Test with zero items
+	assert.Equal(t, "[]", m.String())
+
+	// Test with one item
+	m.Set(1, "elephant")
+	assert.Equal(t, "[1=elephant]", m.String())
+
+	// Test with two items
+	m.Set(2, "monkey")
+	expectedStrings := []string{"[1=elephant, 2=monkey]", "[2=monkey, 1=elephant]"}
+	actualString := m.String()
+	assert.Contains(t, expectedStrings, actualString)
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+	m := New[int, string]()
+	elephant := "elephant"
+	monkey := "monkey"
+
+	deleted := m.Delete(1)
+	assert.False(t, deleted)
+
+	m.Set(1, elephant)
+	m.Set(2, monkey)
+
+	deleted = m.Delete(0)
+	assert.False(t, deleted)
+	deleted = m.Delete(3)
+	assert.False(t, deleted)
+	assert.Equal(t, 2, m.Len())
+
+	deleted = m.Delete(1)
+	assert.True(t, deleted)
+	deleted = m.Delete(1)
+	assert.False(t, deleted)
+	deleted = m.Delete(2)
+	assert.True(t, deleted)
+	assert.Equal(t, 0, m.Len())
+}
+
+func TestRange(t *testing.T) {
+	t.Parallel()
+	m := New[int, string]()
+
+	items := map[int]string{}
+	m.Range(func(key int, value string) bool {
+		items[key] = value
+		return true
+	})
+	assert.Equal(t, 0, len(items))
+
+	itemCount := 16
+	for i := itemCount; i > 0; i-- {
+		m.Set(i, strconv.Itoa(i))
+	}
+
+	items = map[int]string{}
+	m.Range(func(key int, value string) bool {
+		items[key] = value
+		return true
+	})
+
+	assert.Equal(t, itemCount, len(items))
+	for i := 1; i <= itemCount; i++ {
+		value, ok := items[i]
+		assert.True(t, ok)
+		expected := strconv.Itoa(i)
+		assert.Equal(t, expected, value)
+	}
+
+	items = map[int]string{} // test aborting range
+	m.Range(func(key int, value string) bool {
+		items[key] = value
+		return false
+	})
+	assert.Equal(t, 1, len(items))
+}
+
+// nolint: funlen, gocognit
+func TestHashMap_parallel(t *testing.T) {
+	m := New[int, int]()
+
+	max := 10
+	dur := 2 * time.Second
+
+	do := func(t *testing.T, max int, d time.Duration, fn func(*testing.T, int)) <-chan error {
+		t.Helper()
+		done := make(chan error)
+		var times int64
+		// This goroutines will terminate test in case if closure hangs.
+		go func() {
+			for {
+				select {
+				case <-time.After(d + 500*time.Millisecond):
+					if atomic.LoadInt64(&times) == 0 {
+						done <- fmt.Errorf("closure was not executed even once, something blocks it")
+					}
+					close(done)
+				case <-done:
+				}
+			}
+		}()
+		go func() {
+			timer := time.NewTimer(d)
+			defer timer.Stop()
+		InfLoop:
+			for {
+				for i := 0; i < max; i++ {
+					select {
+					case <-timer.C:
+						break InfLoop
+					default:
+					}
+					fn(t, i)
+					atomic.AddInt64(&times, 1)
+				}
+			}
+			close(done)
+		}()
+		return done
+	}
+
+	wait := func(t *testing.T, done <-chan error) {
+		t.Helper()
+		if err := <-done; err != nil {
+			t.Error(err)
+		}
+	}
+
+	// Initial fill.
+	for i := 0; i < max; i++ {
+		m.Set(i, i)
+	}
+	t.Run("set_get", func(t *testing.T) {
+		doneSet := do(t, max, dur, func(t *testing.T, i int) {
+			t.Helper()
+			m.Set(i, i)
+		})
+		doneGet := do(t, max, dur, func(t *testing.T, i int) {
+			t.Helper()
+			if _, ok := m.Get(i); !ok {
+				t.Errorf("missing value for key: %d", i)
+			}
+		})
+		wait(t, doneSet)
+		wait(t, doneGet)
+	})
+	t.Run("get-or-insert-and-delete", func(t *testing.T) {
+		doneGetOrInsert := do(t, max, dur, func(t *testing.T, i int) {
+			t.Helper()
+			m.GetOrSet(i, i)
+		})
+		doneDel := do(t, max, dur, func(t *testing.T, i int) {
+			t.Helper()
+			m.Delete(i)
+		})
+		wait(t, doneGetOrInsert)
+		wait(t, doneDel)
+	})
+}
+
+func TestHashMap_SetConcurrent(t *testing.T) {
+	t.Parallel()
+	m := New[string, int]()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			m.Set(strconv.Itoa(i), i)
+
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+
+				m.Get(strconv.Itoa(i))
+			}(i)
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestConcurrentInsertDelete(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 200; i++ {
+		l := New[int, int]()
+		l.Set(111, 111)
+		l.Set(222, 222)
+		l.Set(333, 333)
+		wg := sync.WaitGroup{}
+		wg.Add(2)
+
+		go func() {
+			rand.Seed(int64(time.Now().Nanosecond()))
+			time.Sleep(time.Duration(rand.Intn(10)))
+			l.Delete(222)
+			wg.Done()
+		}()
+		go func() {
+			defer wg.Done()
+			rand.Seed(int64(time.Now().Nanosecond()))
+			time.Sleep(time.Duration(rand.Intn(10)))
+			l.GetOrSet(223, 223)
+		}()
+		wg.Wait()
+
+		assert.Equal(t, 3, l.Len())
+		_, found := l.Get(223)
+		assert.True(t, found)
+	}
+}
+
+func TestGetOrInsert(t *testing.T) {
+	t.Parallel()
+	m := New[int, string]()
+	value, ok := m.GetOrSet(1, "1")
+	assert.False(t, ok)
+	assert.Equal(t, "1", value)
+
+	value, ok = m.GetOrSet(1, "2")
+	assert.True(t, ok)
+	assert.Equal(t, "1", value)
+}
+
+func TestGetOrInsertHangIssue67(_ *testing.T) {
+	m := New[string, int]()
+
+	var wg sync.WaitGroup
+	key := "key"
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		m.GetOrSet(key, 9)
+		m.Delete(key)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		m.GetOrSet(key, 9)
+		m.Delete(key)
+	}()
+
+	wg.Wait()
+}
+
+// See https://github.com/ssvlabs/ssv/issues/1682
+func TestIssue1682(t *testing.T) {
+	type validatorStatus int
+
+	const (
+		validatorStatusSubscribing validatorStatus = 1
+		validatorStatusSubscribed  validatorStatus = 2
+	)
+
 	cmtIDsHex := []string{
 		"9576fdcd4cfd9e563a5ce54e1a2e8a2950a94d8d0db49696f37889929ad813fd",
 		"b9492d60036f93841da23f7ee49f987ace6cb7d07170b9e9aaa2be54f4fceaf7",
@@ -34,7 +430,7 @@ func TestRaceCondition(t *testing.T) {
 	var wwg sync.WaitGroup
 	var errs []error
 	var mu sync.Mutex
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 10; i++ {
 		wwg.Add(1)
 		go func() {
 			defer wwg.Done()
@@ -49,7 +445,7 @@ func TestRaceCondition(t *testing.T) {
 					go func() {
 						defer wg.Done()
 						time.Sleep(time.Duration(rand.Intn(2000)) * time.Millisecond)
-						_, found := m.GetOrInsert(cmtID, validatorStatusSubscribing)
+						_, found := m.GetOrSet(cmtID, validatorStatusSubscribing)
 						if !found {
 							time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
 							m.Set(cmtID, validatorStatusSubscribed)
@@ -83,102 +479,6 @@ func TestRaceCondition(t *testing.T) {
 						keys = append(keys, key)
 						return true
 					})
-					keysHex := []string{}
-					for _, key := range keys {
-						keysHex = append(keysHex, hex.EncodeToString([]byte(key)))
-					}
-					t.Logf("iteration %d: %d keys, %d expected", i, len(keys), len(cmtIDs))
-					if len(keys) != len(cmtIDs) {
-						t.Logf("expected %d keys, got %d (%v)", len(cmtIDs), len(keys), keysHex)
-						mu.Lock()
-						errs = append(errs, fmt.Errorf("expected %d keys, got %d (%v)", len(cmtIDs), len(keys), keysHex))
-						mu.Unlock()
-					}
-					break Loop
-				case <-ticker.C:
-				}
-			}
-		}()
-	}
-	wwg.Wait()
-	require.Empty(t, errs)
-}
-
-func TestRaceConditionGoMap(t *testing.T) {
-	cmtIDsHex := []string{
-		"9576fdcd4cfd9e563a5ce54e1a2e8a2950a94d8d0db49696f37889929ad813fd",
-		"b9492d60036f93841da23f7ee49f987ace6cb7d07170b9e9aaa2be54f4fceaf7",
-		"e2394daed1f3bfc1714dea43d0aaf663a10af88ed985aed5564e3d027d961b89",
-	}
-	var cmtIDs []string
-	for _, cmtIDHex := range cmtIDsHex {
-		cmtID, err := hex.DecodeString(cmtIDHex)
-		require.NoError(t, err)
-		cmtIDs = append(cmtIDs, string(cmtID))
-	}
-
-	var wwg sync.WaitGroup
-	var errs []error
-	var mu sync.Mutex
-	for i := 0; i < 100; i++ {
-		wwg.Add(1)
-		go func() {
-			defer wwg.Done()
-
-			m := make(map[string]validatorStatus)
-			var mtx sync.Mutex
-			var wg sync.WaitGroup
-			for _, cmtID := range cmtIDs {
-				cmtID := cmtID
-				n := 50 + rand.Intn(200)
-				for j := 0; j < n; j++ {
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
-						time.Sleep(time.Duration(rand.Intn(2000)) * time.Millisecond)
-						mtx.Lock()
-						_, found := m[cmtID]
-						if !found {
-							m[cmtID] = validatorStatusSubscribing
-						}
-						mtx.Unlock()
-						if !found {
-							time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
-							mtx.Lock()
-							m[cmtID] = validatorStatusSubscribed
-							mtx.Unlock()
-						} else {
-							time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
-						}
-					}()
-				}
-			}
-
-			done := make(chan struct{})
-			go func() {
-				defer close(done)
-				wg.Wait()
-			}()
-
-			ticker := time.NewTicker(1 * time.Millisecond)
-			var keys []string
-			defer ticker.Stop()
-		Loop:
-			for {
-				keys = []string{}
-				mtx.Lock()
-				for key := range m {
-					keys = append(keys, key)
-				}
-				mtx.Unlock()
-				select {
-				case <-done:
-					keys = []string{}
-					mtx.Lock()
-					for key := range m {
-						keys = append(keys, key)
-					}
-					mtx.Unlock()
 					keysHex := []string{}
 					for _, key := range keys {
 						keysHex = append(keysHex, hex.EncodeToString([]byte(key)))


### PR DESCRIPTION
## Description

As we found that `cornelk/hashmap` has a bug where it would sometimes silently fail store one of the entries, it was decided just to use regular `sync.Map` as our `hashmap` package backend.

