### PR TITLE
fix: msg validation dutyid set before slot

### DIFF
--- a/message/validation/logger_fields.go
+++ b/message/validation/logger_fields.go
@@ -69,10 +69,6 @@ func (mv *messageValidator) buildLoggerFields(decodedMessage *queue.SSVMessage) 
 	descriptor.Role = decodedMessage.SSVMessage.GetID().GetRoleType()
 	descriptor.SSVMessageType = decodedMessage.SSVMessage.GetType()
 
-	if mv.logger.Level() == zap.DebugLevel {
-		mv.addDutyIDField(descriptor)
-	}
-
 	switch m := decodedMessage.Body.(type) {
 	case *specqbft.Message:
 		if m != nil {
@@ -84,6 +80,10 @@ func (mv *messageValidator) buildLoggerFields(decodedMessage *queue.SSVMessage) 
 		if m != nil {
 			descriptor.Slot = m.Slot
 		}
+	}
+
+	if mv.logger.Level() == zap.DebugLevel {
+		mv.addDutyIDField(descriptor)
 	}
 
 	return descriptor


### PR DESCRIPTION
### Description

Setting the dutyID before we know the slot resulted in zeros in slot and epoch. this moves it forward so its set correctly.