### PR TITLE
fix: (validation) duty count check

### DIFF
--- a/message/validation/common_checks.go
+++ b/message/validation/common_checks.go
@@ -67,7 +67,7 @@ func (mv *messageValidator) validateDutyCount(
 	// Check if the duty count exceeds or equals the duty limit.
 	// This validation occurs before the state is updated, which is why
 	// the first count starts at 0 and we use an inclusive comparison (>=).
-	if dutyCount >= dutyLimit {
+	if dutyCount > dutyLimit {
 		err := ErrTooManyDutiesPerEpoch
 		err.got = fmt.Sprintf("%v (role %v)", dutyCount, msgID.GetRoleType())
 		err.want = fmt.Sprintf("less than %v", dutyLimit)

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -572,22 +572,30 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		identifier := spectypes.NewMsgID(netCfg.DomainType(), ks.ValidatorPK.Serialize(), role)
 		signedSSVMessage := generateSignedMessage(ks, identifier, slot)
 
+		// First duty.
 		topicID := commons.CommitteeTopicID(committeeID)[0]
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, netCfg.Beacon.GetSlotStartTime(slot))
 		require.NoError(t, err)
 
+		// Second duty.
 		signedSSVMessage = generateSignedMessage(ks, identifier, slot+4)
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, netCfg.Beacon.GetSlotStartTime(slot+4))
 		require.NoError(t, err)
 
+		// Second duty (another message).
 		signedSSVMessage = generateSignedMessage(ks, identifier, slot+4, func(qbftMessage *specqbft.Message) {
 			qbftMessage.MsgType = specqbft.RoundChangeMsgType
 		})
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, netCfg.Beacon.GetSlotStartTime(slot+4))
 		require.NoError(t, err)
+
+		// Third duty.
+		// TODO: this should fail, see https://github.com/ssvlabs/ssv/pull/1758
 		signedSSVMessage = generateSignedMessage(ks, identifier, slot+8)
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, netCfg.Beacon.GetSlotStartTime(slot+8))
 		require.NoError(t, err)
+
+		// Third duty (another message).
 		signedSSVMessage = generateSignedMessage(ks, identifier, slot+8, func(qbftMessage *specqbft.Message) {
 			qbftMessage.MsgType = specqbft.RoundChangeMsgType
 		})

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -580,7 +580,17 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, netCfg.Beacon.GetSlotStartTime(slot+4))
 		require.NoError(t, err)
 
+		signedSSVMessage = generateSignedMessage(ks, identifier, slot+4, func(qbftMessage *specqbft.Message) {
+			qbftMessage.MsgType = specqbft.RoundChangeMsgType
+		})
+		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, netCfg.Beacon.GetSlotStartTime(slot+4))
+		require.NoError(t, err)
 		signedSSVMessage = generateSignedMessage(ks, identifier, slot+8)
+		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, netCfg.Beacon.GetSlotStartTime(slot+8))
+		require.NoError(t, err)
+		signedSSVMessage = generateSignedMessage(ks, identifier, slot+8, func(qbftMessage *specqbft.Message) {
+			qbftMessage.MsgType = specqbft.RoundChangeMsgType
+		})
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, netCfg.Beacon.GetSlotStartTime(slot+8))
 		require.ErrorContains(t, err, ErrTooManyDutiesPerEpoch.Error())
 	})


### PR DESCRIPTION
This PR fixes a bug where the first message of the last valid duty is accepted, but then the next messages would be rejected for "too many duties".