### PR TITLE
discovery: fix IP log when adding addresses

### DIFF
--- a/network/discovery/enode.go
+++ b/network/discovery/enode.go
@@ -38,7 +38,7 @@ func addAddresses(localNode *enode.LocalNode, hostAddr, hostDNS string) error {
 	if len(hostAddr) > 0 {
 		hostIP := net.ParseIP(hostAddr)
 		if hostIP.To4() == nil && hostIP.To16() == nil {
-			return fmt.Errorf("invalid host address given: %s", hostIP.String())
+			return fmt.Errorf("invalid host address given: %v", hostAddr)
 		}
 		localNode.SetFallbackIP(hostIP)
 		localNode.SetStaticIP(hostIP)


### PR DESCRIPTION
Outputting `hostIP` when it's `nil` causes this log: `invalid host address given: <nil>`. `hostAddr` should be logged instead