### PR TITLE
fix: (validation) consider encoding overhead in max consensus & partial signature message sizes

### DIFF
--- a/message/validation/consensus_validation.go
+++ b/message/validation/consensus_validation.go
@@ -27,10 +27,10 @@ func (mv *messageValidator) validateConsensusMessage(
 ) (*specqbft.Message, error) {
 	ssvMessage := signedSSVMessage.SSVMessage
 
-	if len(ssvMessage.Data) > maxConsensusMsgSize {
+	if len(ssvMessage.Data) > maxEncodedConsensusMsgSize {
 		e := ErrSSVDataTooBig
 		e.got = len(ssvMessage.Data)
-		e.want = maxConsensusMsgSize
+		e.want = maxEncodedConsensusMsgSize
 		return nil, e
 	}
 

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -30,7 +30,7 @@ const (
 	maxNoJustificationSize     = 3616  // from KB
 	max1JustificationSize      = 50624 // from KB
 	maxConsensusMsgSize        = qbftMsgTypeSize + heightSize + roundSize + identifierSize + rootSize + roundSize + maxSignatures*(maxNoJustificationSize+max1JustificationSize)
-	maxEncodedConsensusMsgSize = maxConsensusMsgSize + maxConsensusMsgSize/20
+	maxEncodedConsensusMsgSize = maxConsensusMsgSize + maxConsensusMsgSize/encodingOverheadDivisor
 )
 
 const (
@@ -39,7 +39,7 @@ const (
 	maxPartialSignatureMessages    = 1000
 	partialSigMsgTypeSize          = 8 // uint64
 	maxPartialSignatureMsgsSize    = partialSigMsgTypeSize + slotSize + maxPartialSignatureMessages*partialSignatureMsgSize
-	maxEncodedPartialSignatureSize = maxPartialSignatureMsgsSize + maxPartialSignatureMsgsSize/20
+	maxEncodedPartialSignatureSize = maxPartialSignatureMsgsSize + maxPartialSignatureMsgsSize/encodingOverheadDivisor
 )
 
 const (

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -8,35 +8,38 @@ const (
 	// lateMessageMargin is the duration past a message's TTL in which it is still considered valid.
 	lateMessageMargin = time.Second * 3
 	// clockErrorTolerance is the maximum amount of clock error we expect to see between nodes.
-	clockErrorTolerance   = time.Millisecond * 50
-	allowedRoundsInFuture = 1
-	allowedRoundsInPast   = 2
-	lateSlotAllowance     = 2
-	syncCommitteeSize     = 512
-	rsaSignatureSize      = 256
-	operatorIDSize        = 8 // uint64
-	slotSize              = 8 // uint64
-	validatorIndexSize    = 8 // uint64
-	identifierSize        = 56
-	rootSize              = 32
-	maxSignatures         = 13
+	clockErrorTolerance     = time.Millisecond * 50
+	allowedRoundsInFuture   = 1
+	allowedRoundsInPast     = 2
+	lateSlotAllowance       = 2
+	syncCommitteeSize       = 512
+	rsaSignatureSize        = 256
+	operatorIDSize          = 8 // uint64
+	slotSize                = 8 // uint64
+	validatorIndexSize      = 8 // uint64
+	identifierSize          = 56
+	rootSize                = 32
+	maxSignatures           = 13
+	encodingOverheadDivisor = 20 // Divisor for message size to get encoding overhead, e.g. 10 for 10%, 20 for 5%. Done this way to keep const int.
 )
 
 const (
-	qbftMsgTypeSize        = 8     // uint64
-	heightSize             = 8     // uint64
-	roundSize              = 8     // uint64
-	maxNoJustificationSize = 3616  // from KB
-	max1JustificationSize  = 50624 // from KB
-	maxConsensusMsgSize    = qbftMsgTypeSize + heightSize + roundSize + identifierSize + rootSize + roundSize + maxSignatures*(maxNoJustificationSize+max1JustificationSize)
+	qbftMsgTypeSize            = 8     // uint64
+	heightSize                 = 8     // uint64
+	roundSize                  = 8     // uint64
+	maxNoJustificationSize     = 3616  // from KB
+	max1JustificationSize      = 50624 // from KB
+	maxConsensusMsgSize        = qbftMsgTypeSize + heightSize + roundSize + identifierSize + rootSize + roundSize + maxSignatures*(maxNoJustificationSize+max1JustificationSize)
+	maxEncodedConsensusMsgSize = maxConsensusMsgSize + maxConsensusMsgSize/20
 )
 
 const (
-	partialSignatureSize        = 96
-	partialSignatureMsgSize     = partialSignatureSize + rootSize + operatorIDSize + validatorIndexSize
-	maxPartialSignatureMessages = 1000
-	partialSigMsgTypeSize       = 8 // uint64
-	maxPartialSignatureMsgsSize = partialSigMsgTypeSize + slotSize + maxPartialSignatureMessages*partialSignatureMsgSize
+	partialSignatureSize           = 96
+	partialSignatureMsgSize        = partialSignatureSize + rootSize + operatorIDSize + validatorIndexSize
+	maxPartialSignatureMessages    = 1000
+	partialSigMsgTypeSize          = 8 // uint64
+	maxPartialSignatureMsgsSize    = partialSigMsgTypeSize + slotSize + maxPartialSignatureMessages*partialSignatureMsgSize
+	maxEncodedPartialSignatureSize = maxPartialSignatureMsgsSize + maxPartialSignatureMsgsSize/20
 )
 
 const (
@@ -47,7 +50,7 @@ const (
 )
 
 const (
-	maxPayloadDataSize = max(maxConsensusMsgSize, maxPartialSignatureMsgsSize)
+	maxPayloadDataSize = max(maxEncodedConsensusMsgSize, maxEncodedPartialSignatureSize)
 	maxSignedMsgSize   = maxSignaturesSize + maxOperatorIDSize + msgTypeSize + identifierSize + maxPayloadDataSize + maxFullDataSize
-	maxEncodedMsgSize  = maxSignedMsgSize + maxSignedMsgSize/10 // 10% for encoding overhead
+	maxEncodedMsgSize  = maxSignedMsgSize + maxSignedMsgSize/encodingOverheadDivisor
 )

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -4,6 +4,8 @@ import (
 	"time"
 )
 
+// To add some encoding overhead for ssz, we use (N + N/encodingOverheadDivisor + 4) for a structure with expected size N
+
 const (
 	// lateMessageMargin is the duration past a message's TTL in which it is still considered valid.
 	lateMessageMargin = time.Second * 3
@@ -30,7 +32,7 @@ const (
 	maxNoJustificationSize     = 3616  // from KB
 	max1JustificationSize      = 50624 // from KB
 	maxConsensusMsgSize        = qbftMsgTypeSize + heightSize + roundSize + identifierSize + rootSize + roundSize + maxSignatures*(maxNoJustificationSize+max1JustificationSize)
-	maxEncodedConsensusMsgSize = maxConsensusMsgSize + maxConsensusMsgSize/encodingOverheadDivisor
+	maxEncodedConsensusMsgSize = maxConsensusMsgSize + maxConsensusMsgSize/encodingOverheadDivisor + 4
 )
 
 const (
@@ -39,7 +41,7 @@ const (
 	maxPartialSignatureMessages    = 1000
 	partialSigMsgTypeSize          = 8 // uint64
 	maxPartialSignatureMsgsSize    = partialSigMsgTypeSize + slotSize + maxPartialSignatureMessages*partialSignatureMsgSize
-	maxEncodedPartialSignatureSize = maxPartialSignatureMsgsSize + maxPartialSignatureMsgsSize/encodingOverheadDivisor
+	maxEncodedPartialSignatureSize = maxPartialSignatureMsgsSize + maxPartialSignatureMsgsSize/encodingOverheadDivisor + 4
 )
 
 const (
@@ -52,5 +54,5 @@ const (
 const (
 	maxPayloadDataSize = max(maxEncodedConsensusMsgSize, maxEncodedPartialSignatureSize)
 	maxSignedMsgSize   = maxSignaturesSize + maxOperatorIDSize + msgTypeSize + identifierSize + maxPayloadDataSize + maxFullDataSize
-	maxEncodedMsgSize  = maxSignedMsgSize + maxSignedMsgSize/encodingOverheadDivisor
+	maxEncodedMsgSize  = maxSignedMsgSize + maxSignedMsgSize/encodingOverheadDivisor + 4
 )

--- a/message/validation/partial_validation.go
+++ b/message/validation/partial_validation.go
@@ -23,10 +23,10 @@ func (mv *messageValidator) validatePartialSignatureMessage(
 ) {
 	ssvMessage := signedSSVMessage.SSVMessage
 
-	if len(ssvMessage.Data) > maxPartialSignatureMsgsSize {
+	if len(ssvMessage.Data) > maxEncodedPartialSignatureSize {
 		e := ErrSSVDataTooBig
 		e.got = len(ssvMessage.Data)
-		e.want = maxPartialSignatureMsgsSize
+		e.want = maxEncodedPartialSignatureSize
 		return nil, e
 	}
 
@@ -208,7 +208,7 @@ func (mv *messageValidator) validatePartialSigMessagesByDutyLogic(
 		if partialSignatureMessageCount > maxSignatures {
 			e := ErrTooManyPartialSignatureMessages
 			e.got = partialSignatureMessageCount
-			e.want = maxConsensusMsgSize
+			e.want = maxSignatures
 			return e
 		}
 	} else if partialSignatureMessageCount > 1 {


### PR DESCRIPTION
When the attack simulator sends a partial signature message with a payload of 1000 messages, such message gets rejected with the error `ssv message data too big, got 144020, want 144016` because max messages sizes of consensus and partial signature messages don't count encoding overhead (we only count overhead of signed message)

The PR allows 5% encoding overhead for all encoded messages. It may be easily adjustable by changing `encodingOverheadDivisor`