### PR TITLE
refactor(network/records): change subnets type to [16]byte

### DIFF
--- a/api/handlers/node.go
+++ b/api/handlers/node.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/ssvlabs/ssv/api"
+	"github.com/ssvlabs/ssv/network/commons"
 	networkpeers "github.com/ssvlabs/ssv/network/peers"
 	"github.com/ssvlabs/ssv/nodeprobe"
 )
@@ -170,10 +171,15 @@ func (h *Node) Health(w http.ResponseWriter, r *http.Request) error {
 func (h *Node) peers(peers []peer.ID) []peerJSON {
 	resp := make([]peerJSON, len(peers))
 	for i, id := range peers {
+		subnets, ok := h.PeersIndex.GetPeerSubnets(id)
+		if !ok {
+			subnets = commons.ZeroSubnets
+		}
+
 		resp[i] = peerJSON{
 			ID:            id,
 			Connectedness: h.Network.Connectedness(id).String(),
-			Subnets:       h.PeersIndex.GetPeerSubnets(id).String(),
+			Subnets:       subnets.String(),
 		}
 
 		for _, addr := range h.Network.Peerstore().Addrs(id) {

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -29,6 +29,8 @@ import (
 	"github.com/ssvlabs/ssv/ssvsigner/keys/rsaencryption"
 	"github.com/ssvlabs/ssv/ssvsigner/keystore"
 
+	ssvsignertls "github.com/ssvlabs/ssv/ssvsigner/tls"
+
 	"github.com/ssvlabs/ssv/api/handlers"
 	apiserver "github.com/ssvlabs/ssv/api/server"
 	"github.com/ssvlabs/ssv/beacon/goclient"
@@ -66,7 +68,6 @@ import (
 	qbftstorage "github.com/ssvlabs/ssv/protocol/v2/qbft/storage"
 	"github.com/ssvlabs/ssv/protocol/v2/types"
 	registrystorage "github.com/ssvlabs/ssv/registry/storage"
-	ssvsignertls "github.com/ssvlabs/ssv/ssvsigner/tls"
 	"github.com/ssvlabs/ssv/storage/basedb"
 	"github.com/ssvlabs/ssv/storage/kv"
 	"github.com/ssvlabs/ssv/utils/commons"
@@ -430,15 +431,12 @@ var StartNodeCmd = &cobra.Command{
 		cfg.SSVOptions.ValidatorOptions.Graffiti = []byte(cfg.Graffiti)
 		cfg.SSVOptions.ValidatorOptions.ValidatorStore = nodeStorage.ValidatorStore()
 
-		fixedSubnets, err := networkcommons.FromString(cfg.P2pNetworkConfig.Subnets)
+		fixedSubnets, err := networkcommons.SubnetsFromString(cfg.P2pNetworkConfig.Subnets)
 		if err != nil {
 			logger.Fatal("failed to parse fixed subnets", zap.Error(err))
 		}
 		if cfg.SSVOptions.ValidatorOptions.Exporter {
-			fixedSubnets, err = networkcommons.FromString(networkcommons.AllSubnets)
-			if err != nil {
-				logger.Fatal("failed to parse all fixed subnets", zap.Error(err))
-			}
+			fixedSubnets = networkcommons.AllSubnets
 		}
 
 		metadataSyncer := metadata.NewSyncer(
@@ -531,12 +529,12 @@ var StartNodeCmd = &cobra.Command{
 			)
 			start := time.Now()
 			myValidators := nodeStorage.ValidatorStore().OperatorValidators(operatorDataStore.GetOperatorID())
-			mySubnets := make(networkcommons.Subnets, networkcommons.SubnetsCount)
+			mySubnets := networkcommons.Subnets{}
 			myActiveSubnets := 0
 			for _, v := range myValidators {
 				subnet := networkcommons.CommitteeSubnet(v.CommitteeID())
-				if mySubnets[subnet] == 0 {
-					mySubnets[subnet] = 1
+				if !mySubnets.IsSet(subnet) {
+					mySubnets.Set(subnet)
 					myActiveSubnets++
 				}
 			}

--- a/ibft/storage/store.go
+++ b/ibft/storage/store.go
@@ -311,7 +311,7 @@ func slotToByteSlice(v phase0.Slot) []byte {
 	b := make([]byte, 4)
 
 	// we're casting down but we should be good for now
-	slot := uint32(uint64(v)) // #nosec G115
+	slot := uint32(v) // #nosec G115
 
 	binary.LittleEndian.PutUint32(b, slot)
 	return b

--- a/logging/fields/fields.go
+++ b/logging/fields/fields.go
@@ -172,7 +172,7 @@ func UpdatedENRLocalNode(val *enode.LocalNode) zapcore.Field {
 }
 
 func Subnets(val commons.Subnets) zapcore.Field {
-	return zap.Stringer(FieldSubnets, val)
+	return zap.Stringer(FieldSubnets, &val)
 }
 
 func PeerID(val peer.ID) zapcore.Field {

--- a/network/commons/subnets.go
+++ b/network/commons/subnets.go
@@ -1,20 +1,22 @@
 package commons
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"math"
 	"math/big"
-	"strconv"
+	"math/bits"
 	"strings"
 
-	"github.com/prysmaticlabs/go-bitfield"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 )
 
 const (
-	// SubnetsCount returns the subnet count for this fork
+	// SubnetsCount returns the subnet count for this fork. It must be power of 2.
 	SubnetsCount = 128
+
+	byteCount = SubnetsCount / 8
 
 	UnknownSubnetId = math.MaxUint64
 
@@ -70,113 +72,137 @@ func Topics() []string {
 	return topics
 }
 
-const (
+var (
 	// ZeroSubnets is the representation of no subnets
-	ZeroSubnets = "00000000000000000000000000000000"
+	ZeroSubnets = Subnets{v: [byteCount]byte(bytes.Repeat([]byte{0x00}, byteCount))}
 	// AllSubnets is the representation of all subnets
-	AllSubnets = "ffffffffffffffffffffffffffffffff"
+	AllSubnets = Subnets{v: [byteCount]byte(bytes.Repeat([]byte{0xFF}, byteCount))}
 )
 
-// Subnets holds all the subscribed subnets of a specific node
-type Subnets []byte
-
-// Clone clones the independent byte slice
-func (s Subnets) Clone() Subnets {
-	cp := make([]byte, len(s))
-	copy(cp, s)
-	return cp
+// Subnets holds all the subscribed subnets of a specific node.
+// The array index represents a subnet number,
+// the value holds either 0 or 1 representing if the node is subscribed to the subnet number.
+type Subnets struct {
+	v [byteCount]byte // wrapped by a struct to forbid indexing outsize of this package
 }
 
-func (s Subnets) String() string {
-	subnetsVec := bitfield.NewBitvector128()
-	subnet := uint64(0)
-	for _, val := range s {
-		subnetsVec.SetBitAt(subnet, val > uint8(0))
-		subnet++
+// SubnetsFromString parses a given subnet string
+func SubnetsFromString(subnetsStr string) (Subnets, error) {
+	subnetsStr = strings.TrimPrefix(subnetsStr, "0x")
+	data, err := hex.DecodeString(subnetsStr)
+	if err != nil {
+		return Subnets{}, err
 	}
-	return hex.EncodeToString(subnetsVec.Bytes())
+
+	if len(data) != byteCount {
+		return Subnets{}, fmt.Errorf("invalid subnets length %d, expected %d", len(data), byteCount)
+	}
+
+	var subnets Subnets
+	copy(subnets.v[:], data)
+	return subnets, nil
 }
 
-func (s Subnets) Active() int {
-	var active int
-	for _, val := range s {
-		if val > 0 {
-			active++
+// IsSet checks if the i-th subnet is set.
+func (s *Subnets) IsSet(i uint64) bool {
+	if i >= SubnetsCount {
+		return false
+	}
+	byteIndex := i / 8
+	bitIndex := i % 8
+	return (s.v[byteIndex] & (1 << bitIndex)) != 0
+}
+
+// Set marks the i-th subnet as set.
+func (s *Subnets) Set(i uint64) {
+	if i >= SubnetsCount {
+		return
+	}
+	byteIndex := i / 8
+	bitIndex := i % 8
+	s.v[byteIndex] |= 1 << bitIndex
+}
+
+// Clear marks the i-th subnet as not set.
+func (s *Subnets) Clear(i uint64) {
+	if i >= SubnetsCount {
+		return
+	}
+	byteIndex := i / 8
+	bitIndex := i % 8
+	s.v[byteIndex] &^= 1 << bitIndex
+}
+
+func (s *Subnets) String() string {
+	return hex.EncodeToString(s.v[:])
+}
+
+func (s *Subnets) SubnetList() []uint64 {
+	indices := make([]uint64, 0)
+	for byteIdx, b := range s.v {
+		if byteIdx >= SubnetsCount {
+			break
 		}
+		for bitIdx := uint64(0); bitIdx < 8; bitIdx++ {
+			bit := byte(1 << uint(bitIdx)) // #nosec G115 -- subnets has a constant max len of 128
+			if b&bit == bit {
+				subnet := uint64(byteIdx)*8 + bitIdx
+				indices = append(indices, subnet)
+			}
+		}
+	}
+
+	return indices
+}
+
+func (s *Subnets) ActiveCount() int {
+	active := 0
+	for _, b := range s.v {
+		active += bits.OnesCount8(b)
 	}
 	return active
 }
 
-// FromString parses a given subnet string
-func FromString(subnetsStr string) (Subnets, error) {
-	subnetsStr = strings.Replace(subnetsStr, "0x", "", 1)
-	var data []byte
-	for i := 0; i+1 < len(subnetsStr); i += 2 {
-		maskData1, err := getCharMask(string(subnetsStr[i]))
-		if err != nil {
-			return nil, err
-		}
-		maskData2, err := getCharMask(string(subnetsStr[i+1]))
-		if err != nil {
-			return nil, err
-		}
-		data = append(data, maskData2...)
-		data = append(data, maskData1...)
+func (s *Subnets) HasActive() bool {
+	return s.ActiveCount() > 0
+}
+
+// ToMap returns a map with all subnets and their values
+func (s *Subnets) ToMap() map[uint64]bool {
+	m := make(map[uint64]bool)
+	for i := uint64(0); i < SubnetsCount; i++ {
+		m[i] = s.IsSet(i)
 	}
-	return data, nil
+	return m
 }
 
 // SharedSubnets returns the shared subnets
-func SharedSubnets(a, b []byte, maxLen int) []int {
-	var shared []int
-	if maxLen == 0 {
-		maxLen = len(a)
+func (s *Subnets) SharedSubnets(other Subnets) []uint64 {
+	return s.SharedSubnetsN(other, 0)
+}
+
+func (s *Subnets) SharedSubnetsN(other Subnets, n int) []uint64 {
+	var shared []uint64
+	if n <= 0 {
+		n = SubnetsCount
 	}
-	if len(a) == 0 || len(b) == 0 {
-		return shared
-	}
-	for subnet, aval := range a {
-		if aval == 0 {
-			continue
-		}
-		if b[subnet] == 0 {
-			continue
-		}
-		shared = append(shared, subnet)
-		if len(shared) == maxLen {
-			break
+	for i := uint64(0); i < SubnetsCount; i++ {
+		if s.IsSet(i) && other.IsSet(i) {
+			shared = append(shared, i)
+			if len(shared) == n {
+				break
+			}
 		}
 	}
 	return shared
 }
 
-// DiffSubnets returns a diff of the two given subnets.
-// returns a map with all the different entries and their post change value
-func DiffSubnets(a, b []byte) map[int]byte {
-	diff := make(map[int]byte)
-	for subnet, bval := range b {
-		if subnet >= len(a) {
-			diff[subnet] = bval
-		} else if aval := a[subnet]; aval != bval {
-			diff[subnet] = bval
-		}
+func (s *Subnets) DiffSubnets(other Subnets) (added Subnets, removed Subnets) {
+	for i := 0; i < byteCount; i++ {
+		// Bits to add: set in 'other' but not in 's'
+		added.v[i] = other.v[i] &^ s.v[i]
+		// Bits to remove: set in 's' but not in 'other'
+		removed.v[i] = s.v[i] &^ other.v[i]
 	}
-	return diff
-}
-
-func getCharMask(str string) ([]byte, error) {
-	val, err := strconv.ParseUint(str, 16, 8)
-	if err != nil {
-		return nil, err
-	}
-	mask := fmt.Sprintf("%04b", val)
-	maskData := make([]byte, 0, 4)
-	for j := 0; j < len(mask); j++ {
-		val, err := strconv.ParseUint(string(mask[len(mask)-1-j]), 2, 8)
-		if err != nil {
-			return nil, err
-		}
-		maskData = append(maskData, uint8(val)) // nolint:gosec
-	}
-	return maskData, nil
+	return added, removed
 }

--- a/network/commons/subnets_test.go
+++ b/network/commons/subnets_test.go
@@ -62,7 +62,7 @@ func TestSubnetsParsing(t *testing.T) {
 	for _, subtest := range subtests {
 		subtest := subtest
 		t.Run(subtest.name, func(t *testing.T) {
-			s, err := FromString(subtest.str)
+			s, err := SubnetsFromString(subtest.str)
 			if subtest.shouldError {
 				require.Error(t, err)
 			} else {
@@ -74,27 +74,73 @@ func TestSubnetsParsing(t *testing.T) {
 }
 
 func TestSharedSubnets(t *testing.T) {
-	s1, err := FromString("0xffffffffffffffffffffffffffffffff")
-	require.NoError(t, err)
-	s2, err := FromString("0x57b080fffd743d9878dc41a184ab160a")
+	s1 := AllSubnets
+	s2, err := SubnetsFromString("0x57b080fffd743d9878dc41a184ab160a")
 	require.NoError(t, err)
 
-	var expectedShared []int
-	for subnet, val := range s2 {
-		if val > 0 {
-			expectedShared = append(expectedShared, subnet)
-		}
-	}
-	shared := SharedSubnets(s1, s2, 0)
+	expectedShared := s2.SubnetList()
+	shared := s1.SharedSubnets(s2)
 	require.Equal(t, expectedShared, shared)
 }
 
 func TestDiffSubnets(t *testing.T) {
-	s1, err := FromString("0xffffffffffffffffffffffffffffffff")
-	require.NoError(t, err)
-	s2, err := FromString("0x57b080fffd743d9878dc41a184ab160a")
+	s1 := AllSubnets
+	s2, err := SubnetsFromString("0x57b080fffd743d9878dc41a184ab160a")
 	require.NoError(t, err)
 
-	diff := DiffSubnets(s1, s2)
-	require.Len(t, diff, 128-62)
+	added, removed := s1.DiffSubnets(s2)
+	require.Equal(t, 128-62, added.ActiveCount()+removed.ActiveCount())
+}
+
+func TestSubnetsList(t *testing.T) {
+	// Test Case 1: All subnets unset
+	subnets := ZeroSubnets
+	subnetList := subnets.SubnetList()
+	require.Emptyf(t, subnetList, "Expected 0 subnets, got %d", len(subnetList))
+
+	// Test Case 2: All subnets set
+	subnets = AllSubnets
+	subnetList = subnets.SubnetList()
+
+	require.Lenf(t, subnetList, SubnetsCount, "Expected %d subnets, got %d", SubnetsCount, len(subnetList))
+	for i := 0; i < SubnetsCount; i++ {
+		require.Equalf(t, i, subnetList[i], "Expected subnet index %d, got %d", i, subnetList[i])
+	}
+
+	// Test Case 3: Random subnets set
+	expected := []uint64{0, 15, 16, 31, 63, 64, 127}
+
+	subnets = ZeroSubnets
+	for _, v := range expected {
+		subnets.Set(v)
+	}
+
+	subnetList = subnets.SubnetList()
+	require.Lenf(t, subnetList, len(expected), "Expected %d subnets, got %d", len(expected), len(subnetList))
+	for i, idx := range expected {
+		require.Equalf(t, idx, subnetList[i], "At position %d: expected %d, got %d", i, idx, subnetList[i])
+	}
+
+	// Test Case 4: No subnets set
+	subnets = ZeroSubnets
+	subnetList = subnets.SubnetList()
+	require.Emptyf(t, subnetList, "Expected 0 subnets, got %d", len(subnetList))
+
+	// Test Case 5: Single subnet set
+	subnets = ZeroSubnets
+	subnets.Set(42)
+	subnetList = subnets.SubnetList()
+	require.Lenf(t, subnetList, 1, "Expected 1 subnet, got %d", len(subnetList))
+	require.Equalf(t, 42, subnetList[0], "Expected subnet [42], got %v", subnetList)
+
+	// Test Case 6: Clearing subnets
+	subnets = AllSubnets
+	subnets.Clear(0)
+	subnets.Clear(64)
+	subnets.Clear(127)
+	subnetList = subnets.SubnetList()
+	require.Lenf(t, subnetList, SubnetsCount-3, "Expected %d subnets, got %d", SubnetsCount-3, len(subnetList))
+	for _, idx := range []int{0, 64, 127} {
+		require.NotContainsf(t, subnetList, idx, "Subnet %d should have been cleared", idx)
+	}
 }

--- a/network/discovery/dv5_filters.go
+++ b/network/discovery/dv5_filters.go
@@ -6,7 +6,6 @@ import (
 	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
 	"go.uber.org/zap"
 
-	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/records"
 )
 
@@ -33,7 +32,7 @@ func (dvs *DiscV5Service) badNodeFilter(logger *zap.Logger) func(node *enode.Nod
 			logger.Warn("could not get peer ID from node record", zap.Error(err))
 			return false
 		}
-		return !dvs.conns.IsBad(logger, pid)
+		return !dvs.conns.IsBad(pid)
 	}
 }
 
@@ -78,7 +77,7 @@ func (dvs *DiscV5Service) subnetFilter(subnets ...uint64) func(node *enode.Node)
 			return false
 		}
 		for _, subnet := range subnets {
-			if fromEntry[subnet] > 0 {
+			if fromEntry.IsSet(subnet) {
 				return true
 			}
 		}
@@ -93,14 +92,11 @@ func (dvs *DiscV5Service) sharedSubnetsFilter(n int) func(node *enode.Node) bool
 		if n == 0 {
 			return true
 		}
-		if len(dvs.subnets) == 0 {
-			return true
-		}
 		nodeSubnets, err := records.GetSubnetsEntry(node.Record())
 		if err != nil {
 			return false
 		}
-		shared := commons.SharedSubnets(dvs.subnets, nodeSubnets, n)
+		shared := dvs.subnets.SharedSubnetsN(nodeSubnets, n)
 		// logger.Debug("shared subnets", zap.Ints("shared", shared),
 		//	zap.String("node", node.String()))
 

--- a/network/discovery/dv5_service_test.go
+++ b/network/discovery/dv5_service_test.go
@@ -50,10 +50,11 @@ func TestCheckPeer(t *testing.T) {
 				expectedError: errors.New("domain type 01020305 doesn't match 01020304"),
 			},
 			{
-				name:          "missing subnets",
-				domainType:    &myDomainType,
-				subnets:       nil,
-				expectedError: errors.New("could not read subnets"),
+				name:           "missing subnets",
+				domainType:     &myDomainType,
+				subnets:        commons.Subnets{},
+				missingSubnets: true,
+				expectedError:  errors.New("could not read subnets"),
 			},
 			{
 				name:          "inactive subnets",
@@ -110,7 +111,7 @@ func TestCheckPeer(t *testing.T) {
 				err := records.SetDomainTypeEntry(localNode, records.KeyDomainType, *test.domainType)
 				require.NoError(t, err)
 			}
-			if test.subnets != nil {
+			if !test.missingSubnets {
 				err := records.SetSubnetsEntry(localNode, test.subnets)
 				require.NoError(t, err)
 			}
@@ -120,7 +121,7 @@ func TestCheckPeer(t *testing.T) {
 	}
 
 	// Run the tests.
-	subnetIndex := peers.NewSubnetsIndex(commons.SubnetsCount)
+	subnetIndex := peers.NewSubnetsIndex()
 	dvs := &DiscV5Service{
 		ctx:                 ctx,
 		conns:               &mock.MockConnectionIndex{LimitValue: false},
@@ -147,17 +148,18 @@ func TestCheckPeer(t *testing.T) {
 }
 
 type checkPeerTest struct {
-	name          string
-	domainType    *spectypes.DomainType
-	subnets       []byte
-	localNode     *enode.LocalNode
-	expectedError error
+	name           string
+	domainType     *spectypes.DomainType
+	subnets        commons.Subnets
+	missingSubnets bool
+	localNode      *enode.LocalNode
+	expectedError  error
 }
 
-func mockSubnets(active ...int) []byte {
-	subnets := make([]byte, commons.SubnetsCount)
+func mockSubnets(active ...uint64) commons.Subnets {
+	subnets := commons.Subnets{}
 	for _, subnet := range active {
-		subnets[subnet] = 1
+		subnets.Set(subnet)
 	}
 	return subnets
 }

--- a/network/discovery/node_record.go
+++ b/network/discovery/node_record.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
+	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/records"
 )
 
@@ -17,7 +18,7 @@ func DecorateWithDomainType(key records.ENRKey, domainType spectypes.DomainType)
 	}
 }
 
-func DecorateWithSubnets(subnets []byte) NodeRecordDecoration {
+func DecorateWithSubnets(subnets commons.Subnets) NodeRecordDecoration {
 	return func(node *enode.LocalNode) error {
 		return records.SetSubnetsEntry(node, subnets)
 	}

--- a/network/discovery/options.go
+++ b/network/discovery/options.go
@@ -33,8 +33,8 @@ type DiscV5Options struct {
 	NetworkKey *ecdsa.PrivateKey
 	// Bootnodes is a list of bootstrapper nodes
 	Bootnodes []string
-	// Subnets is a bool slice represents all the subnets the node is interested in
-	Subnets []byte
+	// Subnets is a bitmask that represents all the subnets the node is interested in
+	Subnets commons.Subnets
 	// EnableLogging when true enables logs to be emitted
 	EnableLogging bool
 }

--- a/network/discovery/service_test.go
+++ b/network/discovery/service_test.go
@@ -59,31 +59,31 @@ func TestDiscV5Service_RegisterSubnets(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, updated)
 
-	require.Equal(t, byte(1), dvs.subnets[1])
-	require.Equal(t, byte(1), dvs.subnets[3])
-	require.Equal(t, byte(1), dvs.subnets[5])
-	require.Equal(t, byte(0), dvs.subnets[2])
+	require.True(t, dvs.subnets.IsSet(1))
+	require.True(t, dvs.subnets.IsSet(3))
+	require.True(t, dvs.subnets.IsSet(5))
+	require.False(t, dvs.subnets.IsSet(2))
 
 	// Register the same subnets. Should not update the state
 	updated, err = dvs.RegisterSubnets(testLogger, 1, 3, 5)
 	assert.NoError(t, err)
 	assert.False(t, updated)
 
-	require.Equal(t, byte(1), dvs.subnets[1])
-	require.Equal(t, byte(1), dvs.subnets[3])
-	require.Equal(t, byte(1), dvs.subnets[5])
-	require.Equal(t, byte(0), dvs.subnets[2])
+	require.True(t, dvs.subnets.IsSet(1))
+	require.True(t, dvs.subnets.IsSet(3))
+	require.True(t, dvs.subnets.IsSet(5))
+	require.False(t, dvs.subnets.IsSet(2))
 
 	// Register different subnets
 	updated, err = dvs.RegisterSubnets(testLogger, 2, 4)
 	assert.NoError(t, err)
 	assert.True(t, updated)
-	require.Equal(t, byte(1), dvs.subnets[1])
-	require.Equal(t, byte(1), dvs.subnets[2])
-	require.Equal(t, byte(1), dvs.subnets[3])
-	require.Equal(t, byte(1), dvs.subnets[4])
-	require.Equal(t, byte(1), dvs.subnets[5])
-	require.Equal(t, byte(0), dvs.subnets[6])
+	require.True(t, dvs.subnets.IsSet(1))
+	require.True(t, dvs.subnets.IsSet(2))
+	require.True(t, dvs.subnets.IsSet(3))
+	require.True(t, dvs.subnets.IsSet(4))
+	require.True(t, dvs.subnets.IsSet(5))
+	require.False(t, dvs.subnets.IsSet(6))
 
 	// Close
 	err = dvs.Close()
@@ -97,18 +97,18 @@ func TestDiscV5Service_DeregisterSubnets(t *testing.T) {
 	_, err := dvs.RegisterSubnets(testLogger, 1, 2, 3)
 	require.NoError(t, err)
 
-	require.Equal(t, byte(1), dvs.subnets[1])
-	require.Equal(t, byte(1), dvs.subnets[2])
-	require.Equal(t, byte(1), dvs.subnets[3])
+	require.True(t, dvs.subnets.IsSet(1))
+	require.True(t, dvs.subnets.IsSet(2))
+	require.True(t, dvs.subnets.IsSet(3))
 
 	// Deregister from 2 and 3
 	updated, err := dvs.DeregisterSubnets(testLogger, 2, 3)
 	assert.NoError(t, err)
 	assert.True(t, updated)
 
-	require.Equal(t, byte(1), dvs.subnets[1])
-	require.Equal(t, byte(0), dvs.subnets[2])
-	require.Equal(t, byte(0), dvs.subnets[3])
+	require.True(t, dvs.subnets.IsSet(1))
+	require.False(t, dvs.subnets.IsSet(2))
+	require.False(t, dvs.subnets.IsSet(3))
 
 	// Deregistering non-existent subnets should not update
 	updated, err = dvs.DeregisterSubnets(testLogger, 4, 5)
@@ -279,8 +279,8 @@ func TestDiscV5Service_checkPeer(t *testing.T) {
 	dvs.conns.(*MockConnection).SetAtLimit(false)
 
 	// Valid peer but no common subnet
-	subnets := make([]byte, len(commons.ZeroSubnets))
-	subnets[10] = 1
+	subnets := commons.Subnets{}
+	subnets.Set(10)
 	err = dvs.checkPeer(context.TODO(), testLogger, ToPeerEvent(NodeWithCustomSubnets(t, subnets)))
 	require.ErrorContains(t, err, "no shared subnets")
 }

--- a/network/discovery/subnets.go
+++ b/network/discovery/subnets.go
@@ -42,13 +42,3 @@ func isSubnet(ns string) bool {
 	defer done()
 	return r.MatchString(ns)
 }
-
-// HasActiveSubnets checks if there is at least one active subnet in the provided byte slice.
-func HasActiveSubnets(subnets []byte) bool {
-	for _, val := range subnets {
-		if val > 0 {
-			return true
-		}
-	}
-	return false
-}

--- a/network/discovery/util_test.go
+++ b/network/discovery/util_test.go
@@ -62,8 +62,7 @@ func testingDiscoveryOptions(t *testing.T, networkConfig networkconfig.NetworkCo
 	}
 
 	// Discovery options
-	allSubs, _ := commons.FromString(commons.AllSubnets)
-	subnetsIndex := peers.NewSubnetsIndex(len(allSubs))
+	subnetsIndex := peers.NewSubnetsIndex()
 	connectionIndex := NewMockConnection()
 
 	return &Options{
@@ -133,7 +132,7 @@ func NodeWithoutNextDomain(t *testing.T) *enode.Node {
 }
 
 func NodeWithoutSubnets(t *testing.T) *enode.Node {
-	return CustomNode(t, true, testNetConfig.DomainType, true, testNetConfig.DomainType, false, nil)
+	return CustomNode(t, true, testNetConfig.DomainType, true, testNetConfig.DomainType, false, commons.Subnets{})
 }
 
 func NodeWithCustomDomains(t *testing.T, domainType spectypes.DomainType, nextDomainType spectypes.DomainType) *enode.Node {
@@ -141,17 +140,17 @@ func NodeWithCustomDomains(t *testing.T, domainType spectypes.DomainType, nextDo
 }
 
 func NodeWithZeroSubnets(t *testing.T) *enode.Node {
-	return CustomNode(t, true, testNetConfig.DomainType, true, testNetConfig.DomainType, true, zeroSubnets)
+	return CustomNode(t, true, testNetConfig.DomainType, true, testNetConfig.DomainType, true, commons.ZeroSubnets)
 }
 
-func NodeWithCustomSubnets(t *testing.T, subnets []byte) *enode.Node {
+func NodeWithCustomSubnets(t *testing.T, subnets commons.Subnets) *enode.Node {
 	return CustomNode(t, true, testNetConfig.DomainType, true, testNetConfig.DomainType, true, subnets)
 }
 
 func CustomNode(t *testing.T,
 	setDomainType bool, domainType spectypes.DomainType,
 	setNextDomainType bool, nextDomainType spectypes.DomainType,
-	setSubnets bool, subnets []byte) *enode.Node {
+	setSubnets bool, subnets commons.Subnets) *enode.Node {
 
 	// Generate key
 	nodeKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -184,8 +183,8 @@ func CustomNode(t *testing.T,
 	}
 	if setSubnets {
 		subnetsVec := bitfield.NewBitvector128()
-		for i, subnet := range subnets {
-			subnetsVec.SetBitAt(uint64(i), subnet > 0)
+		for i := uint64(0); i < commons.SubnetsCount; i++ {
+			subnetsVec.SetBitAt(i, subnets.IsSet(i))
 		}
 		record.Set(enr.WithEntry("subnets", &subnetsVec))
 	}
@@ -295,7 +294,7 @@ func (mc *MockConnection) AtLimit(dir network.Direction) bool {
 	return mc.atLimit
 }
 
-func (mc *MockConnection) IsBad(logger *zap.Logger, id peer.ID) bool {
+func (mc *MockConnection) IsBad(id peer.ID) bool {
 	mc.mu.RLock()
 	defer mc.mu.RUnlock()
 	if bad, ok := mc.isBad[id]; ok {

--- a/network/p2p/p2p_discovery_test.go
+++ b/network/p2p/p2p_discovery_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 // createSubnets creates a commons.Subnets with the specified subnets active
-func createSubnets(activeSubnets ...int) commons.Subnets {
-	subnets := make(commons.Subnets, commons.SubnetsCount)
+func createSubnets(activeSubnets ...uint64) commons.Subnets {
+	subnets := commons.Subnets{}
 	for _, subnet := range activeSubnets {
-		if subnet >= 0 && subnet < commons.SubnetsCount {
-			subnets[subnet] = 1
+		if subnet < commons.SubnetsCount {
+			subnets.Set(subnet)
 		}
 	}
 	return subnets

--- a/network/p2p/p2p_pubsub.go
+++ b/network/p2p/p2p_pubsub.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"time"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -15,7 +16,6 @@ import (
 	"github.com/ssvlabs/ssv/logging/fields"
 	"github.com/ssvlabs/ssv/network"
 	"github.com/ssvlabs/ssv/network/commons"
-	"github.com/ssvlabs/ssv/network/discovery"
 	p2pprotocol "github.com/ssvlabs/ssv/protocol/v2/p2p"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
 )
@@ -73,7 +73,7 @@ func (n *p2pNetwork) SubscribeAll(logger *zap.Logger) error {
 	if !n.isReady() {
 		return p2pprotocol.ErrNetworkIsNotReady
 	}
-	n.fixedSubnets, _ = commons.FromString(commons.AllSubnets)
+	n.persistentSubnets = commons.AllSubnets
 	for subnet := uint64(0); subnet < commons.SubnetsCount; subnet++ {
 		err := n.topicsCtrl.Subscribe(logger, commons.SubnetTopicID(subnet))
 		if err != nil {
@@ -84,6 +84,7 @@ func (n *p2pNetwork) SubscribeAll(logger *zap.Logger) error {
 }
 
 // SubscribeRandoms subscribes to random subnets. This method isn't thread-safe.
+// #nosec G115 -- Perm slice is [0, n)
 func (n *p2pNetwork) SubscribeRandoms(logger *zap.Logger, numSubnets int) error {
 	if !n.isReady() {
 		return p2pprotocol.ErrNetworkIsNotReady
@@ -100,7 +101,7 @@ func (n *p2pNetwork) SubscribeRandoms(logger *zap.Logger, numSubnets int) error 
 		// check if any of subnets we've generated in this random set is already being used by us
 		randSubnetAlreadyInUse := false
 		for _, subnet := range randomSubnets {
-			if n.activeSubnets[subnet] == 1 {
+			if n.currentSubnets.IsSet(uint64(subnet)) {
 				randSubnetAlreadyInUse = true
 				break
 			}
@@ -112,33 +113,27 @@ func (n *p2pNetwork) SubscribeRandoms(logger *zap.Logger, numSubnets int) error 
 	}
 
 	for _, subnet := range randomSubnets {
-		// #nosec G115
-		err := n.topicsCtrl.Subscribe(logger, commons.SubnetTopicID(uint64(subnet))) // Perm slice is [0, n)
+		err := n.topicsCtrl.Subscribe(logger, commons.SubnetTopicID(uint64(subnet)))
 		if err != nil {
 			return fmt.Errorf("could not subscribe to subnet %d: %w", subnet, err)
 		}
 	}
 
-	// Update the subnets slice.
-	subnets := make([]byte, commons.SubnetsCount)
-	copy(subnets, n.fixedSubnets)
 	for _, subnet := range randomSubnets {
-		subnets[subnet] = byte(1)
+		n.persistentSubnets.Set(uint64(subnet))
 	}
-	n.fixedSubnets = subnets
 
 	return nil
 }
 
 // SubscribedSubnets returns the subnets the node is subscribed to, consisting of the fixed subnets and the active committees/validators.
-func (n *p2pNetwork) SubscribedSubnets() []byte {
+func (n *p2pNetwork) SubscribedSubnets() commons.Subnets {
 	// Compute the new subnets according to the active committees/validators.
-	updatedSubnets := make([]byte, commons.SubnetsCount)
-	copy(updatedSubnets, n.fixedSubnets)
+	updatedSubnets := n.persistentSubnets
 
 	n.activeCommittees.Range(func(cid string, status validatorStatus) bool {
 		subnet := commons.CommitteeSubnet(spectypes.CommitteeID([]byte(cid)))
-		updatedSubnets[subnet] = byte(1)
+		updatedSubnets.Set(subnet)
 		return true
 	})
 
@@ -245,22 +240,19 @@ func (n *p2pNetwork) handlePubsubMessages(logger *zap.Logger) func(ctx context.C
 
 // subscribeToFixedSubnets subscribes to all the node's subnets
 func (n *p2pNetwork) subscribeToFixedSubnets(logger *zap.Logger) error {
-	if !discovery.HasActiveSubnets(n.fixedSubnets) {
+	if !n.persistentSubnets.HasActive() {
 		return nil
 	}
 
-	logger.Debug("subscribing to fixed subnets", fields.Subnets(n.fixedSubnets))
+	logger.Debug("subscribing to fixed subnets", fields.Subnets(n.persistentSubnets))
 
-	for i, val := range n.fixedSubnets {
-		if val > 0 {
-			subnet := fmt.Sprintf("%d", i)
-			if err := n.topicsCtrl.Subscribe(logger, subnet); err != nil {
-				logger.Warn("could not subscribe to subnet",
-					zap.String("subnet", subnet), zap.Error(err))
-				// TODO: handle error
-			}
+	subnetList := n.persistentSubnets.SubnetList()
+	for _, subnet := range subnetList {
+		if err := n.topicsCtrl.Subscribe(logger, strconv.FormatUint(subnet, 10)); err != nil {
+			logger.Warn("could not subscribe to subnet",
+				zap.Uint64("subnet", subnet), zap.Error(err))
+			// TODO: handle error
 		}
 	}
-
 	return nil
 }

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -93,13 +93,11 @@ func (n *p2pNetwork) initCfg() error {
 		n.cfg.UserAgent = userAgent(n.cfg.UserAgent)
 	}
 	if len(n.cfg.Subnets) > 0 {
-		subnets, err := p2pcommons.FromString(strings.Replace(n.cfg.Subnets, "0x", "", 1))
+		subnets, err := p2pcommons.SubnetsFromString(strings.Replace(n.cfg.Subnets, "0x", "", 1))
 		if err != nil {
 			return fmt.Errorf("parse subnet: %w", err)
 		}
-		n.fixedSubnets = subnets
-	} else {
-		n.fixedSubnets = make(p2pcommons.Subnets, p2pcommons.SubnetsCount)
+		n.persistentSubnets = subnets
 	}
 	if n.cfg.MaxPeers <= 0 {
 		n.cfg.MaxPeers = minPeersBuffer
@@ -113,11 +111,11 @@ func (n *p2pNetwork) initCfg() error {
 }
 
 // IsBadPeer returns whether a peer is bad
-func (n *p2pNetwork) IsBadPeer(logger *zap.Logger, peerID peer.ID) bool {
+func (n *p2pNetwork) IsBadPeer(peerID peer.ID) bool {
 	if !n.isIdxSet.Load() {
 		return false
 	}
-	return n.idx.IsBad(logger, peerID)
+	return n.idx.IsBad(peerID)
 }
 
 // SetupHost configures a libp2p host and backoff connector utility
@@ -194,13 +192,13 @@ func (n *p2pNetwork) setupPeerServices(logger *zap.Logger) error {
 	self := records.NewNodeInfo(domain)
 	self.Metadata = &records.NodeMetadata{
 		NodeVersion: commons.GetNodeVersion(),
-		Subnets:     p2pcommons.Subnets(n.fixedSubnets).String(),
+		Subnets:     n.persistentSubnets.String(),
 	}
 	getPrivKey := func() crypto.PrivKey {
 		return libPrivKey
 	}
 
-	n.idx = peers.NewPeersIndex(logger, n.host.Network(), self, n.getMaxPeers, getPrivKey, p2pcommons.SubnetsCount, 10*time.Minute, peers.NewGossipScoreIndex())
+	n.idx = peers.NewPeersIndex(logger, n.host.Network(), self, n.getMaxPeers, getPrivKey, peers.NewGossipScoreIndex())
 	n.isIdxSet.Store(true)
 
 	logger.Debug("peers index is ready")
@@ -222,7 +220,7 @@ func (n *p2pNetwork) setupPeerServices(logger *zap.Logger) error {
 		newDomainString := "0x" + hex.EncodeToString(newDomain[:])
 		return []connections.HandshakeFilter{
 			connections.NetworkIDFilter(newDomainString),
-			connections.BadPeerFilter(logger, n.idx),
+			connections.BadPeerFilter(n.idx),
 		}
 	}
 
@@ -249,11 +247,11 @@ func (n *p2pNetwork) setupPeerServices(logger *zap.Logger) error {
 }
 
 func (n *p2pNetwork) ActiveSubnets() p2pcommons.Subnets {
-	return n.activeSubnets
+	return n.currentSubnets
 }
 
 func (n *p2pNetwork) FixedSubnets() p2pcommons.Subnets {
-	return n.fixedSubnets
+	return n.persistentSubnets
 }
 
 func (n *p2pNetwork) setupDiscovery(logger *zap.Logger) error {
@@ -272,9 +270,9 @@ func (n *p2pNetwork) setupDiscovery(logger *zap.Logger) error {
 			Bootnodes:     n.cfg.TransformBootnodes(),
 			EnableLogging: n.cfg.DiscoveryTrace,
 		}
-		if discovery.HasActiveSubnets(n.fixedSubnets) {
-			discV5Opts.Subnets = n.fixedSubnets
-			logger = logger.With(fields.Subnets(n.fixedSubnets))
+		if n.persistentSubnets.HasActive() {
+			discV5Opts.Subnets = n.persistentSubnets
+			logger = logger.With(fields.Subnets(n.persistentSubnets))
 		}
 		logger.Info("discovery: using discv5",
 			zap.Strings("bootnodes", discV5Opts.Bootnodes),

--- a/network/peers/conn_manager.go
+++ b/network/peers/conn_manager.go
@@ -105,8 +105,11 @@ func (c connManager) DisconnectFromBadPeers(logger *zap.Logger, net libp2pnetwor
 func (c connManager) DisconnectFromIrrelevantPeers(logger *zap.Logger, disconnectQuota int, net libp2pnetwork.Network, allPeers []peer.ID, mySubnets commons.Subnets) int {
 	disconnectedPeers := 0
 	for _, peerID := range allPeers {
-		peerSubnets := c.subnetsIdx.GetPeerSubnets(peerID)
-		sharedSubnets := commons.SharedSubnets(mySubnets, peerSubnets, 0)
+		var sharedSubnets []uint64
+		peerSubnets, ok := c.subnetsIdx.GetPeerSubnets(peerID)
+		if ok {
+			sharedSubnets = mySubnets.SharedSubnets(peerSubnets)
+		}
 
 		// If there's no common subnet, disconnect from peer.
 		if len(sharedSubnets) == 0 {

--- a/network/peers/connections/conn_gater.go
+++ b/network/peers/connections/conn_gater.go
@@ -24,7 +24,7 @@ const (
 	ipLimitPeriod = 30 * time.Second
 )
 
-type IsBadPeerF func(logger *zap.Logger, peerID peer.ID) bool
+type IsBadPeerF func(peerID peer.ID) bool
 type AtInboundLimitF func() bool
 
 // connGater implements ConnectionGater interface:
@@ -70,7 +70,7 @@ func (n *connGater) InterceptPeerDial(id peer.ID) bool {
 // particular address. Blocking connections at this stage is typical for
 // address filtering.
 func (n *connGater) InterceptAddrDial(id peer.ID, multiaddr ma.Multiaddr) bool {
-	if n.isBadPeer(n.logger, id) {
+	if n.isBadPeer(id) {
 		n.logger.Debug("preventing outbound connection due to bad peer", fields.PeerID(id))
 		return false
 	}
@@ -111,7 +111,7 @@ func (n *connGater) InterceptSecured(direction libp2pnetwork.Direction, id peer.
 		return false
 	}
 
-	if n.isBadPeer(n.logger, id) {
+	if n.isBadPeer(id) {
 		n.logger.Debug("rejecting inbound connection due to bad peer", fields.PeerID(id))
 		return false
 	}

--- a/network/peers/connections/conn_handler.go
+++ b/network/peers/connections/conn_handler.go
@@ -227,20 +227,22 @@ func (ch *connHandler) Handle(logger *zap.Logger) *libp2pnetwork.NotifyBundle {
 
 func (ch *connHandler) sharesEnoughSubnets(logger *zap.Logger, conn libp2pnetwork.Conn) bool {
 	pid := conn.RemotePeer()
-	subnets := ch.subnetsIndex.GetPeerSubnets(pid)
-	if len(subnets) == 0 {
+	subnets, ok := ch.subnetsIndex.GetPeerSubnets(pid)
+	if !ok {
 		// no subnets for this peer
 		return false
 	}
+
+	logger = logger.With(fields.Subnets(subnets))
+
 	mySubnets := ch.subnetsProvider()
+	logger = logger.With(zap.String("my_subnets", mySubnets.String()))
 
-	logger = logger.With(fields.Subnets(subnets), zap.String("my_subnets", mySubnets.String()))
-
-	if mySubnets.String() == commons.ZeroSubnets { // this node has no subnets
+	if mySubnets == commons.ZeroSubnets { // this node has no subnets
 		return true
 	}
-	shared := commons.SharedSubnets(mySubnets, subnets, 1)
-	logger.Debug("checking subnets", zap.Ints("shared", shared))
+	shared := mySubnets.SharedSubnetsN(subnets, 1)
+	logger.Debug("checking subnets", zap.Uint64s("shared", shared))
 
 	return len(shared) == 1
 }

--- a/network/peers/connections/filters.go
+++ b/network/peers/connections/filters.go
@@ -3,7 +3,6 @@ package connections
 import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/network/peers"
 	"github.com/ssvlabs/ssv/network/records"
@@ -21,9 +20,9 @@ func NetworkIDFilter(networkID string) HandshakeFilter {
 }
 
 // BadPeerFilter avoids connecting to a bad peer
-func BadPeerFilter(logger *zap.Logger, n peers.Index) HandshakeFilter {
+func BadPeerFilter(n peers.Index) HandshakeFilter {
 	return func(senderID peer.ID, sni *records.NodeInfo) error {
-		if n.IsBad(logger, senderID) {
+		if n.IsBad(senderID) {
 			return errors.New("bad peer")
 		}
 		return nil

--- a/network/peers/connections/handshaker.go
+++ b/network/peers/connections/handshaker.go
@@ -198,7 +198,7 @@ func (h *handshaker) updatePeerInfo(pid peer.ID, handshakeErr error) {
 // updateNodeSubnets tries to update the subnets of the given peer
 func (h *handshaker) updateNodeSubnets(logger *zap.Logger, pid peer.ID, ni *records.NodeInfo) {
 	if ni.Metadata != nil {
-		subnets, err := commons.FromString(ni.Metadata.Subnets)
+		subnets, err := commons.SubnetsFromString(ni.Metadata.Subnets)
 		if err == nil {
 			updated := h.subnetsIdx.UpdatePeerSubnets(pid, subnets)
 			if updated {

--- a/network/peers/connections/helpers_test.go
+++ b/network/peers/connections/helpers_test.go
@@ -49,7 +49,7 @@ func getTestingData(t *testing.T) TestData {
 			NodeVersion:   "some-node-version",
 			ExecutionNode: "some-execution-node",
 			ConsensusNode: "some-consensus-node",
-			Subnets:       commons.AllSubnets,
+			Subnets:       commons.AllSubnets.String(),
 		},
 	}
 
@@ -60,7 +60,7 @@ func getTestingData(t *testing.T) TestData {
 				NodeVersion:   "test-node-version",
 				ExecutionNode: "test-execution-node",
 				ConsensusNode: "test-consensus-node",
-				Subnets:       commons.AllSubnets,
+				Subnets:       commons.AllSubnets.String(),
 			},
 		},
 		MockSelfSealed: []byte("something"),
@@ -93,7 +93,7 @@ func getTestingData(t *testing.T) TestData {
 		ctx:        context.Background(),
 		nodeInfos:  nii,
 		peerInfos:  ns,
-		subnetsIdx: peers.NewSubnetsIndex(commons.SubnetsCount),
+		subnetsIdx: peers.NewSubnetsIndex(),
 		ids:        ids,
 		net:        net,
 		streams:    sc,

--- a/network/peers/connections/mock/mock_connection_index.go
+++ b/network/peers/connections/mock/mock_connection_index.go
@@ -3,7 +3,6 @@ package mock
 import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"go.uber.org/zap"
 )
 
 // MockConnectionIndex is a mock implementation of the ConnectionIndex interface
@@ -27,6 +26,6 @@ func (m *MockConnectionIndex) AtLimit(dir network.Direction) bool {
 }
 
 // IsBad panics if called
-func (m *MockConnectionIndex) IsBad(logger *zap.Logger, id peer.ID) bool {
+func (m *MockConnectionIndex) IsBad(id peer.ID) bool {
 	panic("IsBad method is not implemented in MockConnectionIndex")
 }

--- a/network/peers/index.go
+++ b/network/peers/index.go
@@ -7,7 +7,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/records"
@@ -42,7 +41,7 @@ type ConnectionIndex interface {
 	AtLimit(dir libp2pnetwork.Direction) bool
 
 	// IsBad returns whether the given peer is bad
-	IsBad(logger *zap.Logger, id peer.ID) bool
+	IsBad(id peer.ID) bool
 }
 
 // ScoreIndex is an interface for managing peers scores
@@ -92,21 +91,21 @@ type PeerInfoIndex interface {
 // SubnetsStats holds a snapshot of subnets stats
 type SubnetsStats struct {
 	AvgConnected int
-	PeersCount   []int
-	Connected    []int
+	PeersCount   [commons.SubnetsCount]int
+	Connected    [commons.SubnetsCount]int
 }
 
 // SubnetsIndex stores information on subnets.
 // it keeps track of subnets but doesn't mind regards actual connections that we have.
 type SubnetsIndex interface {
 	// UpdatePeerSubnets updates the given peer's subnets
-	UpdatePeerSubnets(id peer.ID, s commons.Subnets) bool
+	UpdatePeerSubnets(id peer.ID, subnets commons.Subnets) bool
 
 	// GetSubnetPeers returns peers that are interested in the given subnet
-	GetSubnetPeers(s int) []peer.ID
+	GetSubnetPeers(subnet int) []peer.ID
 
-	// GetPeerSubnets returns subnets of the given peer
-	GetPeerSubnets(id peer.ID) commons.Subnets
+	// GetPeerSubnets returns subnets of the given peer and whether it was found
+	GetPeerSubnets(id peer.ID) (subnets commons.Subnets, ok bool)
 
 	// GetSubnetsStats collects and returns subnets stats
 	GetSubnetsStats() *SubnetsStats

--- a/network/peers/peers_index.go
+++ b/network/peers/peers_index.go
@@ -3,7 +3,6 @@ package peers
 import (
 	"fmt"
 	"sync"
-	"time"
 
 	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
@@ -23,6 +22,8 @@ type NetworkKeyProvider func() libp2pcrypto.PrivKey
 
 // peersIndex implements Index interface.
 type peersIndex struct {
+	logger *zap.Logger
+
 	netKeyProvider NetworkKeyProvider
 	network        libp2pnetwork.Network
 
@@ -39,13 +40,20 @@ type peersIndex struct {
 }
 
 // NewPeersIndex creates a new Index
-func NewPeersIndex(logger *zap.Logger, network libp2pnetwork.Network, self *records.NodeInfo, maxPeers MaxPeersProvider,
-	netKeyProvider NetworkKeyProvider, subnetsCount int, pruneTTL time.Duration, gossipScoreIndex GossipScoreIndex) *peersIndex {
+func NewPeersIndex(
+	logger *zap.Logger,
+	network libp2pnetwork.Network,
+	self *records.NodeInfo,
+	maxPeers MaxPeersProvider,
+	netKeyProvider NetworkKeyProvider,
+	gossipScoreIndex GossipScoreIndex,
+) *peersIndex {
 
 	return &peersIndex{
+		logger:           logger,
 		network:          network,
 		scoreIdx:         newScoreIndex(),
-		SubnetsIndex:     NewSubnetsIndex(subnetsCount),
+		SubnetsIndex:     NewSubnetsIndex(),
 		PeerInfoIndex:    NewPeerInfoIndex(),
 		self:             self,
 		selfLock:         &sync.RWMutex{},
@@ -60,7 +68,7 @@ func NewPeersIndex(logger *zap.Logger, network libp2pnetwork.Network, self *reco
 // - bad gossip score
 // - pruned (that was not expired)
 // - bad score
-func (pi *peersIndex) IsBad(logger *zap.Logger, id peer.ID) bool {
+func (pi *peersIndex) IsBad(id peer.ID) bool {
 	if isBad, _ := pi.HasBadGossipScore(id); isBad {
 		return true
 	}
@@ -75,7 +83,7 @@ func (pi *peersIndex) IsBad(logger *zap.Logger, id peer.ID) bool {
 
 	for _, score := range scores {
 		if score.Value < threshold {
-			logger.Debug("bad peer (low score)")
+			pi.logger.Debug("bad peer (low score)")
 			return true
 		}
 	}
@@ -159,7 +167,7 @@ func (pi *peersIndex) GetSubnetsStats() *SubnetsStats {
 	if stats == nil {
 		return nil
 	}
-	stats.Connected = make([]int, len(stats.PeersCount))
+
 	var sumConnected int
 	for subnet := range stats.PeersCount {
 		peers := pi.GetSubnetPeers(subnet)
@@ -172,9 +180,8 @@ func (pi *peersIndex) GetSubnetsStats() *SubnetsStats {
 		stats.Connected[subnet] = connectedCount
 		sumConnected += connectedCount
 	}
-	if len(stats.PeersCount) > 0 {
-		stats.AvgConnected = sumConnected / len(stats.PeersCount)
-	}
+
+	stats.AvgConnected = sumConnected / len(stats.PeersCount)
 
 	return stats
 }

--- a/network/peers/subnets.go
+++ b/network/peers/subnets.go
@@ -10,15 +10,14 @@ import (
 
 // subnetsIndex implements SubnetsIndex
 type subnetsIndex struct {
-	subnets     [][]peer.ID
+	subnets     [commons.SubnetsCount][]peer.ID
 	peerSubnets map[peer.ID]commons.Subnets
 
 	lock *sync.RWMutex
 }
 
-func NewSubnetsIndex(count int) SubnetsIndex {
+func NewSubnetsIndex() SubnetsIndex {
 	return &subnetsIndex{
-		subnets:     make([][]peer.ID, count),
 		peerSubnets: map[peer.ID]commons.Subnets{},
 		lock:        &sync.RWMutex{},
 	}
@@ -29,48 +28,42 @@ func (si *subnetsIndex) UpdatePeerSubnets(id peer.ID, s commons.Subnets) bool {
 	defer si.lock.Unlock()
 
 	existing, ok := si.peerSubnets[id]
+	var addedSubnets, removedSubnets commons.Subnets
 	if !ok {
-		existing = make([]byte, 0)
+		// New peer: all subnets in 's' are additions
+		addedSubnets = s
+		// No subnets were previously set, so no removals
+		removedSubnets = commons.ZeroSubnets
+	} else {
+		// Existing peer: compute diffs
+		addedSubnets, removedSubnets = existing.DiffSubnets(s)
 	}
-	diff := commons.DiffSubnets(existing, s)
-	if len(diff) == 0 {
+
+	// Determine if any changes occurred (additions or removals)
+	hasChanges := !ok || addedSubnets.ActiveCount() > 0 || removedSubnets.ActiveCount() > 0
+	if !hasChanges {
 		return false
 	}
+
+	// Update the peer's subnets
 	si.peerSubnets[id] = s
 
-diffLoop:
-	for subnet, val := range diff {
-		if subnet >= len(si.subnets) { // out of range
-			continue
+	// Update subnet-peer mappings
+	for subnet := uint64(0); subnet < commons.SubnetsCount; subnet++ {
+		if addedSubnets.IsSet(subnet) {
+			// Add peer to the subnet
+			si.subnets[subnet] = append(si.subnets[subnet], id)
 		}
-		peers := si.subnets[subnet]
-		if len(peers) == 0 {
-			peers = make([]peer.ID, 0)
-		}
-		for i, p := range peers {
-			if p == id {
-				// skip if peer is already listed in a subnet to be added
-				if val > byte(0) {
-					continue diffLoop
+		if removedSubnets.IsSet(subnet) {
+			// Remove peer from the subnet
+			peers := si.subnets[subnet]
+			for i, p := range peers {
+				if p == id {
+					// Remove peer from slice
+					si.subnets[subnet] = append(peers[:i], peers[i+1:]...)
+					break
 				}
-				// otherwise, remove peer from the subnet
-				if i == 0 {
-					if len(peers) == 1 {
-						si.subnets[subnet] = make([]peer.ID, 0)
-					} else {
-						// #nosec
-						// False positive by the linter, it says potential out of bounds,
-						// but it can't be because we're inside a for on `peers`.
-						si.subnets[subnet] = peers[1:]
-					}
-					continue diffLoop
-				}
-				si.subnets[subnet] = append(peers[:i], peers[i+1:]...)
-				continue diffLoop
 			}
-		}
-		if val > byte(0) {
-			si.subnets[subnet] = append(peers, id)
 		}
 	}
 	return true
@@ -94,9 +87,7 @@ func (si *subnetsIndex) GetSubnetsStats() *SubnetsStats {
 	si.lock.RLock()
 	defer si.lock.RUnlock()
 
-	stats := &SubnetsStats{
-		PeersCount: make([]int, len(si.subnets)),
-	}
+	stats := &SubnetsStats{}
 	for subnet, peers := range si.subnets {
 		stats.PeersCount[subnet] = len(peers)
 	}
@@ -104,32 +95,30 @@ func (si *subnetsIndex) GetSubnetsStats() *SubnetsStats {
 	return stats
 }
 
-func (si *subnetsIndex) GetPeerSubnets(id peer.ID) commons.Subnets {
+func (si *subnetsIndex) GetPeerSubnets(id peer.ID) (commons.Subnets, bool) {
 	si.lock.RLock()
 	defer si.lock.RUnlock()
 
 	subnets, ok := si.peerSubnets[id]
 	if !ok {
-		return make(commons.Subnets, commons.SubnetsCount)
+		return commons.Subnets{}, false
 	}
-	cp := make(commons.Subnets, len(subnets))
-	copy(cp, subnets)
-	return cp
+
+	return subnets, true
 }
 
 // GetSubnetsDistributionScores returns current subnets scores based on peers distribution.
 // subnets with low peer count would get higher score, and overloaded subnets gets a lower score (possibly negative).
 // Subnets in which the node doesn't participate receive a score of 0.
-func GetSubnetsDistributionScores(stats *SubnetsStats, minPerSubnet int, mySubnets commons.Subnets, topicMaxPeers int) []float64 {
+func GetSubnetsDistributionScores(stats *SubnetsStats, minPerSubnet int, mySubnets commons.Subnets, topicMaxPeers int) [commons.SubnetsCount]float64 {
 	const activeSubnetBoost = 0.2
 
-	allSubs, _ := commons.FromString(commons.AllSubnets)
-	activeSubnets := commons.SharedSubnets(allSubs, mySubnets, 0)
+	activeSubnets := commons.AllSubnets.SharedSubnets(mySubnets)
 
-	scores := make([]float64, len(allSubs))
+	var scores [commons.SubnetsCount]float64
 	for _, s := range activeSubnets {
 		var connected int
-		if s < len(stats.Connected) {
+		if s < uint64(len(stats.Connected)) {
 			connected = stats.Connected[s]
 		}
 		scores[s] = activeSubnetBoost + scoreSubnet(connected, minPerSubnet, topicMaxPeers)

--- a/network/peers/subnets_test.go
+++ b/network/peers/subnets_test.go
@@ -27,24 +27,32 @@ func TestSubnetsIndex(t *testing.T) {
 		pids = append(pids, pid)
 	}
 
-	sAll, err := commons.FromString("0xffffffffffffffffffffffffffffffff")
-	require.NoError(t, err)
-	sNone, err := commons.FromString("0x00000000000000000000000000000000")
-	require.NoError(t, err)
-	sPartial, err := commons.FromString("0x57b080fffd743d9878dc41a184ab160a")
+	sPartial, err := commons.SubnetsFromString("0x57b080fffd743d9878dc41a184ab160a")
 	require.NoError(t, err)
 
-	subnetsIdx := NewSubnetsIndex(128)
+	subnetsIdx := NewSubnetsIndex()
 
-	subnetsIdx.UpdatePeerSubnets(pids[0], sAll.Clone())
-	subnetsIdx.UpdatePeerSubnets(pids[1], sNone.Clone())
-	subnetsIdx.UpdatePeerSubnets(pids[2], sPartial.Clone())
-	subnetsIdx.UpdatePeerSubnets(pids[3], sPartial.Clone())
+	initialMapping := map[peer.ID]commons.Subnets{
+		pids[0]: commons.AllSubnets,
+		pids[1]: commons.ZeroSubnets,
+		pids[2]: sPartial,
+		pids[3]: sPartial,
+	}
+
+	for pid, subnets := range initialMapping {
+		subnetsIdx.UpdatePeerSubnets(pid, subnets)
+	}
 
 	require.Len(t, subnetsIdx.GetSubnetPeers(0), 3)
 	require.Len(t, subnetsIdx.GetSubnetPeers(10), 1)
 
-	subnetsIdx.UpdatePeerSubnets(pids[0], sPartial.Clone())
+	for _, pid := range pids {
+		subnets, ok := subnetsIdx.GetPeerSubnets(pid)
+		require.True(t, ok)
+		require.Equal(t, initialMapping[pid], subnets)
+	}
+
+	subnetsIdx.UpdatePeerSubnets(pids[0], sPartial)
 
 	require.Len(t, subnetsIdx.GetSubnetPeers(0), 3)
 	require.Len(t, subnetsIdx.GetSubnetPeers(10), 0)
@@ -52,30 +60,26 @@ func TestSubnetsIndex(t *testing.T) {
 	stats := subnetsIdx.GetSubnetsStats()
 	require.Equal(t, 3, stats.PeersCount[0])
 
-	subnetsIdx.UpdatePeerSubnets(pids[0], sNone.Clone())
-	subnetsIdx.UpdatePeerSubnets(pids[2], sNone.Clone())
-	subnetsIdx.UpdatePeerSubnets(pids[3], sNone.Clone())
+	subnetsIdx.UpdatePeerSubnets(pids[0], commons.ZeroSubnets)
+	subnetsIdx.UpdatePeerSubnets(pids[2], commons.ZeroSubnets)
+	subnetsIdx.UpdatePeerSubnets(pids[3], commons.ZeroSubnets)
 
 	require.Len(t, subnetsIdx.GetSubnetPeers(0), 0)
 	require.Len(t, subnetsIdx.GetSubnetPeers(10), 0)
 }
 
 func TestSubnetsDistributionScores(t *testing.T) {
-	nsubnets := 128
-	mysubnets := make(commons.Subnets, nsubnets)
-	allSubs, _ := commons.FromString(commons.AllSubnets)
-	for sub := range allSubs {
-		if sub%2 == 0 {
-			mysubnets[sub] = byte(0)
-		} else {
-			mysubnets[sub] = byte(1)
+	mySubnets := commons.Subnets{}
+	for i := uint64(0); i < commons.SubnetsCount; i++ {
+		if i%2 != 0 {
+			mySubnets.Set(i)
 		}
 	}
-	stats := &SubnetsStats{
-		PeersCount: make([]int, len(mysubnets)),
-		Connected:  make([]int, len(mysubnets)),
-	}
-	for sub := range mysubnets {
+
+	t.Logf("my subnets: %v", mySubnets.String())
+
+	stats := &SubnetsStats{}
+	for sub := 0; sub < commons.SubnetsCount; sub++ {
 		stats.Connected[sub] = 1 + rand.Intn(20)
 		stats.PeersCount[sub] = stats.Connected[sub] + rand.Intn(10)
 	}
@@ -84,9 +88,9 @@ func TestSubnetsDistributionScores(t *testing.T) {
 	stats.Connected[5] = 30
 	stats.PeersCount[5] = 30
 
-	distScores := GetSubnetsDistributionScores(stats, 3, mysubnets, 5)
+	distScores := GetSubnetsDistributionScores(stats, 3, mySubnets, 5)
 
-	require.Len(t, distScores, len(mysubnets))
+	require.Len(t, distScores, commons.SubnetsCount)
 	require.Equal(t, float64(0), distScores[0])
 	require.Equal(t, float64(4.2), distScores[1])
 	require.Equal(t, float64(2.533333333333333), distScores[3])
@@ -140,7 +144,7 @@ func TestUpdatePeerSubnets_Removal(t *testing.T) {
 
 	getSubnet := func(t *testing.T, subnetHex string) commons.Subnets {
 		require.Len(t, subnetHex, 32, "subnetHex must be 32 characters long, got %d", len(subnetHex))
-		s, err := commons.FromString(subnetHex)
+		s, err := commons.SubnetsFromString(subnetHex)
 		require.NoError(t, err)
 		return s
 	}
@@ -194,7 +198,7 @@ func TestUpdatePeerSubnets_Removal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			subnetsIdx := NewSubnetsIndex(128)
+			subnetsIdx := NewSubnetsIndex()
 			pids := generateTestPeers(t, tt.numPeers)
 			subnetID := 0
 			sInitial := getSubnet(t, tt.initialSubnets)

--- a/network/records/node_info_test.go
+++ b/network/records/node_info_test.go
@@ -20,7 +20,7 @@ func TestNodeInfo_Seal_Consume(t *testing.T) {
 			NodeVersion:   "v0.1.12",
 			ExecutionNode: "geth/x",
 			ConsensusNode: "prysm/x",
-			Subnets:       commons.AllSubnets,
+			Subnets:       commons.AllSubnets.String(),
 		},
 	}
 
@@ -42,7 +42,7 @@ func TestNodeInfo_Marshal_Unmarshal(t *testing.T) {
 			NodeVersion:   "v0.1.12",
 			ExecutionNode: "geth/x",
 			ConsensusNode: "prysm/x",
-			Subnets:       commons.AllSubnets,
+			Subnets:       commons.AllSubnets.String(),
 		},
 	}
 

--- a/network/records/subnets.go
+++ b/network/records/subnets.go
@@ -1,36 +1,34 @@
 package records
 
 import (
-	"bytes"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/pkg/errors"
+
+	"github.com/ssvlabs/ssv/network/commons"
 )
 
 // UpdateSubnets updates subnets entry according to the given changes.
 // count is the amount of subnets, in case that the entry doesn't exist as we want to initialize it
-func UpdateSubnets(node *enode.LocalNode, count int, added []uint64, removed []uint64) ([]byte, error) {
+func UpdateSubnets(node *enode.LocalNode, added []uint64, removed []uint64) (commons.Subnets, bool, error) {
 	subnets, err := GetSubnetsEntry(node.Node().Record())
 	if err != nil && !errors.Is(err, ErrEntryNotFound) {
-		return nil, errors.Wrap(err, "could not read subnets entry")
+		return commons.Subnets{}, false, fmt.Errorf("could not read subnets entry: %w", err)
 	}
-	orig := make([]byte, len(subnets))
-	if len(subnets) == 0 { // not exist, creating slice
-		subnets = make([]byte, count)
-	} else {
-		copy(orig, subnets)
-	}
+
+	orig := subnets
 	for _, i := range added {
-		subnets[i] = 1
+		subnets.Set(i)
 	}
 	for _, i := range removed {
-		subnets[i] = 0
+		subnets.Clear(i)
 	}
-	if bytes.Equal(orig, subnets) {
-		return nil, nil
+	if orig == subnets {
+		return commons.Subnets{}, false, nil
 	}
 	if err := SetSubnetsEntry(node, subnets); err != nil {
-		return nil, errors.Wrap(err, "could not update subnets entry")
+		return commons.Subnets{}, false, fmt.Errorf("could not update subnets entry: %w", err)
 	}
-	return subnets, nil
+	return subnets, true, nil
 }

--- a/network/records/subnets_test.go
+++ b/network/records/subnets_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func Test_SubnetsEntry(t *testing.T) {
-	SubnetsCount := 128
 	priv, _, err := crypto.GenerateSecp256k1Key(crand.Reader)
 	require.NoError(t, err)
 	sk, err := commons.ECDSAPrivFromInterface(priv)
@@ -21,12 +20,12 @@ func Test_SubnetsEntry(t *testing.T) {
 	node, err := CreateLocalNode(sk, "", ip, commons.DefaultUDP, commons.DefaultTCP)
 	require.NoError(t, err)
 
-	subnets := make([]byte, SubnetsCount)
-	for i := 0; i < SubnetsCount; i++ {
+	subnets := commons.Subnets{}
+	for i := uint64(0); i < commons.SubnetsCount; i++ {
 		if i%4 == 0 {
-			subnets[i] = 1
+			subnets.Set(i)
 		} else {
-			subnets[i] = 0
+			subnets.Clear(i)
 		}
 	}
 	require.NoError(t, SetSubnetsEntry(node, subnets))
@@ -34,12 +33,12 @@ func Test_SubnetsEntry(t *testing.T) {
 
 	subnetsFromEnr, err := GetSubnetsEntry(node.Node().Record())
 	require.NoError(t, err)
-	require.Len(t, subnetsFromEnr, SubnetsCount)
-	for i := 0; i < SubnetsCount; i++ {
+	require.Len(t, subnetsFromEnr, commons.SubnetsCount)
+	for i := uint64(0); i < commons.SubnetsCount; i++ {
 		if i%4 == 0 {
-			require.Equal(t, byte(1), subnetsFromEnr[i])
+			require.True(t, subnetsFromEnr.IsSet(i))
 		} else {
-			require.Equal(t, byte(0), subnetsFromEnr[i])
+			require.False(t, subnetsFromEnr.IsSet(i))
 		}
 	}
 }

--- a/operator/validator/controller_test.go
+++ b/operator/validator/controller_test.go
@@ -187,7 +187,7 @@ func TestSetupValidatorsExporter(t *testing.T) {
 			}
 
 			network.EXPECT().ActiveSubnets().Return(subnets[:]).AnyTimes()
-			network.EXPECT().FixedSubnets().Return(make(commons.Subnets, commons.SubnetsCount)).AnyTimes()
+			network.EXPECT().FixedSubnets().Return(commons.Subnets{}).AnyTimes()
 
 			if tc.shareStorageListResponse == nil {
 				sharesStorage.EXPECT().List(gomock.Any(), gomock.Any()).Return(tc.shareStorageListResponse).Times(1)

--- a/operator/validator/metadata/syncer.go
+++ b/operator/validator/metadata/syncer.go
@@ -94,7 +94,7 @@ func (s *Syncer) SyncOnStartup(ctx context.Context) (map[spectypes.ValidatorPK]*
 	shares := s.shareStorage.List(nil, registrystorage.ByNotLiquidated(), func(share *ssvtypes.SSVShare) bool {
 		networkcommons.SetCommitteeSubnet(subnetsBuf, share.CommitteeID())
 		subnet := subnetsBuf.Uint64()
-		return ownSubnets[subnet] != 0
+		return ownSubnets.IsSet(subnet)
 	})
 	if len(shares) == 0 {
 		s.logger.Info("could not find non-liquidated own subnets validator shares on initial metadata retrieval")
@@ -285,7 +285,7 @@ func (s *Syncer) nextBatch(_ context.Context, subnetsBuf *big.Int) []*ssvtypes.S
 
 		networkcommons.SetCommitteeSubnet(subnetsBuf, share.CommitteeID())
 		subnet := subnetsBuf.Uint64()
-		if ownSubnets[subnet] == 0 {
+		if !ownSubnets.IsSet(subnet) {
 			return true
 		}
 
@@ -356,14 +356,13 @@ func (s *Syncer) selfSubnets(buf *big.Int) networkcommons.Subnets {
 		localBuf = new(big.Int)
 	}
 
-	mySubnets := make(networkcommons.Subnets, networkcommons.SubnetsCount)
-	copy(mySubnets, s.fixedSubnets)
+	mySubnets := s.fixedSubnets
 
 	// Compute the new subnets according to the active committees/validators.
 	myValidators := s.validatorStore.SelfValidators()
 	for _, v := range myValidators {
 		networkcommons.SetCommitteeSubnet(localBuf, v.CommitteeID())
-		mySubnets[localBuf.Uint64()] = 1
+		mySubnets.Set(localBuf.Uint64())
 	}
 
 	return mySubnets

--- a/operator/validator/metadata/syncer_test.go
+++ b/operator/validator/metadata/syncer_test.go
@@ -12,7 +12,7 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/beacon/goclient"
@@ -95,11 +95,8 @@ func TestUpdateValidatorMetadata(t *testing.T) {
 				return result, nil
 			}).AnyTimes()
 
-			noSubnets, err := commons.FromString("0x00000000000000000000000000000000")
-			require.NoError(t, err)
-
-			syncer := NewSyncer(logger, sharesStorage, validatorStore, networkconfig.TestNetwork, beaconNode, noSubnets)
-			_, err = syncer.Sync(context.TODO(), []spectypes.ValidatorPK{tc.testPublicKey})
+			syncer := NewSyncer(logger, sharesStorage, validatorStore, networkconfig.TestNetwork, beaconNode, commons.ZeroSubnets)
+			_, err := syncer.Sync(context.TODO(), []spectypes.ValidatorPK{tc.testPublicKey})
 			if tc.sharesStorageErr != nil {
 				require.ErrorIs(t, err, tc.sharesStorageErr)
 			} else {
@@ -665,9 +662,6 @@ func TestWithUpdateInterval(t *testing.T) {
 	// Define the interval we want to set
 	interval := testSyncInterval * 2
 
-	noSubnets, err := commons.FromString("0x00000000000000000000000000000000")
-	require.NoError(t, err)
-
 	// Create an Syncer with the WithSyncInterval option
 	syncer := NewSyncer(
 		logger,
@@ -675,7 +669,7 @@ func TestWithUpdateInterval(t *testing.T) {
 		mockValidatorStore,
 		networkconfig.TestNetwork,
 		mockBeaconNode,
-		noSubnets,
+		commons.ZeroSubnets,
 		WithSyncInterval(interval),
 	)
 


### PR DESCRIPTION
The current handling of records is very error-prone and causes bugs like https://github.com/ssvlabs/ssv/issues/1802. The code always expects subnets to be 128 byte long, so we can use `[128]byte` type instead of `[]byte`. If we use each bit for each subnet, we can even use `[16]byte`