### PR TITLE
fix (main): set discovery interval to 1ms

### DIFF
--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	defaultDiscoveryInterval = time.Millisecond * 100
+	defaultDiscoveryInterval = time.Millisecond * 1
 	publishENRTimeout        = time.Minute
 
 	publishStateReady   = int32(0)


### PR DESCRIPTION
### Description

Since `RandomNodes()` func has internal way to wait for table to fill, it doesn't really need the sleep interval to not create a busy loop when its empty.