### PR TITLE
tests: increase timeouts for flaky tests

### DIFF
--- a/operator/slotticker/slotticker_test.go
+++ b/operator/slotticker/slotticker_test.go
@@ -301,20 +301,20 @@ func TestDoubleTickRealTimer(t *testing.T) {
 
 	// Wait for the first slot.
 	<-ticker.Next()
-	require.WithinDuration(t, firstSlotTime.Add(1*slotTime), time.Now(), 5*time.Millisecond, "Expected the first tick to occur after 1/10th of a slot")
+	require.WithinDuration(t, firstSlotTime.Add(1*slotTime), time.Now(), 50*time.Millisecond, "Expected the first tick to occur after 1/10th of a slot")
 	firstSlot := ticker.Slot()
 	require.Equal(t, phase0.Slot(1), firstSlot)
 
 	// Wait for the 2nd slot, but wake up early.
 	mockTimer.fakeNextReset(slotTime / 2)
 	<-ticker.Next()
-	require.WithinDuration(t, firstSlotTime.Add(1*slotTime+slotTime/2), time.Now(), 5*time.Millisecond, "Expected the first tick to occur after 1/2th of a slot")
+	require.WithinDuration(t, firstSlotTime.Add(1*slotTime+slotTime/2), time.Now(), 50*time.Millisecond, "Expected the first tick to occur after 1/2th of a slot")
 	secondSlot := ticker.Slot()
 	require.Equal(t, phase0.Slot(2), secondSlot)
 
 	// Expect the SlotTicker to realize it woke up early, and wait for the 3rd slot instead.
 	<-ticker.Next()
-	require.WithinDuration(t, firstSlotTime.Add(3*slotTime), time.Now(), 5*time.Millisecond, "Expected the first tick to occur after 1/10th of a slot")
+	require.WithinDuration(t, firstSlotTime.Add(3*slotTime), time.Now(), 50*time.Millisecond, "Expected the first tick to occur after 1/10th of a slot")
 	thirdSlot := ticker.Slot()
 	require.Equal(t, phase0.Slot(3), thirdSlot)
 

--- a/protocol/genesis/ssv/genesisqueue/queue_test.go
+++ b/protocol/genesis/ssv/genesisqueue/queue_test.go
@@ -104,7 +104,7 @@ func TestPriorityQueue_Pop(t *testing.T) {
 		capacity       = 3
 		contextTimeout = 50 * time.Millisecond
 		pushDelay      = 50 * time.Millisecond
-		precision      = 5 * time.Millisecond
+		precision      = 50 * time.Millisecond
 	)
 	queue := New(capacity)
 	require.True(t, queue.Empty())

--- a/protocol/v2/ssv/queue/queue_test.go
+++ b/protocol/v2/ssv/queue/queue_test.go
@@ -104,7 +104,7 @@ func TestPriorityQueue_Pop(t *testing.T) {
 		capacity       = 3
 		contextTimeout = 50 * time.Millisecond
 		pushDelay      = 50 * time.Millisecond
-		precision      = 5 * time.Millisecond
+		precision      = 50 * time.Millisecond
 	)
 	queue := New(capacity)
 	require.True(t, queue.Empty())


### PR DESCRIPTION
I'm running `make docker-unit-test` and it fails pretty reliably with errors like this one (attaching also [full log example](https://github.com/user-attachments/files/17257227/failed-tests.txt)):
```
	github.com/ssvlabs/ssv/protocol/v2/ssv		coverage: 0.0% of statements
--- FAIL: TestPriorityQueue_Pop (0.22s)
    queue_test.go:153:
        	Error Trace:	/go/src/github.com/ssvlabs/ssv/protocol/v2/ssv/queue/queue_test.go:153
        	Error:      	Max difference between 2024-10-04 08:32:38.253621092 +0000 UTC m=+0.420658418 and 2024-10-04 08:32:38.267124259 +0000 UTC m=+0.434161626 allowed is 5ms, but difference was -13.503208ms
        	Test:       	TestPriorityQueue_Pop
```

Looks like timeouts need to be increased (5ms->50ms change seems reasonable to me  because I'm encountering it on Mac M3 pro machine which is quite powerful)