### PR TITLE
fix: (bug) geth won't recognize ecdsa curve

### DIFF
--- a/network/commons/keys.go
+++ b/network/commons/keys.go
@@ -5,6 +5,7 @@ import (
 	crand "crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+
 	gcrypto "github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/btcsuite/btcd/btcec/v2"

--- a/network/commons/keys.go
+++ b/network/commons/keys.go
@@ -5,6 +5,7 @@ import (
 	crand "crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	gcrypto "github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -20,8 +21,9 @@ func ECDSAPrivFromInterface(privkey crypto.PrivKey) (*ecdsa.PrivateKey, error) {
 	}
 
 	privKey, _ := btcec.PrivKeyFromBytes(rawKey)
-
-	return privKey.ToECDSA(), nil
+	ecdsaKey := privKey.ToECDSA()
+	ecdsaKey.Curve = gcrypto.S256() // temporary hack, so libp2p Secp256k1 is recognized as geth Secp256k1 in disc v5.1
+	return ecdsaKey, nil
 }
 
 // ECDSAPrivToInterface converts ecdsa.PrivateKey to crypto.PrivKey

--- a/network/commons/keys_test.go
+++ b/network/commons/keys_test.go
@@ -1,10 +1,10 @@
 package commons
 
 import (
-	"crypto/ecdsa"
 	"encoding/hex"
 	"testing"
 
+	gcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/stretchr/testify/require"
 )
@@ -22,11 +22,12 @@ func TestECDSAPrivFromInterface(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ecdsaPrivKey)
 
-	require.IsType(t, &ecdsa.PrivateKey{}, ecdsaPrivKey)
-	require.NotNil(t, ecdsaPrivKey.D)
-	require.NotNil(t, ecdsaPrivKey.X)
-	require.NotNil(t, ecdsaPrivKey.Y)
-	require.NotNil(t, ecdsaPrivKey.Curve)
-
 	require.Equal(t, ecdsaPrivKey.D.String(), "6792055902439951130224479433662882604105028919500185693322687975860017874966")
+	require.Equal(t, ecdsaPrivKey.X.String(), "22653320514410971312249902166871933285664081749262857866749567141267477006697")
+	require.Equal(t, ecdsaPrivKey.Y.String(), "103853204202400939811590846319591563498962634102053730872842929232997685705657")
+	require.Equal(t, ecdsaPrivKey.Curve, gcrypto.S256())
+
+	require.Equal(t, ecdsaPrivKey.PublicKey.X.String(), "22653320514410971312249902166871933285664081749262857866749567141267477006697")
+	require.Equal(t, ecdsaPrivKey.PublicKey.Y.String(), "103853204202400939811590846319591563498962634102053730872842929232997685705657")
+	require.Equal(t, ecdsaPrivKey.PublicKey.Curve, gcrypto.S256())
 }

--- a/protocol/genesis/qbft/instance/prepare.go
+++ b/protocol/genesis/qbft/instance/prepare.go
@@ -59,7 +59,7 @@ func (i *Instance) uponPrepare(logger *zap.Logger, signedPrepare *genesisspecqbf
 
 	logger.Debug("📢 broadcasting commit message",
 		fields.Round(specqbft.Round(i.State.Round)),
-		zap.Any("commit_singers", commitMsg.Signers),
+		zap.Any("commit_signers", commitMsg.Signers),
 		fields.Root(commitMsg.Message.Root))
 
 	if err := i.Broadcast(logger, commitMsg); err != nil {

--- a/protocol/v2/qbft/instance/prepare.go
+++ b/protocol/v2/qbft/instance/prepare.go
@@ -56,7 +56,7 @@ func (i *Instance) uponPrepare(logger *zap.Logger, msg *specqbft.ProcessingMessa
 
 	logger.Debug("📢 broadcasting commit message",
 		fields.Round(i.State.Round),
-		zap.Any("commit_singers", commitMsg.OperatorIDs),
+		zap.Any("commit_signers", commitMsg.OperatorIDs),
 		fields.Root(proposedRoot))
 
 	if err := i.Broadcast(logger, commitMsg); err != nil {


### PR DESCRIPTION
### Description 

We changed the way we read `Secp256k1PrivateKey` (#1734) to use `btcec`, but we skipped the "hack" that was instilled to make geth's discv5 be able to use our keys. this caused an issue where we would not do discovery, resulting in no peers and no duties.

### Fix

Keep using new method but enforce the curve geth requires.

### TODO
- [x] - add unit tests