### PR TITLE
fix (stage): set discovery interval to 1ms

### DIFF
--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	defaultDiscoveryInterval = time.Millisecond * 100
+	defaultDiscoveryInterval = time.Millisecond * 1
 	publishENRTimeout        = time.Minute
 )
 


### PR DESCRIPTION
### Description

Since `RandomNodes()` func has internal way to wait for table to fill, it doesn't really need the sleep interval to not create a busy loop when its empty.