### PR TITLE
pubsub: set max msg size

### DIFF
--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -54,5 +54,7 @@ const (
 const (
 	maxPayloadDataSize = max(maxEncodedConsensusMsgSize, maxEncodedPartialSignatureSize)
 	maxSignedMsgSize   = maxSignaturesSize + maxOperatorIDSize + msgTypeSize + identifierSize + maxPayloadDataSize + maxFullDataSize
-	maxEncodedMsgSize  = maxSignedMsgSize + maxSignedMsgSize/encodingOverheadDivisor + 4
 )
+
+// MaxEncodedMsgSize defines max pubsub message size
+const MaxEncodedMsgSize = maxSignedMsgSize + maxSignedMsgSize/encodingOverheadDivisor + 4

--- a/message/validation/pubsub_validation.go
+++ b/message/validation/pubsub_validation.go
@@ -11,7 +11,7 @@ func (mv *messageValidator) validatePubSubMessage(pMsg *pubsub.Message) error {
 	}
 
 	// Rule: Pubsub.Message.Message.Data size upper limit
-	if len(pMsg.GetData()) > maxEncodedMsgSize {
+	if len(pMsg.GetData()) > MaxEncodedMsgSize {
 		e := ErrPubSubDataTooBig
 		e.got = len(pMsg.GetData())
 		return e

--- a/network/topics/pubsub.go
+++ b/network/topics/pubsub.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/ssvlabs/ssv/message/validation"
 	"github.com/ssvlabs/ssv/networkconfig"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -15,6 +16,7 @@ import (
 	"go.uber.org/zap"
 
 	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
+
 	"github.com/ssvlabs/ssv/network"
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/peers"
@@ -136,6 +138,7 @@ func NewPubSub(ctx context.Context, logger *zap.Logger, cfg *PubSubConfig, metri
 		pubsub.WithSubscriptionFilter(sf),
 		pubsub.WithGossipSubParams(params.GossipSubParams()),
 		pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign),
+		pubsub.WithMaxMessageSize(validation.MaxEncodedMsgSize),
 		// pubsub.WithPeerFilter(func(pid peer.ID, topic string) bool {
 		//	logger.Debug("pubsubTrace: filtering peer", zap.String("id", pid.String()), zap.String("topic", topic))
 		//	return true

--- a/network/topics/pubsub.go
+++ b/network/topics/pubsub.go
@@ -5,22 +5,20 @@ import (
 	"net"
 	"time"
 
-	"github.com/ssvlabs/ssv/message/validation"
-	"github.com/ssvlabs/ssv/networkconfig"
-
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/discovery"
 	"github.com/libp2p/go-libp2p/core/host"
+	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
-
+	"github.com/ssvlabs/ssv/message/validation"
 	"github.com/ssvlabs/ssv/network"
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/peers"
 	"github.com/ssvlabs/ssv/network/topics/params"
+	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/registry/storage"
 )
 


### PR DESCRIPTION
Currently, the max message size supported by the protocol is `6286507` but default pub-sub max message size is 1 MiB according to https://github.com/libp2p/go-libp2p-pubsub/blob/f71345c1ec0ee4b30cd702bb605927f788ff9f36/pubsub.go#L495.

The PR changes the max pub-sub message size to MaxEncodedMsgSize (`6286507` as of now).

@MatheusFranco99 @GalRogozinski `go-libp2p-pubsub` discourages increasing the max size, should we consider reducing it? 