### PR TITLE
message validation: fix panic on malformed SignedSSVMessage

### DIFF
--- a/message/validation/logger_fields.go
+++ b/message/validation/logger_fields.go
@@ -61,9 +61,13 @@ func (mv *messageValidator) buildLoggerFields(decodedMessage *queue.SSVMessage) 
 		return descriptor
 	}
 
-	descriptor.DutyExecutorID = decodedMessage.GetID().GetDutyExecutorID()
-	descriptor.Role = decodedMessage.GetID().GetRoleType()
-	descriptor.SSVMessageType = decodedMessage.GetType()
+	if decodedMessage.SSVMessage == nil {
+		return descriptor
+	}
+
+	descriptor.DutyExecutorID = decodedMessage.SSVMessage.GetID().GetDutyExecutorID()
+	descriptor.Role = decodedMessage.SSVMessage.GetID().GetRoleType()
+	descriptor.SSVMessageType = decodedMessage.SSVMessage.GetType()
 
 	if mv.logger.Level() == zap.DebugLevel {
 		mv.addDutyIDField(descriptor)


### PR DESCRIPTION
If `validateSignedSSVMessage` returns an error, then `SSVMessage` is not set: https://github.com/ssvlabs/ssv/blob/b30bc8b4ed4ebf862ebc16f924c11239619c0c63/message/validation/validation.go#L128. 

In this case, `buildLoggerFields` panics in https://github.com/ssvlabs/ssv/blob/b30bc8b4ed4ebf862ebc16f924c11239619c0c63/message/validation/logger_fields.go#L64 on `decodedMessage.GetID()` because it's actually `decodedMessage.SSVMessage.GetID()` since `SSVMessage` is embedded into `queue.SSVMessage`.

The PR adds a check if `decodedMessage.SSVMessage` is `nil` and changes usage like `decodedMessage.GetID()` to `decodedMessage.SSVMessage.GetID()` for clarity.