### PR TITLE
fix (alan): use genesis func to generate msgid on pre-fork

### DIFF
--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -300,7 +300,7 @@ func (n *p2pNetwork) setupPubsub(logger *zap.Logger) error {
 		cfg.ScoreIndex = nil
 	}
 
-	midHandler := topics.NewMsgIDHandler(n.ctx, time.Minute*2)
+	midHandler := topics.NewMsgIDHandler(n.ctx, n.cfg.Network, time.Minute*2)
 	n.msgResolver = midHandler
 	cfg.MsgIDHandler = midHandler
 	go cfg.MsgIDHandler.Start()

--- a/network/topics/controller_test.go
+++ b/network/topics/controller_test.go
@@ -367,7 +367,7 @@ func newPeer(ctx context.Context, logger *zap.Logger, t *testing.T, msgValidator
 	var p *P
 	var midHandler MsgIDHandler
 	if msgID {
-		midHandler = NewMsgIDHandler(ctx, 2*time.Minute)
+		midHandler = NewMsgIDHandler(ctx, networkconfig.TestNetwork, 2*time.Minute)
 		go midHandler.Start()
 	}
 	cfg := &PubSubConfig{

--- a/network/topics/msg_id.go
+++ b/network/topics/msg_id.go
@@ -10,8 +10,10 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/zap"
 
+	genesisspectypes "github.com/ssvlabs/ssv-spec-pre-cc/types"
 	"github.com/ssvlabs/ssv/logging/fields"
 	"github.com/ssvlabs/ssv/network/commons"
+	"github.com/ssvlabs/ssv/networkconfig"
 )
 
 const (
@@ -53,21 +55,23 @@ type msgIDEntry struct {
 
 // msgIDHandler implements MsgIDHandler
 type msgIDHandler struct {
-	ctx    context.Context
-	added  chan addedEvent
-	ids    map[string]*msgIDEntry
-	locker sync.Locker
-	ttl    time.Duration
+	networkConfig networkconfig.NetworkConfig
+	ctx           context.Context
+	added         chan addedEvent
+	ids           map[string]*msgIDEntry
+	locker        sync.Locker
+	ttl           time.Duration
 }
 
 // NewMsgIDHandler creates a new MsgIDHandler
-func NewMsgIDHandler(ctx context.Context, ttl time.Duration) MsgIDHandler {
+func NewMsgIDHandler(ctx context.Context, networkConfig networkconfig.NetworkConfig, ttl time.Duration) MsgIDHandler {
 	handler := &msgIDHandler{
-		ctx:    ctx,
-		added:  make(chan addedEvent, msgIDHandlerBufferSize),
-		ids:    make(map[string]*msgIDEntry),
-		locker: &sync.Mutex{},
-		ttl:    ttl,
+		networkConfig: networkConfig,
+		ctx:           ctx,
+		added:         make(chan addedEvent, msgIDHandlerBufferSize),
+		ids:           make(map[string]*msgIDEntry),
+		locker:        &sync.Mutex{},
+		ttl:           ttl,
 	}
 	return handler
 }
@@ -123,12 +127,21 @@ func (handler *msgIDHandler) MsgID(logger *zap.Logger) func(pmsg *ps_pb.Message)
 
 func (handler *msgIDHandler) pubsubMsgToMsgID(msg []byte) string {
 	// TODO: (Alan) should we hash only the message body or what? @GalRogozinski @MatheusFranco99
-	// decodedMsg, _, _, err := spectypes.DecodeSignedSSVMessage(msg)
-	// if err != nil {
-	// 	// todo: should err here or just log and let the decode function err?
-	// } else {
-	// 	return commons.MsgID()(decodedMsg)
-	// }
+
+	// pre-fork hashing scheme
+
+	if !handler.networkConfig.PastAlanFork() {
+		decodedMsg, _, _, err := genesisspectypes.DecodeSignedSSVMessage(msg)
+		if err != nil {
+			// todo: should err here or just log and let the decode function err?
+		} else {
+			return commons.MsgID()(decodedMsg)
+		}
+	}
+
+	// In Alan message structure the message body can be identical for all 4 operators
+	// whereas before it included a BLS signature which made it unique
+	// so we hash full message (including signer) to make it unique
 
 	return commons.MsgID()(msg)
 }


### PR DESCRIPTION
### Description

We noticed an issue where `main` and pre-fork - `stage` were tagging each other as `low_score` peers, reducing each other peers because they sent each other `selfOrigin` message, which is an internal mechanism in `go-libp2p-pubsub` to reduce score based on peers that are sending us our own messages.

We were puzzled by this for a while because the `go-libp2p` `Publish` func has a mechanism in place to stop this -
```go
    out := rpcWithMessages(msg.Message)
    for pid := range tosend {
        if pid == from || pid == peer.ID(msg.GetFrom()) { // this should skip original sender of the message
            continue
        }

        gs.sendRPC(pid, out)
    }
```

Apparently these messages were arriving from the heartbeat of control message libp2p uses to fill the "gaps" of messages, using an anti-entropy mechanism where they publish `Iwant`/`Ihave` msg ids to each other, the above mentioned code doesn't run on this heartbeat, though this should've still prevented due to checking the msgid of the message.

This made us realize our bug that is rooted in the way we provide libp2p a function to give ids to messages. Which has changed in Alan. Previously (in `main) we were hashing only the body of the message, and that was enough to create a unique message since we had a unique BLS sig inside the body. Since in Alan we dropped the BLS signatures in the message body, messages id could've ended up identical because the bodies were identical; To overcome this we changed the msg id func to use the whole message (including the signer id) so unique ids are generated.

Because this was implemented in stage and we didn't check for pre/post fork condition, peers were using different IDs, hence ending up sending the messages to the original sender, triggering score reduced by the `selfOrigin` message check.

### Solution

Use old msgid func before the fork, start using new format on fork.


#### kudos 

Big thanks to @moshe-blox for spotting this
Also thanks to @nkryuchkov , @Roy-blox looking on this