### PR TITLE
alan testnet: disable protocol ID & set fork epochs

### DIFF
--- a/network/discovery/options.go
+++ b/network/discovery/options.go
@@ -16,8 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/discover"
 )
 
-var SSVProtocolID = [6]byte{'s', 's', 'v', 'd', 'v', '5'}
-
 // DiscV5Options for creating a new discv5 listener
 type DiscV5Options struct {
 	// StoragePath is the path used to store the DB (DHT)
@@ -88,8 +86,7 @@ func (opts *DiscV5Options) IPs() (net.IP, net.IP, string) {
 // DiscV5Cfg creates discv5 config from the options
 func (opts *DiscV5Options) DiscV5Cfg(logger *zap.Logger) (*discover.Config, error) {
 	dv5Cfg := discover.Config{
-		PrivateKey:   opts.NetworkKey,
-		V5ProtocolID: &SSVProtocolID,
+		PrivateKey: opts.NetworkKey,
 	}
 	if len(opts.Bootnodes) > 0 {
 		bootnodes, err := ParseENR(nil, false, opts.Bootnodes...)

--- a/networkconfig/holesky.go
+++ b/networkconfig/holesky.go
@@ -14,6 +14,7 @@ var Holesky = NetworkConfig{
 	GenesisDomainType:    spectypes.DomainType{0x0, 0x0, 0x5, 0x1},
 	AlanDomainType:       spectypes.DomainType{0x0, 0x0, 0x5, 0x2},
 	GenesisEpoch:         1,
+	AlanForkEpoch:        84600, // Oct-08-2024 12:00:00 PM UTC
 	RegistrySyncOffset:   new(big.Int).SetInt64(181612),
 	RegistryContractAddr: "0x38A4794cCEd47d3baf7370CcC43B560D3a1beEFA",
 	Bootnodes: []string{

--- a/networkconfig/mainnet.go
+++ b/networkconfig/mainnet.go
@@ -14,6 +14,7 @@ var Mainnet = NetworkConfig{
 	GenesisDomainType:    spectypes.GenesisMainnet,
 	AlanDomainType:       spectypes.AlanMainnet,
 	GenesisEpoch:         218450,
+	AlanForkEpoch:        9999999999,
 	RegistrySyncOffset:   new(big.Int).SetInt64(17507487),
 	RegistryContractAddr: "0xDD9BC35aE942eF0cFa76930954a156B3fF30a4E1",
 	Bootnodes: []string{

--- a/utils/boot_node/node.go
+++ b/utils/boot_node/node.go
@@ -24,8 +24,6 @@ import (
 	"github.com/ssvlabs/ssv/utils"
 )
 
-var SSVProtocolID = [6]byte{'s', 's', 'v', 'd', 'v', '5'}
-
 // Options contains options to create the node
 type Options struct {
 	PrivateKey string `yaml:"PrivateKey" env:"BOOT_NODE_PRIVATE_KEY" env-description:"boot node private key (default will generate new)"`
@@ -103,8 +101,7 @@ func (n *bootNode) Start(ctx context.Context, logger *zap.Logger) error {
 		log.Fatal("Failed to get p2p privateKey", zap.Error(err))
 	}
 	cfg := discover.Config{
-		PrivateKey:   privKey,
-		V5ProtocolID: &SSVProtocolID,
+		PrivateKey: privKey,
 	}
 	ipAddr, err := network.ExternalIP()
 	// ipAddr = "127.0.0.1"


### PR DESCRIPTION
### Description

This PR:
- Disables `ProtocolID` for the testnet release ( in both node and bootnode)
- Sets the fork epoch of `holesky` testnet to 84600, // Oct-08-2024 12:00:00 PM UTC
- Sets `mainnet `fork epoch in the far future to avoid mistakes and to enable margin if we eventually change the date.