### PR TITLE
fix: change custom domain type to genesis custom domain type +1 on fork.

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -609,16 +609,16 @@ func setupSSVNetwork(logger *zap.Logger) (networkconfig.NetworkConfig, error) {
 		if len(byts) != 4 {
 			return networkconfig.NetworkConfig{}, errors.New("custom domain type must be 4 bytes")
 		}
+		// Assign domain type as-is for Genesis.
 		networkConfig.GenesisDomainType = spectypes.DomainType(byts)
-		alanDomainUint := binary.LittleEndian.Uint32(byts) + 1
-		alanbyts := make([]byte, 4)
-		binary.LittleEndian.PutUint32(alanbyts, alanDomainUint)
-		networkConfig.AlanDomainType = spectypes.DomainType(alanbyts)
-		if networkConfig.PastAlanFork() {
-			logger.Info("running with custom domain type", fields.Domain(networkConfig.AlanDomainType))
-		} else {
-			logger.Info("running with custom domain type", fields.Domain(networkConfig.GenesisDomainType))
-		}
+		// Assign domain type incremented by 1 for Alan.
+		alanDomainType := binary.LittleEndian.Uint32(byts) + 1
+		binary.LittleEndian.PutUint32(networkConfig.AlanDomainType[:], alanDomainType)
+
+		logger.Info("running with custom domain type",
+			zap.Stringer("genesis", format.DomainType(networkConfig.GenesisDomainType)),
+			zap.Stringer("alan", format.DomainType(networkConfig.AlanDomainType)),
+		)
 	}
 
 	genesisssvtypes.SetDefaultDomain(genesisspectypes.DomainType(networkConfig.GenesisDomainType))

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -609,11 +609,13 @@ func setupSSVNetwork(logger *zap.Logger) (networkconfig.NetworkConfig, error) {
 		if len(byts) != 4 {
 			return networkconfig.NetworkConfig{}, errors.New("custom domain type must be 4 bytes")
 		}
+
 		// Assign domain type as-is for Genesis.
 		networkConfig.GenesisDomainType = spectypes.DomainType(byts)
+
 		// Assign domain type incremented by 1 for Alan.
-		alanDomainType := binary.LittleEndian.Uint32(byts) + 1
-		binary.LittleEndian.PutUint32(networkConfig.AlanDomainType[:], alanDomainType)
+		alanDomainType := binary.BigEndian.Uint32(byts) + 1
+		binary.BigEndian.PutUint32(networkConfig.AlanDomainType[:], alanDomainType)
 
 		logger.Info("running with custom domain type",
 			zap.Stringer("genesis", format.DomainType(networkConfig.GenesisDomainType)),
@@ -626,6 +628,10 @@ func setupSSVNetwork(logger *zap.Logger) (networkconfig.NetworkConfig, error) {
 	nodeType := "light"
 	if cfg.SSVOptions.ValidatorOptions.FullNode {
 		nodeType = "full"
+	}
+
+	if !networkConfig.PastAlanFork() {
+		logger = logger.With(zap.Stringer("alan_domain", format.DomainType(networkConfig.AlanDomainType)))
 	}
 
 	logger.Info("setting ssv network",

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"log"
@@ -609,8 +610,12 @@ func setupSSVNetwork(logger *zap.Logger) (networkconfig.NetworkConfig, error) {
 			return networkconfig.NetworkConfig{}, errors.New("custom domain type must be 4 bytes")
 		}
 		networkConfig.GenesisDomainType = spectypes.DomainType(byts)
+		alanDomainUint := binary.LittleEndian.Uint32(byts) + 1
+		alanbyts := make([]byte, 4)
+		binary.LittleEndian.PutUint32(alanbyts, alanDomainUint)
+		networkConfig.AlanDomainType = spectypes.DomainType(alanbyts)
 		if networkConfig.PastAlanFork() {
-			logger.Info("custom domain type is ineffective now after Alan fork", fields.Domain(networkConfig.GenesisDomainType))
+			logger.Info("running with custom domain type", fields.Domain(networkConfig.AlanDomainType))
 		} else {
 			logger.Info("running with custom domain type", fields.Domain(networkConfig.GenesisDomainType))
 		}

--- a/operator/node.go
+++ b/operator/node.go
@@ -33,7 +33,7 @@ type Node interface {
 type Options struct {
 	// NetworkName is the network name of this node
 	NetworkName         string `yaml:"Network" env:"NETWORK" env-default:"mainnet" env-description:"Network is the network of this node"`
-	CustomDomainType    string `yaml:"CustomDomainType" env:"CUSTOM_DOMAIN_TYPE" env-default:"" env-description:"Override the SSV domain type. This is used to isolate the node from the rest of the network. Do not set unless you know what you are doing. Example: 0x01020304"`
+	CustomDomainType    string `yaml:"CustomDomainType" env:"CUSTOM_DOMAIN_TYPE" env-default:"" env-description:"Override the SSV domain type and next domain type. This is used to isolate the node from the rest of the network. Do not set unless you know what you are doing. Example: 0x01020304"`
 	Network             networkconfig.NetworkConfig
 	BeaconNode          beaconprotocol.BeaconNode // TODO: consider renaming to ConsensusClient
 	ExecutionClient     *executionclient.ExecutionClient

--- a/operator/node.go
+++ b/operator/node.go
@@ -33,7 +33,7 @@ type Node interface {
 type Options struct {
 	// NetworkName is the network name of this node
 	NetworkName         string `yaml:"Network" env:"NETWORK" env-default:"mainnet" env-description:"Network is the network of this node"`
-	CustomDomainType    string `yaml:"CustomDomainType" env:"CUSTOM_DOMAIN_TYPE" env-default:"" env-description:"Override the SSV domain type and next domain type. This is used to isolate the node from the rest of the network. Do not set unless you know what you are doing. Example: 0x01020304"`
+	CustomDomainType    string `yaml:"CustomDomainType" env:"CUSTOM_DOMAIN_TYPE" env-default:"" env-description:"Override the SSV domain type. This is used to isolate the node from the rest of the network. Do not set unless you know what you are doing. This would be incremented by 1 for Alan, for example: 0x01020304 becomes 0x01020305 post-fork."`
 	Network             networkconfig.NetworkConfig
 	BeaconNode          beaconprotocol.BeaconNode // TODO: consider renaming to ConsensusClient
 	ExecutionClient     *executionclient.ExecutionClient


### PR DESCRIPTION
### Description

We decided to not merge all custom domains to alan domain on fork, but to make them increase domain type value +1 and stay on a different domain. 

Genesis Domain Type -> Alan Domain Type
Genesis custom domain type -> Alan custom domain type (genesis +1)