### PR TITLE
rsa: benchmark go vs openssl implementations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ ifeq ($(COVERAGE),true)
 endif
 UNFORMATTED=$(shell gofmt -l .)
 
-#Lint
 .PHONY: lint-prepare
 lint-prepare:
 	@echo "Preparing Linter"
@@ -84,14 +83,17 @@ spec-test-raceless:
 	@echo "Running spec tests without race flag"
 	@go test -tags blst_enabled -timeout 20m -count=1 -p 1 -v `go list ./... | grep spectest`
 
-#Test
+.PHONY: benchmark
+benchmark:
+	@echo "Running benchmark for specified directory"
+	@go test -run=^# -bench . -benchmem -v TARGET_DIR_PATH -count 3
+
 .PHONY: docker-spec-test
 docker-spec-test:
 	@echo "Running spec tests in docker"
 	@docker build -t ssv_tests -f tests.Dockerfile .
 	@docker run --rm ssv_tests make spec-test
 
-#Test
 .PHONY: docker-unit-test
 docker-unit-test:
 	@echo "Running unit tests in docker"
@@ -104,7 +106,12 @@ docker-integration-test:
 	@docker build -t ssv_tests -f tests.Dockerfile .
 	@docker run --rm ssv_tests make integration-test
 
-#Build
+.PHONY: docker-benchmark
+docker-benchmark:
+	@echo "Running benchmark in docker"
+	@docker build -t ssv_tests -f tests.Dockerfile .
+	@docker run --rm ssv_tests make benchmark
+
 .PHONY: build
 build:
 	CGO_ENABLED=1 go build -o ./bin/ssvnode -ldflags "-X main.Commit=`git rev-parse HEAD` -X main.Version=`git describe --tags $(git rev-list --tags --max-count=1)`" ./cmd/ssvnode/

--- a/operator/keys/rsa_benchmark_test.go
+++ b/operator/keys/rsa_benchmark_test.go
@@ -1,0 +1,74 @@
+package keys
+
+import (
+	crand "crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"testing"
+)
+
+const (
+	keySize = 2048
+)
+
+var (
+	// msg we'll use for benchmarking.
+	msg = []byte("Some message example to be hashed for benchmarking, let's make it at " +
+		"least 100 bytes long so we can benchmark against somewhat real-world message size. " +
+		"Although it still might be way too small. Lajfklflfaslfjsalfalsfjsla fjlajlfaslkfjaslkf" +
+		"lasjflkasljfLFSJLfjsalfjaslfLKFsalfjalsfjalsfjaslfjaslfjlasflfslafasklfjsalfj;eqwfgh442")
+	// msgHash is a typical sha256 hash, we use it for benchmarking because it's the most
+	// common type of data we work with.
+	msgHash = func() []byte {
+		hash := sha256.Sum256(msg)
+		return hash[:]
+	}()
+)
+
+func BenchmarkSignRSA(b *testing.B) {
+	privKey, _ := genKeypair(b)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := SignRSA(privKey, msgHash)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncryptRSA(b *testing.B) {
+	_, pubKey := genKeypair(b)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := EncryptRSA(pubKey, msgHash)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerifyRSA(b *testing.B) {
+	privKey, pubKey := genKeypair(b)
+	signature, err := SignRSA(privKey, msgHash)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := VerifyRSA(pubKey, msg, signature)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func genKeypair(b *testing.B) (*privateKey, *publicKey) {
+	pKey, err := rsa.GenerateKey(crand.Reader, keySize)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return &privateKey{privKey: pKey}, &publicKey{pubKey: &pKey.PublicKey}
+}

--- a/operator/keys/rsa_linux.go
+++ b/operator/keys/rsa_linux.go
@@ -69,14 +69,6 @@ func SignRSA(priv *privateKey, data []byte) ([]byte, error) {
 	return openssl.SignRSAPKCS1v15(opriv, crypto.SHA256, data)
 }
 
-func checkCachePubkey(pub *publicKey) (*openssl.PublicKeyRSA, error) {
-	var err error
-	pub.once.Do(func() {
-		pub.cachedPubkey, err = rsaPublicKeyToOpenSSL(pub.pubKey)
-	})
-	return pub.cachedPubkey, err
-}
-
 func EncryptRSA(pub *publicKey, data []byte) ([]byte, error) {
 	opub, err := checkCachePubkey(pub)
 	if err != nil {
@@ -92,4 +84,12 @@ func VerifyRSA(pub *publicKey, data, signature []byte) error {
 	}
 	hashed := sha256.Sum256(data)
 	return openssl.VerifyRSAPKCS1v15(opub, crypto.SHA256, hashed[:], signature)
+}
+
+func checkCachePubkey(pub *publicKey) (*openssl.PublicKeyRSA, error) {
+	var err error
+	pub.once.Do(func() {
+		pub.cachedPubkey, err = rsaPublicKeyToOpenSSL(pub.pubKey)
+	})
+	return pub.cachedPubkey, err
 }


### PR DESCRIPTION
This PR adds simple `make benchmark` command to `Makefile` in order to be able to run benchmark for a certain directory in this repo (you need to specify it replacing `TARGET_DIR_PATH` value accordingly).

Need for https://github.com/ssvlabs/ssv/issues/1643