### PR TITLE
fix: (discovery) logged configuration

### DIFF
--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -11,14 +11,13 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
-
 	"github.com/ssvlabs/ssv/logging"
 	"github.com/ssvlabs/ssv/logging/fields"
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/peers"
 	"github.com/ssvlabs/ssv/network/records"
 	"github.com/ssvlabs/ssv/networkconfig"
+	"go.uber.org/zap"
 )
 
 var (
@@ -67,20 +66,25 @@ type DiscV5Service struct {
 	publishLock chan struct{}
 }
 
-func newDiscV5Service(pctx context.Context, logger *zap.Logger, discOpts *Options) (Service, error) {
+func newDiscV5Service(pctx context.Context, logger *zap.Logger, opts *Options) (Service, error) {
 	ctx, cancel := context.WithCancel(pctx)
 	dvs := DiscV5Service{
 		ctx:           ctx,
 		cancel:        cancel,
-		conns:         discOpts.ConnIndex,
-		subnetsIdx:    discOpts.SubnetsIdx,
-		networkConfig: discOpts.NetworkConfig,
-		subnets:       discOpts.DiscV5Opts.Subnets,
+		conns:         opts.ConnIndex,
+		subnetsIdx:    opts.SubnetsIdx,
+		networkConfig: opts.NetworkConfig,
+		subnets:       opts.DiscV5Opts.Subnets,
 		publishLock:   make(chan struct{}, 1),
 	}
 
-	logger.Debug("configuring discv5 discovery", zap.Any("discOpts", discOpts))
-	if err := dvs.initDiscV5Listener(logger, discOpts); err != nil {
+	logger.Debug(
+		"configuring discv5 discovery",
+		zap.Any("discV5Opts", opts.DiscV5Opts),
+		zap.Any("hostAddress", opts.HostAddress),
+		zap.Any("hostDNS", opts.HostDNS),
+	)
+	if err := dvs.initDiscV5Listener(logger, opts); err != nil {
 		return nil, err
 	}
 	return &dvs, nil

--- a/network/discovery/options.go
+++ b/network/discovery/options.go
@@ -4,14 +4,12 @@ import (
 	"crypto/ecdsa"
 	"net"
 
-	"github.com/ssvlabs/ssv/logging"
-	compatible_logger "github.com/ssvlabs/ssv/network/discovery/logger"
-
-	"github.com/ssvlabs/ssv/network/commons"
-
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/pkg/errors"
+	"github.com/ssvlabs/ssv/logging"
+	"github.com/ssvlabs/ssv/network/commons"
+	compatible_logger "github.com/ssvlabs/ssv/network/discovery/logger"
 	"go.uber.org/zap"
 )
 
@@ -34,7 +32,7 @@ type DiscV5Options struct {
 	NetworkKey *ecdsa.PrivateKey
 	// Bootnodes is a list of bootstrapper nodes
 	Bootnodes []string
-	// Subnets is a bool slice represents all the subnets the node is intreseted in
+	// Subnets is a bool slice represents all the subnets the node is interested in
 	Subnets []byte
 	// EnableLogging when true enables logs to be emitted
 	EnableLogging bool


### PR DESCRIPTION
Noticed the following log:
```
{
  "level": "\u001b[35mDEBUG\u001b[0m",
  "time": "2024-10-25T17:19:55.282860Z",
  "name": "P2PNetwork",
  "msg": "configuring discv5 discovery",
  "selfPeer": "16Uiu2HAm5z6GYQaV4ddzic9zSugMFzgjtsUteCLWshkRXiKnodiy",
  "subnets": "00000000000000000000000000000000",
  "discOptsError": "json: unsupported type: basichost.AddrsFactory"
}
```
it seems `zap.Any` can't digest arbitrary structs and that results into this: `"discOptsError": "json: unsupported type: basichost.AddrsFactory"`, so in this PR I'm logging only most relevant options(hand-picked).