### PR TITLE
openssl: upgrade bindings package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/ferranbt/fastssz v0.1.3
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-chi/render v1.0.2
+	github.com/golang-fips/openssl/v2 v2.0.3
 	github.com/golang/gddo v0.0.0-20200528160355-8d077c1d8f4c
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-fips/openssl/v2 v2.0.3 h1:9+J2R0BQio6Jz8+dPZf/0ylISByl0gZWjTEKm+J+y7Y=
+github.com/golang-fips/openssl/v2 v2.0.3/go.mod h1:7tuBqX2Zov8Yq5mJ2yzlKhpnxOnWyEzi38AzeWRuQdg=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/gddo v0.0.0-20200528160355-8d077c1d8f4c h1:HoqgYR60VYu5+0BuG6pjeGp7LKEPZnHt+dUClx9PeIs=

--- a/operator/keys/rsa_linux.go
+++ b/operator/keys/rsa_linux.go
@@ -36,6 +36,9 @@ func init() {
 }
 
 // getVersion returns the highest available OpenSSL version.
+// Note, this func is borrowed from https://github.com/golang-fips/openssl/blob/v2/openssl_test.go
+// as I found it working (when testing in Docker) and there is no documented example for how this
+// actually should be done.
 func getVersion() string {
 	v := os.Getenv("GO_OPENSSL_VERSION_OVERRIDE")
 	if v != "" {


### PR DESCRIPTION
This PR switches OpenSSL package we use for RSA from https://github.com/microsoft/go-crypto-openssl (now deprecated) to https://github.com/golang-fips/openssl,

according to benchmarks I ran, it doesn't bring any performance improvements though.

We can also close this PR for now, and we can get back to it later on. See https://github.com/ssvlabs/ssv/pull/1348 for additional historical context.

Reminder to self, before merging will need to:
- [ ] test/check (by deploying to stage) there aren't any panic/fatal/segmentation/fault/cgo errors related to this change