### PR TITLE
tests: p2p validation - use correct mutex to read roleBroadcasts changes

### DIFF
--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
 
-	"github.com/ssvlabs/ssv/utils/hashmap"
-
 	"github.com/ssvlabs/ssv/message/validation"
 	beaconprotocol "github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
@@ -149,7 +147,6 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// Prepare a pool of broadcasters.
-	mu := sync.Mutex{}
 	height := atomic.Int64{}
 	roleBroadcasts := map[spectypes.RunnerRole]int{}
 	broadcasters := pool.New().WithErrors().WithContext(ctx)
@@ -158,9 +155,9 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 			for i := 0; i < 12; i++ {
 				role := roles[i%len(roles)]
 
-				mu.Lock()
+				mtx.Lock()
 				roleBroadcasts[role]++
-				mu.Unlock()
+				mtx.Unlock()
 
 				msgID, msg := dummyMsg(t, hex.EncodeToString(shares[rand.Intn(len(shares))].ValidatorPubKey[:]), int(height.Add(1)), role)
 				err := node.Broadcast(msgID, msg)
@@ -192,10 +189,9 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 	// Wait for the broadcasters to finish.
 	err := broadcasters.Wait()
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
 
 	// Assert that the messages were distributed as expected.
-	time.Sleep(7 * time.Second)
+	time.Sleep(8 * time.Second)
 
 	interval := 100 * time.Millisecond
 	for i := 0; i < nodeCount; i++ {
@@ -246,11 +242,10 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 			index NodeIndex
 			score float64
 		}
-		peers := make([]peerScore, 0, node.PeerScores.SlowLen())
-		node.PeerScores.Range(func(index NodeIndex, snapshot *pubsub.PeerScoreSnapshot) bool {
+		peers := make([]peerScore, 0)
+		for index, snapshot := range *node.PeerScores.Load() {
 			peers = append(peers, peerScore{index, snapshot.Score})
-			return true
-		})
+		}
 		sort.Slice(peers, func(i, j int) bool {
 			return peers[i].score > peers[j].score
 		})
@@ -321,7 +316,7 @@ type NodeIndex int
 type VirtualNode struct {
 	Index      NodeIndex
 	Network    *p2pNetwork
-	PeerScores *hashmap.Map[NodeIndex, *pubsub.PeerScoreSnapshot]
+	PeerScores atomic.Pointer[map[NodeIndex]*pubsub.PeerScoreSnapshot]
 }
 
 func (n *VirtualNode) Broadcast(msgID spectypes.MessageID, msg *spectypes.SignedSSVMessage) error {
@@ -360,19 +355,16 @@ func CreateVirtualNet(
 				return
 			}
 
-			node.PeerScores.Range(func(index NodeIndex, snapshot *pubsub.PeerScoreSnapshot) bool {
-				node.PeerScores.Delete(index)
-				return true
-			})
+			peerScoresUpdated := make(map[NodeIndex]*pubsub.PeerScoreSnapshot, len(peerMap))
 			for peerID, peerScore := range peerMap {
 				peerNode := vn.NodeByPeerID(peerID)
 				if peerNode == nil {
 					t.Fatalf("peer not found (%s)", peerID)
 					return
 				}
-				node.PeerScores.Set(peerNode.Index, peerScore)
+				peerScoresUpdated[peerNode.Index] = peerScore
 			}
-
+			node.PeerScores.Store(&peerScoresUpdated)
 		},
 		PeerScoreInspectorInterval: time.Millisecond * 5,
 		Shares:                     shares,
@@ -384,9 +376,8 @@ func CreateVirtualNet(
 
 	for i, node := range ln.Nodes {
 		vn.Nodes = append(vn.Nodes, &VirtualNode{
-			Index:      NodeIndex(i),
-			Network:    node.(*p2pNetwork),
-			PeerScores: hashmap.New[NodeIndex, *pubsub.PeerScoreSnapshot](), //{}make(map[NodeIndex]*pubsub.PeerScoreSnapshot),
+			Index:   NodeIndex(i),
+			Network: node.(*p2pNetwork),
 		})
 	}
 	doneSetup.Store(true)


### PR DESCRIPTION
I've been observing flaky test running `make docker-unit-test` (eg. https://github.com/ssvlabs/ssv/actions/runs/11482239405/job/31954803590, it also seems to be the Case 1 described in https://github.com/ssvlabs/ssv/issues/1578):
```
--- FAIL: TestP2pNetwork_MessageValidation (11.50s)
    p2p_validation_test.go:279:
        	Error Trace:	/go/src/github.com/ssvlabs/ssv/network/p2p/p2p_validation_test.go:279
        	Error:      	Not equal:
        	            	expected: 3
        	            	actual  : 2
        	Test:       	TestP2pNetwork_MessageValidation
        	Messages:   	node 3
FAIL
coverage: 12.7% of statements
FAIL	github.com/ssvlabs/ssv/network/p2p	15.897s
```
This occasional failure seems to be due to the way `sync.Map` is being iterated with `Range` method (namely there is no way to get a consistent view for the whole map). In this PR I've simply changed the way access to this map is handled (instead of per-element update/read - map as a whole gets updated at once) and I no longer see this test failing (after running it locally a bunch of times with `make docker-unit-test`).