### PR TITLE
fix: duties log string for committee duties

### DIFF
--- a/logging/fields/fields.go
+++ b/logging/fields/fields.go
@@ -352,8 +352,8 @@ func FeeRecipient(pubKey []byte) zap.Field {
 	return zap.Stringer(FieldFeeRecipient, stringer.HexStringer{Val: pubKey})
 }
 
-func FormatDutyID(epoch phase0.Epoch, slot phase0.Slot, role spectypes.RunnerRole, index phase0.ValidatorIndex) string {
-	return fmt.Sprintf("%v-e%v-s%v-v%v", role.String(), epoch, slot, index)
+func FormatDutyID(epoch phase0.Epoch, slot phase0.Slot, role string, index phase0.ValidatorIndex) string {
+	return fmt.Sprintf("%v-e%v-s%v-v%v", role, epoch, slot, index)
 }
 
 func GenesisFormatDutyID(epoch phase0.Epoch, slot phase0.Slot, role genesisspectypes.BeaconRole, index phase0.ValidatorIndex) string {
@@ -378,7 +378,7 @@ func Duties(epoch phase0.Epoch, duties []*spectypes.ValidatorDuty) zap.Field {
 		if i > 0 {
 			b.WriteString(", ")
 		}
-		b.WriteString(FormatDutyID(epoch, duty.Slot, duty.RunnerRole(), duty.ValidatorIndex))
+		b.WriteString(FormatDutyID(epoch, duty.Slot, duty.Type.String(), duty.ValidatorIndex))
 	}
 	return zap.String(FieldDuties, b.String())
 }

--- a/logging/fields/fields.go
+++ b/logging/fields/fields.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p/core/peer"
-	genesisspectypes "github.com/ssvlabs/ssv-spec-pre-cc/types"
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"go.uber.org/zap"
@@ -354,10 +353,6 @@ func FeeRecipient(pubKey []byte) zap.Field {
 
 func FormatDutyID(epoch phase0.Epoch, slot phase0.Slot, role string, index phase0.ValidatorIndex) string {
 	return fmt.Sprintf("%v-e%v-s%v-v%v", role, epoch, slot, index)
-}
-
-func GenesisFormatDutyID(epoch phase0.Epoch, slot phase0.Slot, role genesisspectypes.BeaconRole, index phase0.ValidatorIndex) string {
-	return fmt.Sprintf("%v-e%v-s%v-v%v", role.String(), epoch, slot, index)
 }
 
 func FormatCommittee(operators []spectypes.OperatorID) string {

--- a/message/validation/logger_fields.go
+++ b/message/validation/logger_fields.go
@@ -95,7 +95,7 @@ func (mv *messageValidator) addDutyIDField(lf *LoggerFields) {
 		// get the validator index from the msgid
 		v := mv.validatorStore.Validator(lf.DutyExecutorID)
 		if v != nil {
-			lf.DutyID = fields.FormatDutyID(mv.netCfg.Beacon.EstimatedEpochAtSlot(lf.Slot), lf.Slot, lf.Role, v.ValidatorIndex)
+			lf.DutyID = fields.FormatDutyID(mv.netCfg.Beacon.EstimatedEpochAtSlot(lf.Slot), lf.Slot, lf.Role.String(), v.ValidatorIndex)
 		}
 	}
 }

--- a/protocol/genesis/ssv/validator/validator.go
+++ b/protocol/genesis/ssv/validator/validator.go
@@ -98,7 +98,7 @@ func (v *Validator) StartDuty(logger *zap.Logger, duty *genesisspectypes.Duty) e
 
 	// Log with duty ID.
 	baseRunner := dutyRunner.GetBaseRunner()
-	v.dutyIDs.Set(duty.Type, fields.GenesisFormatDutyID(baseRunner.BeaconNetwork.EstimatedEpochAtSlot(duty.Slot), duty.Slot, duty.Type, duty.ValidatorIndex))
+	v.dutyIDs.Set(duty.Type, fields.FormatDutyID(baseRunner.BeaconNetwork.EstimatedEpochAtSlot(duty.Slot), duty.Slot, duty.Type.String(), duty.ValidatorIndex))
 	logger = trySetDutyID(logger, v.dutyIDs, duty.Type)
 
 	// Log with height.

--- a/protocol/v2/ssv/validator/validator.go
+++ b/protocol/v2/ssv/validator/validator.go
@@ -109,7 +109,7 @@ func (v *Validator) StartDuty(logger *zap.Logger, iduty spectypes.Duty) error {
 
 	// Log with duty ID.
 	baseRunner := dutyRunner.GetBaseRunner()
-	v.dutyIDs.Set(spectypes.MapDutyToRunnerRole(duty.Type), fields.FormatDutyID(baseRunner.BeaconNetwork.EstimatedEpochAtSlot(duty.Slot), duty.Slot, duty.RunnerRole(), duty.ValidatorIndex))
+	v.dutyIDs.Set(spectypes.MapDutyToRunnerRole(duty.Type), fields.FormatDutyID(baseRunner.BeaconNetwork.EstimatedEpochAtSlot(duty.Slot), duty.Slot, duty.Type.String(), duty.ValidatorIndex))
 	logger = trySetDutyID(logger, v.dutyIDs, spectypes.MapDutyToRunnerRole(duty.Type))
 
 	// Log with height.


### PR DESCRIPTION
### Description 

#1653 introduced a logging bug where duties in the `duties` field are formatted using the runner role, means they all get "COMITTTEE" when they are committee duties. We want to support any duty role type so a string might fix better this parameter to enable flexibility. 