### PR TITLE
tests: executionclient fix & simplify

### DIFF
--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -33,8 +33,10 @@ type ExecutionClient struct {
 	contractAddress ethcommon.Address
 
 	// optional
-	logger                      *zap.Logger
-	metrics                     metrics
+	logger  *zap.Logger
+	metrics metrics
+	// followDistance defines an offset into the past from the head block such that the block
+	// at this offset will be considered as very likely finalized.
 	followDistance              uint64 // TODO: consider reading the finalized checkpoint from consensus layer
 	connectionTimeout           time.Duration
 	reconnectionInitialInterval time.Duration

--- a/eth/executionclient/options.go
+++ b/eth/executionclient/options.go
@@ -23,8 +23,8 @@ func WithMetrics(metrics metrics) Option {
 	}
 }
 
-// WithFollowDistance sets finalization offset.
-// It defines how many blocks in the past the latest block we want to process is.
+// WithFollowDistance sets finalization offset (a block at this offset into the past
+// from the head block will be considered as very likely finalized).
 func WithFollowDistance(offset uint64) Option {
 	return func(s *ExecutionClient) {
 		s.followDistance = offset


### PR DESCRIPTION
This PR resolves potential memory leak (similar to what's described in https://github.com/ssvlabs/ssv/pull/1780), also simplifying the test affected.