### PR TITLE
fix: (alan) dont stop prefork discovery

### DIFF
--- a/network/discovery/forking_dv5_listener.go
+++ b/network/discovery/forking_dv5_listener.go
@@ -1,7 +1,6 @@
 package discovery
 
 import (
-	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -21,7 +20,6 @@ type forkingDV5Listener struct {
 	preForkListener  Listener
 	postForkListener Listener
 	iteratorTimeout  time.Duration
-	closeOnce        sync.Once
 	netCfg           networkconfig.NetworkConfig
 }
 
@@ -87,9 +85,7 @@ func (l *forkingDV5Listener) Close() {
 
 // closePreForkListener ensures preForkListener is closed once
 func (l *forkingDV5Listener) closePreForkListener() {
-	l.closeOnce.Do(func() {
-		l.preForkListener.Close()
-	})
+	l.preForkListener.Close()
 }
 
 // annotatedIterator wraps an enode.Iterator with metrics collection.

--- a/network/discovery/forking_dv5_listener.go
+++ b/network/discovery/forking_dv5_listener.go
@@ -41,11 +41,6 @@ func NewForkingDV5Listener(logger *zap.Logger, preFork, postFork Listener, itera
 // Before the fork, returns the result of a Lookup in both pre and post-fork services.
 // After the fork, returns only the result from the post-fork service.
 func (l *forkingDV5Listener) Lookup(id enode.ID) []*enode.Node {
-	if l.netCfg.PastAlanFork() {
-		l.closePreForkListener()
-		return l.postForkListener.Lookup(id)
-	}
-
 	nodes := l.postForkListener.Lookup(id)
 	nodes = append(nodes, l.preForkListener.Lookup(id)...)
 	return nodes
@@ -54,11 +49,6 @@ func (l *forkingDV5Listener) Lookup(id enode.ID) []*enode.Node {
 // Before the fork, returns an iterator for both pre and post-fork services.
 // After the fork, returns only the iterator from the post-fork service.
 func (l *forkingDV5Listener) RandomNodes() enode.Iterator {
-	if l.netCfg.PastAlanFork() {
-		l.closePreForkListener()
-		return l.postForkListener.RandomNodes()
-	}
-
 	fairMix := enode.NewFairMix(l.iteratorTimeout)
 	fairMix.AddSource(&annotatedIterator{l.postForkListener.RandomNodes(), "post"})
 	fairMix.AddSource(&annotatedIterator{l.preForkListener.RandomNodes(), "pre"})
@@ -68,11 +58,6 @@ func (l *forkingDV5Listener) RandomNodes() enode.Iterator {
 // Before the fork, returns all nodes from the pre and post-fork listeners.
 // After the fork, returns only the result from the post-fork service.
 func (l *forkingDV5Listener) AllNodes() []*enode.Node {
-	if l.netCfg.PastAlanFork() {
-		l.closePreForkListener()
-		return l.postForkListener.AllNodes()
-	}
-
 	enodes := l.postForkListener.AllNodes()
 	enodes = append(enodes, l.preForkListener.AllNodes()...)
 	return enodes
@@ -81,11 +66,6 @@ func (l *forkingDV5Listener) AllNodes() []*enode.Node {
 // Sends a ping in the post-fork service.
 // Before the fork, it also tries to ping with the pre-fork service in case of error.
 func (l *forkingDV5Listener) Ping(node *enode.Node) error {
-	if l.netCfg.PastAlanFork() {
-		l.closePreForkListener()
-		return l.postForkListener.Ping(node)
-	}
-
 	err := l.postForkListener.Ping(node)
 	if err != nil {
 		return l.preForkListener.Ping(node)
@@ -96,10 +76,6 @@ func (l *forkingDV5Listener) Ping(node *enode.Node) error {
 // Returns the LocalNode using the post-fork listener.
 // Both pre and post-fork listeners should have the same LocalNode.
 func (l *forkingDV5Listener) LocalNode() *enode.LocalNode {
-	if l.netCfg.PastAlanFork() {
-		l.closePreForkListener()
-		return l.postForkListener.LocalNode()
-	}
 	return l.postForkListener.LocalNode()
 }
 


### PR DESCRIPTION
### Description

We want to stop the pre-fork discovery only after a restart to keep it as simple as possible.
