### PR TITLE
message validation: rearrange checks

### DIFF
--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -1398,11 +1398,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 				receivedAt := netCfg.Beacon.GetSlotStartTime(slot).Add(sinceSlotStart)
 				_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, receivedAt)
-				if validator.messageLateness(slot, role, receivedAt) > 0 {
-					require.ErrorContains(t, err, ErrLateSlotMessage.Error())
-				} else {
-					require.ErrorContains(t, err, ErrRoundTooHigh.Error())
-				}
+				require.ErrorContains(t, err, ErrRoundTooHigh.Error())
 			})
 		}
 	})


### PR DESCRIPTION
move ErrUnexpectedConsensusMessage ErrRoundTooHigh to be triggered as soon as possible to be able to replicate them in the attack sim

@MatheusFranco99 please adjust the knowledge base