### PR TITLE
peers: fix subnets index removal logic

### DIFF
--- a/network/peers/subnets.go
+++ b/network/peers/subnets.go
@@ -65,7 +65,7 @@ diffLoop:
 					}
 					continue diffLoop
 				}
-				si.subnets[subnet] = append(peers[:i], peers[i:]...)
+				si.subnets[subnet] = append(peers[:i], peers[i+1:]...)
 				continue diffLoop
 			}
 		}

--- a/network/peers/subnets_test.go
+++ b/network/peers/subnets_test.go
@@ -140,9 +140,7 @@ func TestUpdatePeerSubnets_Removal(t *testing.T) {
 	}
 
 	getSubnet := func(t *testing.T, subnetHex string) records.Subnets {
-		if len(subnetHex) != 32 {
-			t.Fatalf("subnetHex must be 32 characters long, got %d", len(subnetHex))
-		}
+		require.Len(t, subnetHex, 32, "subnetHex must be 32 characters long, got %d", len(subnetHex))
 		s, err := records.Subnets{}.FromString(subnetHex)
 		require.NoError(t, err)
 		return s

--- a/network/peers/subnets_test.go
+++ b/network/peers/subnets_test.go
@@ -1,16 +1,18 @@
 package peers
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math"
 	"math/rand"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/records"
 	nettesting "github.com/ssvlabs/ssv/network/testing"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSubnetsIndex(t *testing.T) {
@@ -117,6 +119,118 @@ func TestSubnetScore(t *testing.T) {
 			if math.Abs(score-tc.expected) > 1e-6 {
 				t.Errorf("Expected score to be %f, got %f", tc.expected, score)
 			}
+		})
+	}
+}
+
+func TestUpdatePeerSubnets_Removal(t *testing.T) {
+	generateTestPeers := func(t *testing.T, count int) []peer.ID {
+		nks, err := nettesting.CreateKeys(count)
+		require.NoError(t, err)
+
+		var pids []peer.ID
+		for _, nk := range nks {
+			sk, err := commons.ECDSAPrivToInterface(nk.NetKey)
+			require.NoError(t, err)
+			pid, err := peer.IDFromPrivateKey(sk)
+			require.NoError(t, err)
+			pids = append(pids, pid)
+		}
+		return pids
+	}
+
+	getSubnet := func(t *testing.T, subnetHex string) records.Subnets {
+		if len(subnetHex) != 32 {
+			t.Fatalf("subnetHex must be 32 characters long, got %d", len(subnetHex))
+		}
+		s, err := records.Subnets{}.FromString(subnetHex)
+		require.NoError(t, err)
+		return s
+	}
+
+	generateSubnetString := func(subnetIndices ...int) string {
+		bytes := make([]byte, 16)
+		for _, idx := range subnetIndices {
+			if idx < 0 || idx >= 128 {
+				continue
+			}
+			byteIndex := idx / 8
+			bitIndex := idx % 8
+			bytes[byteIndex] |= 1 << bitIndex
+		}
+		return hex.EncodeToString(bytes)
+	}
+
+	tests := []struct {
+		name            string
+		numPeers        int
+		peerToRemoveIdx int
+		initialSubnets  string
+		removeSubnets   string
+		expectedPeers   []int
+	}{
+		{
+			name:            "RemoveFirstPeer",
+			numPeers:        3,
+			peerToRemoveIdx: 0,
+			initialSubnets:  generateSubnetString(0), // Subnet 0
+			removeSubnets:   generateSubnetString(),  // No subnets
+			expectedPeers:   []int{1, 2},
+		},
+		{
+			name:            "RemoveMiddlePeer",
+			numPeers:        4,
+			peerToRemoveIdx: 2,
+			initialSubnets:  generateSubnetString(0), // Subnet 0
+			removeSubnets:   generateSubnetString(),  // No subnets
+			expectedPeers:   []int{0, 1, 3},
+		},
+		{
+			name:            "RemoveLastPeer",
+			numPeers:        3,
+			peerToRemoveIdx: 2,
+			initialSubnets:  generateSubnetString(0), // Subnet 0
+			removeSubnets:   generateSubnetString(),  // No subnets
+			expectedPeers:   []int{0, 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subnetsIdx := NewSubnetsIndex(128)
+			pids := generateTestPeers(t, tt.numPeers)
+			subnetID := 0
+			sInitial := getSubnet(t, tt.initialSubnets)
+			sRemove := getSubnet(t, tt.removeSubnets)
+
+			emptySubnet := generateSubnetString()
+			if tt.initialSubnets != emptySubnet {
+				for _, pid := range pids {
+					updated := subnetsIdx.UpdatePeerSubnets(pid, sInitial)
+					require.True(t, updated)
+				}
+
+				peersInSubnet := subnetsIdx.GetSubnetPeers(subnetID)
+				require.ElementsMatch(t, pids, peersInSubnet)
+			}
+
+			var peerToRemove peer.ID
+			if tt.peerToRemoveIdx < len(pids) {
+				peerToRemove = pids[tt.peerToRemoveIdx]
+			} else {
+				extraPids := generateTestPeers(t, 1)
+				peerToRemove = extraPids[0]
+			}
+
+			updated := subnetsIdx.UpdatePeerSubnets(peerToRemove, sRemove)
+			require.True(t, updated)
+
+			peersInSubnet := subnetsIdx.GetSubnetPeers(subnetID)
+			expectedPeers := make([]peer.ID, len(tt.expectedPeers))
+			for i, idx := range tt.expectedPeers {
+				expectedPeers[i] = pids[idx]
+			}
+			require.ElementsMatch(t, expectedPeers, peersInSubnet)
 		})
 	}
 }


### PR DESCRIPTION
The logic is incorrect for `i != 0`, the peer is not removed.

This change is copied from https://github.com/ssvlabs/ssv/pull/1813 as it seems more important