### PR TITLE
fix: queue priority not take partial messags until decided

### DIFF
--- a/protocol/v2/ssv/validator/committee_queue.go
+++ b/protocol/v2/ssv/validator/committee_queue.go
@@ -115,7 +115,7 @@ func (v *Committee) ConsumeQueue(
 		} else if runningInstance != nil && !runningInstance.State.Decided {
 			filter = func(ssvMessage *queue.SSVMessage) bool {
 				// don't read post consensus until decided
-				return ssvMessage.SSVMessage.MsgType == spectypes.SSVPartialSignatureMsgType
+				return ssvMessage.SSVMessage.MsgType != spectypes.SSVPartialSignatureMsgType
 			}
 		}
 


### PR DESCRIPTION
### Description

#1674 introduced a bug where we didn't grab consensus messages until it was decided, hence we never decided.