### PR TITLE
fix: create DutyID for message in single validators

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -928,6 +928,8 @@ func (c *controller) onShareInit(share *ssvtypes.SSVShare) (*validators.Validato
 		opts.SSVShare = share
 		opts.Operator = operator
 		opts.DutyRunners = SetupRunners(validatorCtx, c.logger, opts)
+		opts.ValidatorIndex = share.ValidatorIndex
+
 		alanValidator := validator.NewValidator(validatorCtx, validatorCancel, opts)
 
 		// TODO: (Alan) share mutations such as metadata changes and fee recipient updates aren't reflected in genesis shares
@@ -941,7 +943,7 @@ func (c *controller) onShareInit(share *ssvtypes.SSVShare) (*validators.Validato
 			genesisOpts := c.genesisValidatorOptions
 			genesisOpts.SSVShare = genesisssvtypes.ConvertToGenesisSSVShare(share, operator)
 			genesisOpts.DutyRunners = SetupGenesisRunners(genesisValidatorCtx, c.logger, opts)
-
+			genesisOpts.ValidatorIndex = share.ValidatorIndex
 			genesisValidator = genesisvalidator.NewValidator(genesisValidatorCtx, validatorCancel, genesisOpts)
 		}
 

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -928,7 +928,6 @@ func (c *controller) onShareInit(share *ssvtypes.SSVShare) (*validators.Validato
 		opts.SSVShare = share
 		opts.Operator = operator
 		opts.DutyRunners = SetupRunners(validatorCtx, c.logger, opts)
-		opts.ValidatorIndex = share.ValidatorIndex
 
 		alanValidator := validator.NewValidator(validatorCtx, validatorCancel, opts)
 

--- a/protocol/genesis/ssv/genesisqueue/messages.go
+++ b/protocol/genesis/ssv/genesisqueue/messages.go
@@ -36,6 +36,12 @@ func (d *GenesisSSVMessage) Slot() (phase0.Slot, error) {
 				return 0, ErrUnknownMessageType // TODO alan: other error
 			}
 			return phase0.Slot(data.Height), nil
+		} else if m.Type == ssvtypes.ExecuteDuty {
+			data, err := m.GetExecuteDutyData()
+			if err != nil {
+				return 0, ErrUnknownMessageType // TODO alan: other error
+			}
+			return data.Duty.Slot, nil
 		}
 		return 0, ErrUnknownMessageType // TODO: alan: slot not supporting dutyexec msg?
 	case *genesisspecqbft.SignedMessage: // TODO: remove post-fork

--- a/protocol/genesis/ssv/validator/msgqueue_consumer.go
+++ b/protocol/genesis/ssv/validator/msgqueue_consumer.go
@@ -148,7 +148,8 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID genesisspectypes.Mess
 			logger.Error("❗ can't get slot from msg", zap.Error(err))
 			continue
 		}
-		msgLogger := logger.With(fields.DutyID(fields.FormatDutyID(v.NetworkConfig.Beacon.EstimatedEpochAtSlot(slot), slot, msgID.GetRoleType().String(), v.Index)))
+
+		msgLogger := logger.With(fields.DutyID(fields.FormatDutyID(v.BeaconNetwork.EstimatedEpochAtSlot(slot), slot, msgID.GetRoleType().String(), v.Index)))
 
 		lens = append(lens, q.Q.Len())
 		if len(lens) >= 10 {

--- a/protocol/genesis/ssv/validator/msgqueue_consumer.go
+++ b/protocol/genesis/ssv/validator/msgqueue_consumer.go
@@ -145,7 +145,9 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID genesisspectypes.Mess
 
 		slot, err := msg.Slot()
 		if err != nil {
-			logger.Error("❗ can't get slot from msg", zap.Error(err))
+			v.logMsg(logger, msg, "❗ could not handle message",
+				fields.MessageType(spectypes.MsgType(msg.SSVMessage.MsgType)),
+				zap.Error(fmt.Errorf("can't get slot from msg: %w", err)))
 			continue
 		}
 

--- a/protocol/genesis/ssv/validator/opts.go
+++ b/protocol/genesis/ssv/validator/opts.go
@@ -4,8 +4,6 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	genesisspecqbft "github.com/ssvlabs/ssv-spec-pre-cc/qbft"
 	genesisspectypes "github.com/ssvlabs/ssv-spec-pre-cc/types"
-	"github.com/ssvlabs/ssv/networkconfig"
-
 	genesisibftstorage "github.com/ssvlabs/ssv/ibft/genesisstorage"
 	"github.com/ssvlabs/ssv/message/validation"
 	qbftctrl "github.com/ssvlabs/ssv/protocol/genesis/qbft/controller"
@@ -21,7 +19,6 @@ const (
 // Options represents options that should be passed to a new instance of Validator.
 type Options struct {
 	Network           genesisspecqbft.Network
-	NetworkConfig     networkconfig.NetworkConfig
 	ValidatorIndex    phase0.ValidatorIndex
 	BeaconNetwork     beacon.BeaconNetwork
 	Storage           *genesisibftstorage.QBFTStores

--- a/protocol/genesis/ssv/validator/opts.go
+++ b/protocol/genesis/ssv/validator/opts.go
@@ -1,8 +1,10 @@
 package validator
 
 import (
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	genesisspecqbft "github.com/ssvlabs/ssv-spec-pre-cc/qbft"
 	genesisspectypes "github.com/ssvlabs/ssv-spec-pre-cc/types"
+	"github.com/ssvlabs/ssv/networkconfig"
 
 	genesisibftstorage "github.com/ssvlabs/ssv/ibft/genesisstorage"
 	"github.com/ssvlabs/ssv/message/validation"
@@ -19,6 +21,8 @@ const (
 // Options represents options that should be passed to a new instance of Validator.
 type Options struct {
 	Network           genesisspecqbft.Network
+	NetworkConfig     networkconfig.NetworkConfig
+	ValidatorIndex    phase0.ValidatorIndex
 	BeaconNetwork     beacon.BeaconNetwork
 	Storage           *genesisibftstorage.QBFTStores
 	SSVShare          *types.SSVShare

--- a/protocol/genesis/ssv/validator/validator.go
+++ b/protocol/genesis/ssv/validator/validator.go
@@ -41,9 +41,6 @@ type Validator struct {
 	Storage *genesisstorage.QBFTStores
 	Queues  map[genesisspectypes.BeaconRole]queueContainer
 
-	// dutyIDs is a map for logging a unique ID for a given duty
-	//dutyIDs *hashmap.Map[genesisspectypes.BeaconRole, string]
-
 	state uint32
 
 	messageValidator validation.MessageValidator

--- a/protocol/genesis/ssv/validator/validator.go
+++ b/protocol/genesis/ssv/validator/validator.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/ssvlabs/ssv/networkconfig"
+	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -30,7 +30,7 @@ type Validator struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	NetworkConfig networkconfig.NetworkConfig
+	BeaconNetwork beacon.BeaconNetwork
 	Index         phase0.ValidatorIndex
 
 	DutyRunners runner.DutyRunners
@@ -61,7 +61,7 @@ func NewValidator(pctx context.Context, cancel func(), options Options) *Validat
 		mtx:              &sync.RWMutex{},
 		ctx:              pctx,
 		cancel:           cancel,
-		NetworkConfig:    options.NetworkConfig,
+		BeaconNetwork:    options.BeaconNetwork,
 		Index:            options.ValidatorIndex,
 		DutyRunners:      options.DutyRunners,
 		Network:          options.Network,
@@ -103,7 +103,7 @@ func (v *Validator) StartDuty(logger *zap.Logger, duty *genesisspectypes.Duty) e
 
 	// Log with duty ID.
 	baseRunner := dutyRunner.GetBaseRunner()
-	dutyID := fields.FormatDutyID(v.NetworkConfig.Beacon.EstimatedEpochAtSlot(duty.Slot), duty.Slot, duty.Type.String(), v.Index)
+	dutyID := fields.FormatDutyID(v.BeaconNetwork.EstimatedEpochAtSlot(duty.Slot), duty.Slot, duty.Type.String(), v.Index)
 	logger = logger.With(fields.DutyID(dutyID))
 
 	// Log with height.

--- a/protocol/v2/ssv/queue/messages.go
+++ b/protocol/v2/ssv/queue/messages.go
@@ -40,6 +40,12 @@ func (d *SSVMessage) Slot() (phase0.Slot, error) {
 				return 0, ErrUnknownMessageType // TODO alan: other error
 			}
 			return phase0.Slot(data.Height), nil
+		} else if m.Type == ssvtypes.ExecuteDuty {
+			data, err := m.GetExecuteDutyData()
+			if err != nil {
+				return 0, ErrUnknownMessageType // TODO alan: other error
+			}
+			return data.Duty.Slot, nil
 		}
 		return 0, ErrUnknownMessageType // TODO: alan: slot not supporting dutyexec msg?
 	default:

--- a/protocol/v2/ssv/validator/msgqueue_consumer.go
+++ b/protocol/v2/ssv/validator/msgqueue_consumer.go
@@ -151,7 +151,7 @@ func (v *Validator) ConsumeQueue(logger *zap.Logger, msgID spectypes.MessageID, 
 			continue
 		}
 
-		msgDutyID := fields.FormatDutyID(v.NetworkConfig.Beacon.EstimatedEpochAtSlot(slot), slot, role, v.Index)
+		msgDutyID := fields.FormatDutyID(v.NetworkConfig.Beacon.EstimatedEpochAtSlot(slot), slot, role, v.Share.ValidatorIndex)
 		msgLogger := logger.With(fields.DutyID(msgDutyID))
 
 		lens = append(lens, q.Q.Len())

--- a/protocol/v2/ssv/validator/opts.go
+++ b/protocol/v2/ssv/validator/opts.go
@@ -1,7 +1,6 @@
 package validator
 
 import (
-	"github.com/attestantio/go-eth2-client/spec/phase0"
 	genesisspecqbft "github.com/ssvlabs/ssv-spec-pre-cc/qbft"
 	genesisspectypes "github.com/ssvlabs/ssv-spec-pre-cc/types"
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
@@ -37,7 +36,6 @@ type Options struct {
 	OperatorSigner    ssvtypes.OperatorSigner
 	DutyRunners       runner.ValidatorDutyRunners
 	NewDecidedHandler qbftctrl.NewDecidedHandler
-	ValidatorIndex    phase0.ValidatorIndex
 	FullNode          bool
 	Exporter          bool
 	QueueSize         int

--- a/protocol/v2/ssv/validator/opts.go
+++ b/protocol/v2/ssv/validator/opts.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	genesisspecqbft "github.com/ssvlabs/ssv-spec-pre-cc/qbft"
 	genesisspectypes "github.com/ssvlabs/ssv-spec-pre-cc/types"
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
@@ -36,6 +37,7 @@ type Options struct {
 	OperatorSigner    ssvtypes.OperatorSigner
 	DutyRunners       runner.ValidatorDutyRunners
 	NewDecidedHandler qbftctrl.NewDecidedHandler
+	ValidatorIndex    phase0.ValidatorIndex
 	FullNode          bool
 	Exporter          bool
 	QueueSize         int

--- a/protocol/v2/ssv/validator/validator.go
+++ b/protocol/v2/ssv/validator/validator.go
@@ -41,8 +41,6 @@ type Validator struct {
 	Storage *storage.QBFTStores
 	Queues  map[spectypes.RunnerRole]queueContainer
 
-	Index phase0.ValidatorIndex
-
 	state uint32
 
 	messageValidator validation.MessageValidator
@@ -57,21 +55,19 @@ func NewValidator(pctx context.Context, cancel func(), options Options) *Validat
 	}
 
 	v := &Validator{
-		mtx:            &sync.RWMutex{},
-		ctx:            pctx,
-		cancel:         cancel,
-		NetworkConfig:  options.NetworkConfig,
-		DutyRunners:    options.DutyRunners,
-		Network:        options.Network,
-		Storage:        options.Storage,
-		Operator:       options.Operator,
-		Share:          options.SSVShare,
-		Signer:         options.Signer,
-		OperatorSigner: options.OperatorSigner,
-		Index:          options.ValidatorIndex,
-		Queues:         make(map[spectypes.RunnerRole]queueContainer),
-		state:          uint32(NotStarted),
-		//dutyIDs:          hashmap.New[spectypes.RunnerRole, string](), // TODO: use beaconrole here?
+		mtx:              &sync.RWMutex{},
+		ctx:              pctx,
+		cancel:           cancel,
+		NetworkConfig:    options.NetworkConfig,
+		DutyRunners:      options.DutyRunners,
+		Network:          options.Network,
+		Storage:          options.Storage,
+		Operator:         options.Operator,
+		Share:            options.SSVShare,
+		Signer:           options.Signer,
+		OperatorSigner:   options.OperatorSigner,
+		Queues:           make(map[spectypes.RunnerRole]queueContainer),
+		state:            uint32(NotStarted),
 		messageValidator: options.MessageValidator,
 	}
 
@@ -200,7 +196,7 @@ func (v *Validator) ProcessMessage(logger *zap.Logger, msg *queue.SSVMessage) er
 
 func (v *Validator) loggerForDuty(logger *zap.Logger, role spectypes.BeaconRole, slot phase0.Slot) *zap.Logger {
 	logger = logger.With(fields.Slot(slot))
-	dutyID := fields.FormatDutyID(v.NetworkConfig.Beacon.EstimatedEpochAtSlot(slot), slot, role.String(), v.Index)
+	dutyID := fields.FormatDutyID(v.NetworkConfig.Beacon.EstimatedEpochAtSlot(slot), slot, role.String(), v.Share.ValidatorIndex)
 	logger = logger.With(fields.DutyID(dutyID))
 	return logger
 }


### PR DESCRIPTION
### Description

We were managing some cache for dutyid for validators, this created some weird cases where wrong DutyID would show. 
*NOTE*: This also adds DutyID log to genesis/single validator `could not handle message` logs, which makes debugging a consensus process a breeze :)

### Solution 

Generate dutyID on demand from validator and message data.


### TODO: 

- [x] - check cpu/mem impact