### PR TITLE
fix: (eventhandler) pubkey & id uniqueness check in OperatorAdded

### DIFF
--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -202,10 +202,10 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		}
 	})
 
-	t.Run("test OperatorAdded event handle with duplicated pubkey, but different Id", func(t *testing.T) {
+	t.Run("test OperatorAdded event handle with the same pubkey, but with a different id", func(t *testing.T) {
 		op := &testOperator{}
 		op.id = 5
-		op.privateKey = ops[0].privateKey
+		op.privateKey = ops[1].privateKey
 
 		encodedPubKey, err := op.privateKey.Public().Base64()
 		require.NoError(t, err)
@@ -243,23 +243,6 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		operators, err = eh.nodeStorage.ListOperators(nil, 0, 0)
 		require.NoError(t, err)
 		require.Equal(t, len(ops), len(operators))
-
-		// Check if operators in the storage have same attributes
-		for _, log := range block.Logs {
-			operatorAddedEvent, err := contractFilterer.ParseOperatorAdded(log)
-			require.NoError(t, err)
-			fmt.Println(operatorAddedEvent)
-
-			//data, _, err := eh.nodeStorage.GetOperatorData(nil, operatorAddedEvent.OperatorId)
-			//require.NoError(t, err)
-			//require.Equal(t, operatorAddedEvent.OperatorId, data.ID)
-			//require.Equal(t, operatorAddedEvent.Owner, data.OwnerAddress)
-			//
-			//encodedPubKey, err := ops[i].privateKey.Public().Base64()
-			//require.NoError(t, err)
-			//
-			//require.Equal(t, encodedPubKey, data.PublicKey)
-		}
 	})
 
 	t.Run("test OperatorRemoved event handle", func(t *testing.T) {

--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -220,7 +220,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				Owner:      testAddr,
 				PublicKey:  encodedPubKey,
 			})
-			require.ErrorContains(t, err, "operator registered with the same operator public key")
+			require.ErrorContains(t, err, "operator public key already exists")
 
 			// check no operators were added
 			operators, err = eh.nodeStorage.ListOperators(nil, 0, 0)
@@ -247,7 +247,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				Owner:      testAddr,
 				PublicKey:  encodedPubKey,
 			})
-			require.ErrorContains(t, err, "operator registered with the same ID")
+			require.ErrorContains(t, err, "operator ID already exists")
 
 			// check no operators were added
 			operators, err = eh.nodeStorage.ListOperators(nil, 0, 0)

--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -206,7 +206,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		t.Run("test OperatorAdded event handle with the same pubkey, but with a different id", func(t *testing.T) {
 			op := &testOperator{}
 			op.privateKey = ops[2].privateKey
-			op.id = 5
+			op.id = 8
 
 			encodedPubKey, err := op.privateKey.Public().Base64()
 			require.NoError(t, err)
@@ -216,7 +216,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.Equal(t, len(ops), len(operators))
 
 			err = eh.handleOperatorAdded(nil, &contract.ContractOperatorAdded{
-				OperatorId: ops[1].id,
+				OperatorId: op.id,
 				Owner:      testAddr,
 				PublicKey:  encodedPubKey,
 			})
@@ -243,11 +243,11 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.Equal(t, len(ops), len(operators))
 
 			err = eh.handleOperatorAdded(nil, &contract.ContractOperatorAdded{
-				OperatorId: ops[1].id,
+				OperatorId: op.id,
 				Owner:      testAddr,
 				PublicKey:  encodedPubKey,
 			})
-			require.ErrorContains(t, err, "operator registered with the same operator public key")
+			require.ErrorContains(t, err, "operator registered with the same ID")
 
 			// check no operators were added
 			operators, err = eh.nodeStorage.ListOperators(nil, 0, 0)

--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -202,49 +202,92 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		}
 	})
 
-	t.Run("test OperatorAdded event handle with the same pubkey, but with a different id", func(t *testing.T) {
-		op := &testOperator{}
-		op.id = 5
-		op.privateKey = ops[1].privateKey
+	t.Run("test OperatorAdded event fails for same event data", func(t *testing.T) {
+		t.Run("test OperatorAdded event handle with the same pubkey, but with a different id", func(t *testing.T) {
+			op := &testOperator{}
+			op.id = 5
+			op.privateKey = ops[1].privateKey
 
-		encodedPubKey, err := op.privateKey.Public().Base64()
-		require.NoError(t, err)
+			encodedPubKey, err := op.privateKey.Public().Base64()
+			require.NoError(t, err)
 
-		// Call the contract method
-		packedOperatorPubKey, err := eventparser.PackOperatorPublicKey(encodedPubKey)
-		require.NoError(t, err)
-		_, err = boundContract.SimcontractTransactor.RegisterOperator(auth, packedOperatorPubKey, big.NewInt(100_000_000))
-		require.NoError(t, err)
+			// Call the contract method
+			packedOperatorPubKey, err := eventparser.PackOperatorPublicKey(encodedPubKey)
+			require.NoError(t, err)
+			_, err = boundContract.SimcontractTransactor.RegisterOperator(auth, packedOperatorPubKey, big.NewInt(100_000_000))
+			require.NoError(t, err)
 
-		sim.Commit()
+			sim.Commit()
 
-		block := <-logs
-		require.NotEmpty(t, block.Logs)
-		require.Equal(t, ethcommon.HexToHash("0xd839f31c14bd632f424e307b36abff63ca33684f77f28e35dc13718ef338f7f4"), block.Logs[0].Topics[0])
+			block := <-logs
+			require.NotEmpty(t, block.Logs)
+			require.Equal(t, ethcommon.HexToHash("0xd839f31c14bd632f424e307b36abff63ca33684f77f28e35dc13718ef338f7f4"), block.Logs[0].Topics[0])
 
-		eventsCh := make(chan executionclient.BlockLogs)
-		go func() {
-			defer close(eventsCh)
-			eventsCh <- block
-		}()
+			eventsCh := make(chan executionclient.BlockLogs)
+			go func() {
+				defer close(eventsCh)
+				eventsCh <- block
+			}()
 
-		// Check that there is no registered operators
-		operators, err := eh.nodeStorage.ListOperators(nil, 0, 0)
-		require.NoError(t, err)
-		require.Equal(t, len(ops), len(operators))
+			// Check that there is no registered operators
+			operators, err := eh.nodeStorage.ListOperators(nil, 0, 0)
+			require.NoError(t, err)
+			require.Equal(t, len(ops), len(operators))
 
-		// Handle the event
-		lastProcessedBlock, err := eh.HandleBlockEventsStream(eventsCh, false)
-		require.Equal(t, blockNum+1, lastProcessedBlock)
-		require.NoError(t, err)
-		blockNum++
+			// Handle the event
+			lastProcessedBlock, err := eh.HandleBlockEventsStream(eventsCh, false)
+			require.Equal(t, blockNum+1, lastProcessedBlock)
+			require.NoError(t, err)
+			blockNum++
 
-		// Check storage for the new operators
-		operators, err = eh.nodeStorage.ListOperators(nil, 0, 0)
-		require.NoError(t, err)
-		require.Equal(t, len(ops), len(operators))
+			// Check storage for the new operators
+			operators, err = eh.nodeStorage.ListOperators(nil, 0, 0)
+			require.NoError(t, err)
+			require.Equal(t, len(ops), len(operators))
+		})
+		t.Run("test OperatorAdded event handle with same id", func(t *testing.T) {
+			op := &testOperator{}
+			op.id = ops[1].id
+			op.privateKey = ops[2].privateKey
+
+			encodedPubKey, err := op.privateKey.Public().Base64()
+			require.NoError(t, err)
+
+			// Call the contract method
+			packedOperatorPubKey, err := eventparser.PackOperatorPublicKey(encodedPubKey)
+			require.NoError(t, err)
+			_, err = boundContract.SimcontractTransactor.RegisterOperator(auth, packedOperatorPubKey, big.NewInt(100_000_000))
+			require.NoError(t, err)
+
+			sim.Commit()
+
+			block := <-logs
+			require.NotEmpty(t, block.Logs)
+			require.Equal(t, ethcommon.HexToHash("0xd839f31c14bd632f424e307b36abff63ca33684f77f28e35dc13718ef338f7f4"), block.Logs[0].Topics[0])
+
+			eventsCh := make(chan executionclient.BlockLogs)
+			go func() {
+				defer close(eventsCh)
+				eventsCh <- block
+			}()
+
+			// Check that there is no registered operators
+			operators, err := eh.nodeStorage.ListOperators(nil, 0, 0)
+			require.NoError(t, err)
+			require.Equal(t, len(ops), len(operators))
+
+			// Handle the event
+			lastProcessedBlock, err := eh.HandleBlockEventsStream(eventsCh, false)
+			require.Equal(t, blockNum+1, lastProcessedBlock)
+			require.NoError(t, err)
+			blockNum++
+
+			// Check storage for the new operators
+			operators, err = eh.nodeStorage.ListOperators(nil, 0, 0)
+			require.NoError(t, err)
+			require.Equal(t, len(ops), len(operators))
+		})
 	})
-
 	t.Run("test OperatorRemoved event handle", func(t *testing.T) {
 
 		// Should return MalformedEventError and no changes to the state

--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -25,12 +25,13 @@ import (
 const encryptedKeyLength = 256
 
 var (
-	ErrAlreadyRegistered            = fmt.Errorf("operator registered with the same operator public key")
-	ErrOperatorDataNotFound         = fmt.Errorf("operator data not found")
-	ErrIncorrectSharesLength        = fmt.Errorf("shares length is not correct")
-	ErrSignatureVerification        = fmt.Errorf("signature verification failed")
-	ErrShareBelongsToDifferentOwner = fmt.Errorf("share already exists and belongs to different owner")
-	ErrValidatorShareNotFound       = fmt.Errorf("validator share not found")
+	ErrAlreadyRegisteredWithSamePubkey = fmt.Errorf("operator registered with the same operator public key")
+	ErrAlreadyRegisteredWithSameId     = fmt.Errorf("operator registered with the same ID")
+	ErrOperatorDataNotFound            = fmt.Errorf("operator data not found")
+	ErrIncorrectSharesLength           = fmt.Errorf("shares length is not correct")
+	ErrSignatureVerification           = fmt.Errorf("signature verification failed")
+	ErrShareBelongsToDifferentOwner    = fmt.Errorf("share already exists and belongs to different owner")
+	ErrValidatorShareNotFound          = fmt.Errorf("validator share not found")
 )
 
 // TODO: make sure all handlers are tested properly:
@@ -60,7 +61,7 @@ func (eh *EventHandler) handleOperatorAdded(txn basedb.Txn, event *contract.Cont
 	if existsById {
 		logger.Warn("malformed event: operator registered with ID",
 			zap.Uint64("expected_operator_id", event.OperatorId))
-		return &MalformedEventError{Err: ErrAlreadyRegistered}
+		return &MalformedEventError{Err: ErrAlreadyRegisteredWithSameId}
 	}
 
 	// throw an error if there is an existing operator with the same public key
@@ -71,7 +72,7 @@ func (eh *EventHandler) handleOperatorAdded(txn basedb.Txn, event *contract.Cont
 	if foundByPubKey && operatorData.ID != 0 && bytes.Equal(operatorData.PublicKey, event.PublicKey) && operatorData.ID != event.OperatorId {
 		logger.Warn("malformed event: operator registered with the same operator public key",
 			zap.Uint64("expected_operator_id", operatorData.ID))
-		return &MalformedEventError{Err: ErrAlreadyRegistered}
+		return &MalformedEventError{Err: ErrAlreadyRegisteredWithSamePubkey}
 	}
 
 	exists, err := eh.nodeStorage.SaveOperatorData(txn, od)

--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -64,7 +64,6 @@ func (eh *EventHandler) handleOperatorAdded(txn basedb.Txn, event *contract.Cont
 		return &MalformedEventError{Err: ErrAlreadyRegistered}
 	}
 
-	// TODO: consider saving other operators as well
 	exists, err := eh.nodeStorage.SaveOperatorData(txn, od)
 	if err != nil {
 		return fmt.Errorf("save operator data: %w", err)

--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -54,7 +54,11 @@ func (eh *EventHandler) handleOperatorAdded(txn basedb.Txn, event *contract.Cont
 
 	// throw an error if there is an existing operator with the same public key and different operator id
 	operatorData := eh.operatorDataStore.GetOperatorData()
-	if operatorData.ID != 0 && bytes.Equal(operatorData.PublicKey, event.PublicKey) && operatorData.ID != event.OperatorId {
+	_, found, err := eh.nodeStorage.GetOperatorDataByPubKey(txn, event.PublicKey)
+	if err != nil {
+		return fmt.Errorf("could not get operator data by public key: %w", err)
+	}
+	if found || operatorData.ID != 0 && bytes.Equal(operatorData.PublicKey, event.PublicKey) && operatorData.ID != event.OperatorId {
 		logger.Warn("malformed event: operator registered with the same operator public key",
 			zap.Uint64("expected_operator_id", operatorData.ID))
 		return &MalformedEventError{Err: ErrAlreadyRegistered}

--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -53,12 +53,11 @@ func (eh *EventHandler) handleOperatorAdded(txn basedb.Txn, event *contract.Cont
 	}
 
 	// throw an error if there is an existing operator with the same public key and different operator id
-	operatorData := eh.operatorDataStore.GetOperatorData()
-	_, found, err := eh.nodeStorage.GetOperatorDataByPubKey(txn, event.PublicKey)
+	operatorData, found, err := eh.nodeStorage.GetOperatorDataByPubKey(txn, event.PublicKey)
 	if err != nil {
 		return fmt.Errorf("could not get operator data by public key: %w", err)
 	}
-	if found || operatorData.ID != 0 && bytes.Equal(operatorData.PublicKey, event.PublicKey) && operatorData.ID != event.OperatorId {
+	if found && operatorData.ID != 0 && bytes.Equal(operatorData.PublicKey, event.PublicKey) && operatorData.ID != event.OperatorId {
 		logger.Warn("malformed event: operator registered with the same operator public key",
 			zap.Uint64("expected_operator_id", operatorData.ID))
 		return &MalformedEventError{Err: ErrAlreadyRegistered}
@@ -73,7 +72,7 @@ func (eh *EventHandler) handleOperatorAdded(txn basedb.Txn, event *contract.Cont
 		return nil
 	}
 
-	if bytes.Equal(event.PublicKey, operatorData.PublicKey) {
+	if bytes.Equal(event.PublicKey, eh.operatorDataStore.GetOperatorData().PublicKey) {
 		eh.operatorDataStore.SetOperatorData(od)
 		logger = logger.With(zap.Bool("own_operator", true))
 	}

--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -65,11 +65,11 @@ func (eh *EventHandler) handleOperatorAdded(txn basedb.Txn, event *contract.Cont
 	}
 
 	// throw an error if there is an existing operator with the same public key
-	operatorData, foundByPubKey, err := eh.nodeStorage.GetOperatorDataByPubKey(txn, event.PublicKey)
+	operatorData, pubkeyExists, err := eh.nodeStorage.GetOperatorDataByPubKey(txn, event.PublicKey)
 	if err != nil {
 		return fmt.Errorf("could not get operator data by public key: %w", err)
 	}
-	if foundByPubKey && operatorData.ID != 0 && bytes.Equal(operatorData.PublicKey, event.PublicKey) && operatorData.ID != event.OperatorId {
+	if pubkeyExists {
 		logger.Warn("malformed event: operator public key already exists",
 			fields.OperatorPubKey(operatorData.PublicKey))
 		return &MalformedEventError{Err: ErrOperatorPubkeyAlreadyExists}


### PR DESCRIPTION
## Description

Adde verification mechanism to ensure the uniqueness of the operator's public key and ID


### Validation flow

Handling OperatorAdded event we now check:
- there is no operator in storage with the same ID (otherwise throwing `ErrAlreadyRegisteredWithSameId`)
- there is no operator in storage with the same pubkey (otherwise throwing `ErrAlreadyRegisteredWithSamePubkey`)

