### PR TITLE
fix: committee role duty limit

### DIFF
--- a/message/validation/common_checks.go
+++ b/message/validation/common_checks.go
@@ -64,7 +64,7 @@ func (mv *messageValidator) validateDutyCount(
 		return nil
 	}
 
-	if dutyCount > dutyLimit {
+	if dutyCount >= dutyLimit {
 		err := ErrTooManyDutiesPerEpoch
 		err.got = fmt.Sprintf("%v (role %v)", dutyCount, msgID.GetRoleType())
 		err.want = fmt.Sprintf("less than %v", dutyLimit)

--- a/message/validation/common_checks.go
+++ b/message/validation/common_checks.go
@@ -54,17 +54,17 @@ func (mv *messageValidator) messageLateness(slot phase0.Slot, role spectypes.Run
 func (mv *messageValidator) validateDutyCount(
 	msgID spectypes.MessageID,
 	msgSlot phase0.Slot,
-	validatorIndexCount int,
+	validatorIndices []phase0.ValidatorIndex,
 	signerStateBySlot *OperatorState,
 ) error {
 	dutyCount := signerStateBySlot.DutyCount(mv.netCfg.Beacon.EstimatedEpochAtSlot(msgSlot))
 
-	dutyLimit, exists := mv.dutyLimit(msgID, msgSlot, validatorIndexCount)
+	dutyLimit, exists := mv.dutyLimit(msgID, msgSlot, validatorIndices)
 	if !exists {
 		return nil
 	}
 
-	if dutyCount >= dutyLimit {
+	if dutyCount > dutyLimit {
 		err := ErrTooManyDutiesPerEpoch
 		err.got = fmt.Sprintf("%v (role %v)", dutyCount, msgID.GetRoleType())
 		err.want = fmt.Sprintf("less than %v", dutyLimit)
@@ -74,7 +74,7 @@ func (mv *messageValidator) validateDutyCount(
 	return nil
 }
 
-func (mv *messageValidator) dutyLimit(msgID spectypes.MessageID, slot phase0.Slot, validatorIndexCount int) (int, bool) {
+func (mv *messageValidator) dutyLimit(msgID spectypes.MessageID, slot phase0.Slot, validatorIndices []phase0.ValidatorIndex) (int, bool) {
 	switch msgID.GetRoleType() {
 	case spectypes.RoleVoluntaryExit:
 		pk := phase0.BLSPubKey{}
@@ -86,7 +86,24 @@ func (mv *messageValidator) dutyLimit(msgID spectypes.MessageID, slot phase0.Slo
 		return 2, true
 
 	case spectypes.RoleCommittee:
-		return 2 * validatorIndexCount, true
+		validatorIndexCount := len(validatorIndices)
+		slotsPerEpoch := int(mv.netCfg.Beacon.SlotsPerEpoch())
+
+		// Skip duty search if validators * 2 exceeds slots per epoch,
+		// as the maximum duties per epoch is capped at the number of slots.
+		// This avoids unnecessary checks.
+		if validatorIndexCount < slotsPerEpoch/2 {
+			// Check if there is at least one validator in the sync committee.
+			// If so, the duty limit is equal to the number of slots per epoch.
+			period := mv.netCfg.Beacon.EstimatedSyncCommitteePeriodAtEpoch(mv.netCfg.Beacon.EstimatedEpochAtSlot(slot))
+			for _, i := range validatorIndices {
+				if mv.dutyStore.SyncCommittee.Duty(period, i) != nil {
+					return slotsPerEpoch, true
+				}
+			}
+		}
+
+		return min(slotsPerEpoch, 2*validatorIndexCount), true
 
 	default:
 		return 0, false

--- a/message/validation/common_checks.go
+++ b/message/validation/common_checks.go
@@ -64,6 +64,9 @@ func (mv *messageValidator) validateDutyCount(
 		return nil
 	}
 
+	// Check if the duty count exceeds or equals the duty limit.
+	// This validation occurs before the state is updated, which is why
+	// the first count starts at 0 and we use an inclusive comparison (>=).
 	if dutyCount >= dutyLimit {
 		err := ErrTooManyDutiesPerEpoch
 		err.got = fmt.Sprintf("%v (role %v)", dutyCount, msgID.GetRoleType())

--- a/message/validation/consensus_validation.go
+++ b/message/validation/consensus_validation.go
@@ -268,7 +268,7 @@ func (mv *messageValidator) validateQBFTMessageByDutyLogic(
 	// - else, accept
 	for _, signer := range signedSSVMessage.OperatorIDs {
 		signerStateBySlot := state.GetOrCreate(signer)
-		if err := mv.validateDutyCount(signedSSVMessage.SSVMessage.GetID(), msgSlot, len(validatorIndices), signerStateBySlot); err != nil {
+		if err := mv.validateDutyCount(signedSSVMessage.SSVMessage.GetID(), msgSlot, validatorIndices, signerStateBySlot); err != nil {
 			return err
 		}
 	}

--- a/message/validation/partial_validation.go
+++ b/message/validation/partial_validation.go
@@ -180,15 +180,15 @@ func (mv *messageValidator) validatePartialSigMessagesByDutyLogic(
 		return err
 	}
 
-	clusterValidatorCount := len(committeeInfo.indices)
 	// Rule: valid number of duties per epoch:
 	// - 2 for aggregation, voluntary exit and validator registration
 	// - 2*V for Committee duty (where V is the number of validators in the cluster) (if no validator is doing sync committee in this epoch)
 	// - else, accept
-	if err := mv.validateDutyCount(signedSSVMessage.SSVMessage.GetID(), messageSlot, clusterValidatorCount, signerStateBySlot); err != nil {
+	if err := mv.validateDutyCount(signedSSVMessage.SSVMessage.GetID(), messageSlot, committeeInfo.indices, signerStateBySlot); err != nil {
 		return err
 	}
 
+	clusterValidatorCount := len(committeeInfo.indices)
 	partialSignatureMessageCount := len(partialSignatureMessages.Messages)
 
 	if signedSSVMessage.SSVMessage.MsgID.GetRoleType() == spectypes.RoleCommittee {

--- a/protocol/genesis/qbft/instance/prepare.go
+++ b/protocol/genesis/qbft/instance/prepare.go
@@ -59,7 +59,7 @@ func (i *Instance) uponPrepare(logger *zap.Logger, signedPrepare *genesisspecqbf
 
 	logger.Debug("📢 broadcasting commit message",
 		fields.Round(specqbft.Round(i.State.Round)),
-		zap.Any("commit_singers", commitMsg.Signers),
+		zap.Any("commit_signers", commitMsg.Signers),
 		fields.Root(commitMsg.Message.Root))
 
 	if err := i.Broadcast(logger, commitMsg); err != nil {

--- a/protocol/v2/qbft/instance/prepare.go
+++ b/protocol/v2/qbft/instance/prepare.go
@@ -56,7 +56,7 @@ func (i *Instance) uponPrepare(logger *zap.Logger, msg *specqbft.ProcessingMessa
 
 	logger.Debug("📢 broadcasting commit message",
 		fields.Round(i.State.Round),
-		zap.Any("commit_singers", commitMsg.OperatorIDs),
+		zap.Any("commit_signers", commitMsg.OperatorIDs),
 		fields.Root(proposedRoot))
 
 	if err := i.Broadcast(logger, commitMsg); err != nil {


### PR DESCRIPTION
This PR fixes the committee role's duty limit by ensuring that unnecessary duty checks are skipped when the number of validators is high. It adjusts duty limit calculations and ensures proper checks for the sync committee based on validator count.