### PR TITLE
feat: prevent incompatible version downgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,11 @@ docker-integration-test:
 #Build
 .PHONY: build
 build:
-	CGO_ENABLED=1 go build -o ./bin/ssvnode -ldflags "-X main.Commit=`git rev-parse HEAD` -X main.Version=`git describe --tags $(git rev-list --tags --max-count=1)`" ./cmd/ssvnode/
+	CGO_ENABLED=1 go build -o ./bin/ssvnode \
+	-ldflags "-X main.Commit=`git rev-parse HEAD` \
+	          -X main.Version=${VERSION:-`git describe --tags $(git rev-list --tags --max-count=1)`}" \
+	./cmd/ssvnode/
+
 
 .PHONY: start-node
 start-node:

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -432,11 +432,6 @@ func verifyConfig(
 		logger.Fatal("failed to get stored config", zap.Error(err))
 	}
 
-	//// TODO(Aleg) should not fail check what if received latest
-	//if !semver.IsValid(version) {
-	//	logger.Fatal("invalid version format", zap.String("version", version))
-	//}
-
 	currentConfig := &operatorstorage.ConfigLock{
 		NetworkName:      networkName,
 		UsingLocalEvents: usingLocalEvents,

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -104,12 +104,12 @@ var StartNodeCmd = &cobra.Command{
 	Use:   "start-node",
 	Short: "Starts an instance of SSV node",
 	Run: func(cmd *cobra.Command, args []string) {
-		commons.SetBuildData(cmd.Parent().Short, cmd.Parent().Version)
-
 		logger, err := setupGlobal()
 		if err != nil {
 			log.Fatal("could not create logger", err)
 		}
+
+		commons.SetBuildData(logger, cmd.Parent().Short, cmd.Parent().Version)
 
 		defer logging.CapturePanic(logger)
 

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -88,9 +88,11 @@ func Test_verifyConfig(t *testing.T) {
 		require.NoError(t, nodeStorage.SaveConfig(nil, c))
 
 		validVersion := "v0.0.0-test"
-		require.Panics(t, func() {
-			verifyConfig(logger, nodeStorage, testNetworkName, true, validVersion)
-		})
+		require.PanicsWithValue(t,
+			"incompatible config change: invalid stored version format: invalid-version. The database must be removed or reinitialized",
+			func() {
+				verifyConfig(logger, nodeStorage, testNetworkName, true, validVersion)
+			})
 
 		storedConfig, found, err := nodeStorage.GetConfig(nil)
 		require.NoError(t, err)
@@ -152,7 +154,7 @@ func Test_verifyConfig(t *testing.T) {
 		require.NoError(t, nodeStorage.SaveConfig(nil, c))
 
 		require.PanicsWithValue(t,
-			"incompatible config change: can't change network from \"testnet1\" to \"testnet\" in an existing database, it must be removed first",
+			"incompatible config change: network mismatch. Stored network testnet1 does not match current network testnet. The database must be removed or reinitialized",
 			func() { verifyConfig(logger, nodeStorage, testNetworkName, true, testingVersion) },
 		)
 
@@ -173,7 +175,7 @@ func Test_verifyConfig(t *testing.T) {
 		require.NoError(t, nodeStorage.SaveConfig(nil, c))
 
 		require.PanicsWithValue(t,
-			"incompatible config change: can't change network from \"testnet1\" to \"testnet\" in an existing database, it must be removed first",
+			"incompatible config change: network mismatch. Stored network testnet1 does not match current network testnet. The database must be removed or reinitialized",
 			func() { verifyConfig(logger, nodeStorage, testNetworkName, true, testingVersion) },
 		)
 
@@ -194,7 +196,7 @@ func Test_verifyConfig(t *testing.T) {
 		require.NoError(t, nodeStorage.SaveConfig(nil, c))
 
 		require.PanicsWithValue(t,
-			"incompatible config change: can't switch on localevents, database must be removed first",
+			"incompatible config change: enabling local events is not allowed. The database must be removed or reinitialized",
 			func() { verifyConfig(logger, nodeStorage, testNetworkName, true, testingVersion) },
 		)
 
@@ -215,7 +217,7 @@ func Test_verifyConfig(t *testing.T) {
 		require.NoError(t, nodeStorage.SaveConfig(nil, c))
 
 		require.PanicsWithValue(t,
-			"incompatible config change: can't switch off localevents, database must be removed first",
+			"incompatible config change: disabling local events is not allowed. The database must be removed or reinitialized",
 			func() { verifyConfig(logger, nodeStorage, testNetworkName, false, testingVersion) },
 		)
 

--- a/cli/operator/node_test.go
+++ b/cli/operator/node_test.go
@@ -23,13 +23,15 @@ func Test_verifyConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	testNetworkName := networkconfig.TestNetwork.Name
+	testingVersion := "v0.0.0-test"
 
 	t.Run("no config in DB", func(t *testing.T) {
 		c := &operatorstorage.ConfigLock{
 			NetworkName:      testNetworkName,
 			UsingLocalEvents: true,
+			Version:          testingVersion,
 		}
-		verifyConfig(logger, nodeStorage, c.NetworkName, c.UsingLocalEvents)
+		verifyConfig(logger, nodeStorage, c.NetworkName, c.UsingLocalEvents, c.Version)
 
 		storedConfig, found, err := nodeStorage.GetConfig(nil)
 		require.NoError(t, err)
@@ -43,10 +45,11 @@ func Test_verifyConfig(t *testing.T) {
 		c := &operatorstorage.ConfigLock{
 			NetworkName:      testNetworkName,
 			UsingLocalEvents: true,
+			Version:          testingVersion,
 		}
 		require.NoError(t, nodeStorage.SaveConfig(nil, c))
 
-		verifyConfig(logger, nodeStorage, testNetworkName, true)
+		verifyConfig(logger, nodeStorage, testNetworkName, true, testingVersion)
 
 		storedConfig, found, err := nodeStorage.GetConfig(nil)
 		require.NoError(t, err)
@@ -56,16 +59,101 @@ func Test_verifyConfig(t *testing.T) {
 		require.NoError(t, nodeStorage.DeleteConfig(nil))
 	})
 
+	t.Run("has different version in DB", func(t *testing.T) {
+		c := &operatorstorage.ConfigLock{
+			NetworkName:      testNetworkName,
+			UsingLocalEvents: true,
+			Version:          "v0.0.0-old", // Different version in the DB
+		}
+		require.NoError(t, nodeStorage.SaveConfig(nil, c))
+
+		// Expect that the version is updated when it differs from the one in DB
+		newVersion := "v0.0.0-new"
+		verifyConfig(logger, nodeStorage, testNetworkName, true, newVersion)
+
+		storedConfig, found, err := nodeStorage.GetConfig(nil)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, newVersion, storedConfig.Version) // Ensure version was updated
+
+		require.NoError(t, nodeStorage.DeleteConfig(nil))
+	})
+
+	t.Run("has invalid version in DB", func(t *testing.T) {
+		c := &operatorstorage.ConfigLock{
+			NetworkName:      testNetworkName,
+			UsingLocalEvents: true,
+			Version:          "invalid-version", // Invalid version format
+		}
+		require.NoError(t, nodeStorage.SaveConfig(nil, c))
+
+		validVersion := "v0.0.0-test"
+		require.Panics(t, func() {
+			verifyConfig(logger, nodeStorage, testNetworkName, true, validVersion)
+		})
+
+		storedConfig, found, err := nodeStorage.GetConfig(nil)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, c, storedConfig)
+
+		require.NoError(t, nodeStorage.DeleteConfig(nil))
+	})
+
+	t.Run("version downgrade detected (failure)", func(t *testing.T) {
+		c := &operatorstorage.ConfigLock{
+			NetworkName:      testNetworkName,
+			UsingLocalEvents: true,
+			Version:          "v2.0.0", // Stored version has a higher major version
+		}
+		require.NoError(t, nodeStorage.SaveConfig(nil, c))
+
+		// Attempt to run with a lower major version (e.g., v1.0.0)
+		require.PanicsWithValue(t,
+			"incompatible config change: downgrade detected. Current version v1.0.0 (major: v1) is lower than stored version v2.0.0 (major: v2)",
+			func() {
+				verifyConfig(logger, nodeStorage, testNetworkName, true, "v1.0.0")
+			},
+		)
+
+		storedConfig, found, err := nodeStorage.GetConfig(nil)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, c, storedConfig)
+
+		require.NoError(t, nodeStorage.DeleteConfig(nil))
+	})
+
+	t.Run("version upgrade detected (success)", func(t *testing.T) {
+		c := &operatorstorage.ConfigLock{
+			NetworkName:      testNetworkName,
+			UsingLocalEvents: true,
+			Version:          "v1.0.0", // Stored version has a lower major version
+		}
+		require.NoError(t, nodeStorage.SaveConfig(nil, c))
+
+		// Attempt to run with a higher major version (e.g., v2.0.0)
+		verifyConfig(logger, nodeStorage, testNetworkName, true, "v2.0.0")
+
+		storedConfig, found, err := nodeStorage.GetConfig(nil)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, "v2.0.0", storedConfig.Version) // Ensure the config was updated with the new version
+
+		require.NoError(t, nodeStorage.DeleteConfig(nil))
+	})
+
 	t.Run("has different network name and events type in DB", func(t *testing.T) {
 		c := &operatorstorage.ConfigLock{
 			NetworkName:      testNetworkName + "1",
 			UsingLocalEvents: false,
+			Version:          testingVersion,
 		}
 		require.NoError(t, nodeStorage.SaveConfig(nil, c))
 
 		require.PanicsWithValue(t,
 			"incompatible config change: can't change network from \"testnet1\" to \"testnet\" in an existing database, it must be removed first",
-			func() { verifyConfig(logger, nodeStorage, testNetworkName, true) },
+			func() { verifyConfig(logger, nodeStorage, testNetworkName, true, testingVersion) },
 		)
 
 		storedConfig, found, err := nodeStorage.GetConfig(nil)
@@ -80,12 +168,13 @@ func Test_verifyConfig(t *testing.T) {
 		c := &operatorstorage.ConfigLock{
 			NetworkName:      testNetworkName + "1",
 			UsingLocalEvents: true,
+			Version:          testingVersion,
 		}
 		require.NoError(t, nodeStorage.SaveConfig(nil, c))
 
 		require.PanicsWithValue(t,
 			"incompatible config change: can't change network from \"testnet1\" to \"testnet\" in an existing database, it must be removed first",
-			func() { verifyConfig(logger, nodeStorage, testNetworkName, true) },
+			func() { verifyConfig(logger, nodeStorage, testNetworkName, true, testingVersion) },
 		)
 
 		storedConfig, found, err := nodeStorage.GetConfig(nil)
@@ -100,12 +189,13 @@ func Test_verifyConfig(t *testing.T) {
 		c := &operatorstorage.ConfigLock{
 			NetworkName:      testNetworkName,
 			UsingLocalEvents: false,
+			Version:          testingVersion,
 		}
 		require.NoError(t, nodeStorage.SaveConfig(nil, c))
 
 		require.PanicsWithValue(t,
 			"incompatible config change: can't switch on localevents, database must be removed first",
-			func() { verifyConfig(logger, nodeStorage, testNetworkName, true) },
+			func() { verifyConfig(logger, nodeStorage, testNetworkName, true, testingVersion) },
 		)
 
 		storedConfig, found, err := nodeStorage.GetConfig(nil)
@@ -120,12 +210,13 @@ func Test_verifyConfig(t *testing.T) {
 		c := &operatorstorage.ConfigLock{
 			NetworkName:      testNetworkName,
 			UsingLocalEvents: true,
+			Version:          testingVersion,
 		}
 		require.NoError(t, nodeStorage.SaveConfig(nil, c))
 
 		require.PanicsWithValue(t,
 			"incompatible config change: can't switch off localevents, database must be removed first",
-			func() { verifyConfig(logger, nodeStorage, testNetworkName, false) },
+			func() { verifyConfig(logger, nodeStorage, testNetworkName, false, testingVersion) },
 		)
 
 		storedConfig, found, err := nodeStorage.GetConfig(nil)

--- a/migrations/migration_4_add_version_to_configlock.go
+++ b/migrations/migration_4_add_version_to_configlock.go
@@ -31,8 +31,6 @@ var migration_4_add_version_to_configlock = Migration{
 
 			// If config is found, check if version is missing and update it
 			if config.Version == "" {
-
-				// TODO(Aleg) we need to check for version validity - check what version we receive when running locally
 				config.Version = opt.Version
 
 				// Save the updated config back atomically

--- a/migrations/migration_4_add_version_to_configlock.go
+++ b/migrations/migration_4_add_version_to_configlock.go
@@ -1,0 +1,51 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/storage/basedb"
+)
+
+// This migration adds a version field to the ConfigLock structure
+var migration_4_add_version_to_configlock = Migration{
+	Name: "migration_4_add_version_to_configlock",
+	Run: func(ctx context.Context, logger *zap.Logger, opt Options, key []byte, completed CompletedFunc) error {
+		return opt.Db.Update(func(txn basedb.Txn) error {
+			nodeStorage, err := opt.nodeStorage(logger)
+			if err != nil {
+				return fmt.Errorf("failed to get node storage: %w", err)
+			}
+
+			config, found, err := nodeStorage.GetConfig(txn)
+			if err != nil {
+				return fmt.Errorf("failed to get config: %w", err)
+			}
+
+			// If config is not found, skip the migration
+			if !found {
+				return nil
+			}
+
+			// If config is found, check if version is missing and update it
+			if config.Version == "" {
+
+				// TODO(Aleg) we need to check for version validity - check what version we receive when running locally
+				config.Version = opt.Version
+
+				// Save the updated config back atomically
+				if err := nodeStorage.SaveConfig(txn, config); err != nil {
+					return fmt.Errorf("failed to save config: %w", err)
+				}
+
+				logger.Debug("ConfigLock updated with version", zap.String("version", config.Version))
+			} else if found {
+				logger.Debug("ConfigLock already has version", zap.String("version", config.Version))
+			}
+
+			return completed(txn)
+		})
+	},
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -26,6 +26,7 @@ var (
 		migration_1_example,
 		migration_2_encrypt_shares,
 		migration_3_drop_registry_data,
+		migration_4_add_version_to_configlock,
 	}
 )
 
@@ -56,6 +57,7 @@ type Options struct {
 	NodeStorage operatorstorage.Storage
 	DbPath      string
 	Network     beacon.Network
+	Version     string
 }
 
 // nolint

--- a/operator/storage/config_lock.go
+++ b/operator/storage/config_lock.go
@@ -2,25 +2,41 @@ package storage
 
 import (
 	"fmt"
+
+	"golang.org/x/mod/semver"
 )
 
 type ConfigLock struct {
 	NetworkName      string `json:"network_name"`
 	UsingLocalEvents bool   `json:"using_local_events"`
+	Version          string `json:"version"`
 }
 
-func (stored *ConfigLock) EnsureSameWith(current *ConfigLock) error {
+func (stored *ConfigLock) ValidateCompatibility(current *ConfigLock) error {
+	if !semver.IsValid(stored.Version) {
+		return fmt.Errorf("invalid stored version format: %s. The database must be removed or reinitialized", stored.Version)
+	}
+	if !semver.IsValid(current.Version) {
+		return fmt.Errorf("invalid current version format: %s", current.Version)
+	}
+
+	storedMajor := semver.Major(stored.Version)
+	currentMajor := semver.Major(current.Version)
+
+	if semver.Compare(currentMajor, storedMajor) < 0 {
+		return fmt.Errorf("downgrade detected. Current version %s (major: %s) is lower than stored version %s (major: %s)", current.Version, currentMajor, stored.Version, storedMajor)
+	}
+
 	if stored.NetworkName != current.NetworkName {
-		return fmt.Errorf("can't change network from %q to %q in an existing database, it must be removed first",
-			stored.NetworkName, current.NetworkName)
+		return fmt.Errorf("network mismatch. Stored network %s does not match current network %s. The database must be removed or reinitialized", stored.NetworkName, current.NetworkName)
 	}
 
 	if stored.UsingLocalEvents && !current.UsingLocalEvents {
-		return fmt.Errorf("can't switch off localevents, database must be removed first")
+		return fmt.Errorf("disabling local events is not allowed. The database must be removed or reinitialized")
 	}
 
 	if !stored.UsingLocalEvents && current.UsingLocalEvents {
-		return fmt.Errorf("can't switch on localevents, database must be removed first")
+		return fmt.Errorf("enabling local events is not allowed. The database must be removed or reinitialized")
 	}
 
 	return nil

--- a/operator/storage/config_lock_test.go
+++ b/operator/storage/config_lock_test.go
@@ -18,7 +18,7 @@ func TestConfigLock(t *testing.T) {
 			UsingLocalEvents: true,
 		}
 
-		require.NoError(t, c1.EnsureSameWith(c2))
+		require.NoError(t, c1.ValidateCompatibility(c2))
 	})
 
 	t.Run("all fields are different", func(t *testing.T) {
@@ -32,7 +32,7 @@ func TestConfigLock(t *testing.T) {
 			UsingLocalEvents: false,
 		}
 
-		require.Error(t, c1.EnsureSameWith(c2))
+		require.Error(t, c1.ValidateCompatibility(c2))
 	})
 
 	t.Run("only network name is different", func(t *testing.T) {
@@ -46,7 +46,7 @@ func TestConfigLock(t *testing.T) {
 			UsingLocalEvents: true,
 		}
 
-		require.Error(t, c1.EnsureSameWith(c2))
+		require.Error(t, c1.ValidateCompatibility(c2))
 	})
 
 	t.Run("only local events usage is different", func(t *testing.T) {
@@ -60,6 +60,6 @@ func TestConfigLock(t *testing.T) {
 			UsingLocalEvents: false,
 		}
 
-		require.Error(t, c1.EnsureSameWith(c2))
+		require.Error(t, c1.ValidateCompatibility(c2))
 	})
 }

--- a/operator/storage/config_lock_test.go
+++ b/operator/storage/config_lock_test.go
@@ -11,11 +11,13 @@ func TestConfigLock(t *testing.T) {
 		c1 := &ConfigLock{
 			NetworkName:      "test",
 			UsingLocalEvents: true,
+			Version:          "v0.0.0-test",
 		}
 
 		c2 := &ConfigLock{
 			NetworkName:      "test",
 			UsingLocalEvents: true,
+			Version:          "v0.0.0-test",
 		}
 
 		require.NoError(t, c1.ValidateCompatibility(c2))
@@ -25,11 +27,13 @@ func TestConfigLock(t *testing.T) {
 		c1 := &ConfigLock{
 			NetworkName:      "test",
 			UsingLocalEvents: true,
+			Version:          "v0.0.0-test",
 		}
 
 		c2 := &ConfigLock{
 			NetworkName:      "test2",
 			UsingLocalEvents: false,
+			Version:          "v1.0.0-test",
 		}
 
 		require.Error(t, c1.ValidateCompatibility(c2))
@@ -39,11 +43,13 @@ func TestConfigLock(t *testing.T) {
 		c1 := &ConfigLock{
 			NetworkName:      "test",
 			UsingLocalEvents: true,
+			Version:          "v0.0.0-test",
 		}
 
 		c2 := &ConfigLock{
 			NetworkName:      "test2",
 			UsingLocalEvents: true,
+			Version:          "v0.0.0-test",
 		}
 
 		require.Error(t, c1.ValidateCompatibility(c2))
@@ -53,11 +59,61 @@ func TestConfigLock(t *testing.T) {
 		c1 := &ConfigLock{
 			NetworkName:      "test",
 			UsingLocalEvents: true,
+			Version:          "v0.0.0-test",
 		}
 
 		c2 := &ConfigLock{
 			NetworkName:      "test",
 			UsingLocalEvents: false,
+			Version:          "v0.0.0-test",
+		}
+
+		require.Error(t, c1.ValidateCompatibility(c2))
+	})
+
+	t.Run("only version is different (possible upgrade)", func(t *testing.T) {
+		c1 := &ConfigLock{
+			NetworkName:      "test",
+			UsingLocalEvents: false,
+			Version:          "v0.0.2-test",
+		}
+
+		c2 := &ConfigLock{
+			NetworkName:      "test",
+			UsingLocalEvents: false,
+			Version:          "v0.0.3-test",
+		}
+
+		require.NoError(t, c1.ValidateCompatibility(c2))
+	})
+
+	t.Run("only version is different (possible downgrade)", func(t *testing.T) {
+		c1 := &ConfigLock{
+			NetworkName:      "test",
+			UsingLocalEvents: false,
+			Version:          "v0.0.2-test",
+		}
+
+		c2 := &ConfigLock{
+			NetworkName:      "test",
+			UsingLocalEvents: false,
+			Version:          "v0.0.1-test",
+		}
+
+		require.NoError(t, c1.ValidateCompatibility(c2))
+	})
+
+	t.Run("only version is different (impossible downgrade)", func(t *testing.T) {
+		c1 := &ConfigLock{
+			NetworkName:      "test",
+			UsingLocalEvents: false,
+			Version:          "v1.0.1-test",
+		}
+
+		c2 := &ConfigLock{
+			NetworkName:      "test",
+			UsingLocalEvents: false,
+			Version:          "v0.9.0-test",
 		}
 
 		require.Error(t, c1.ValidateCompatibility(c2))

--- a/utils/commons/build_data.go
+++ b/utils/commons/build_data.go
@@ -3,6 +3,7 @@ package commons
 import (
 	"fmt"
 
+	"go.uber.org/zap"
 	"golang.org/x/mod/semver"
 )
 
@@ -12,13 +13,13 @@ var (
 )
 
 // SetBuildData updates local vars for build data
-func SetBuildData(app string, ver string) {
+func SetBuildData(logger *zap.Logger, app string, ver string) {
 	appName = app
-	version = normalizeVersion(ver)
+	version = normalizeVersion(logger, ver)
 }
 
 // normalizeVersion ensures the version starts with "v" and is valid semver.
-func normalizeVersion(ver string) string {
+func normalizeVersion(logger *zap.Logger, ver string) string {
 	if ver == "" {
 		return version // Return the default version if no version provided
 	}
@@ -29,7 +30,7 @@ func normalizeVersion(ver string) string {
 			ver = "v" + ver
 		} else {
 			// Invalid version, fallback to default version
-			fmt.Printf("Invalid version format: %s, defaulting to %s\n", ver, version)
+			logger.Warn("Invalid version format", zap.String("version", ver), zap.String("default", version))
 			ver = version
 		}
 	}

--- a/utils/commons/build_data.go
+++ b/utils/commons/build_data.go
@@ -1,19 +1,43 @@
 package commons
 
-import "fmt"
+import (
+	"fmt"
+
+	"golang.org/x/mod/semver"
+)
 
 var (
 	appName = "SSV-Node"
-	version = "latest"
+	version = "v0.0.0-dev" // Default for local and untagged builds
 )
 
 // SetBuildData updates local vars for build data
 func SetBuildData(app string, ver string) {
 	appName = app
-	version = ver
+	version = normalizeVersion(ver)
 }
 
-// GetBuildData returns build data
+// normalizeVersion ensures the version starts with "v" and is valid semver.
+func normalizeVersion(ver string) string {
+	if ver == "" {
+		return version // Return the default version if no version provided
+	}
+
+	// If the version isn't valid semver, attempt to add the "v" prefix
+	if !semver.IsValid(ver) {
+		if semver.IsValid("v" + ver) {
+			ver = "v" + ver
+		} else {
+			// Invalid version, fallback to default version
+			fmt.Printf("Invalid version format: %s, defaulting to %s\n", ver, version)
+			ver = version
+		}
+	}
+
+	return ver
+}
+
+// GetBuildData returns build data as "AppName:Version"
 func GetBuildData() string {
 	return fmt.Sprintf("%s:%s", appName, version)
 }


### PR DESCRIPTION
close #1759 

This PR includes the following changes:

- **Major Version Compatibility Check**: The version is now stored in the ConfigLock struct, and ValidateCompatibility ensures no downgrade on the major version.
- **Migration**: Adds a migration to store the version in ConfigLock.
- **Local Build Versioning**: Introduces a default version (v0.0.0-dev) for local builds and allows custom version input via the Makefile.

The downgrade incompatibility currently applies only to major version changes. We can extend this to include minor version changes to prevent minor updates from requiring major version increments.