### PR TITLE
exporter: save participants' indices in committee instead of operator IDs

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -412,6 +412,7 @@ var StartNodeCmd = &cobra.Command{
 				&handlers.Exporter{
 					DomainType: networkConfig.AlanDomainType,
 					QBFTStores: storageMap,
+					Shares:     nodeStorage.Shares(),
 				},
 			)
 			go func() {

--- a/eth/eventhandler/validation.go
+++ b/eth/eventhandler/validation.go
@@ -12,12 +12,12 @@ import (
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
-const maxOperators = 13
+const maxCommitteeSize = 13 // TODO: define in ssv network config
 
 func (eh *EventHandler) validateOperators(txn basedb.Txn, operators []uint64) error {
 	operatorCount := len(operators)
 
-	if operatorCount > maxOperators {
+	if operatorCount > maxCommitteeSize {
 		return fmt.Errorf("too many operators (%d)", operatorCount)
 	}
 

--- a/exporter/api/interfaces.go
+++ b/exporter/api/interfaces.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net"
 	"time"
-
-	"go.uber.org/zap"
 )
 
 // Connection is an interface to abstract the actual websocket connection implementation
@@ -22,7 +20,7 @@ type NetworkMessage struct {
 }
 
 // QueryMessageHandler handles the given message
-type QueryMessageHandler func(logger *zap.Logger, nm *NetworkMessage)
+type QueryMessageHandler func(nm *NetworkMessage)
 
 // ConnectionID calculates the id of the given Connection
 func ConnectionID(conn Connection) string {

--- a/exporter/api/server.go
+++ b/exporter/api/server.go
@@ -140,7 +140,7 @@ func (ws *wsServer) handleQuery(logger *zap.Logger, conn *websocket.Conn) {
 			networkMessage = NetworkMessage{incoming, nil, conn}
 		}
 		// handler is processing the request and updates msg
-		ws.handler(logger, &networkMessage)
+		ws.handler(&networkMessage)
 
 		err = tasks.Retry(func() error {
 			return conn.WriteJSON(&networkMessage.Msg)

--- a/exporter/api/server_test.go
+++ b/exporter/api/server_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
@@ -22,7 +20,7 @@ func TestHandleQuery(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	ctx, cancelServerCtx := context.WithCancel(context.Background())
 	mux := http.NewServeMux()
-	ws := NewWsServer(ctx, func(logger *zap.Logger, nm *NetworkMessage) {
+	ws := NewWsServer(ctx, func(nm *NetworkMessage) {
 		nm.Msg.Data = []registrystorage.OperatorData{
 			{PublicKey: []byte(fmt.Sprintf("pubkey-%d", nm.Msg.Filter.From))},
 		}

--- a/ibft/storage/store.go
+++ b/ibft/storage/store.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"encoding/binary"
 	"fmt"
-	"slices"
 	"sync"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -13,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
+
 	"github.com/ssvlabs/ssv/exporter/convert"
 	qbftstorage "github.com/ssvlabs/ssv/protocol/v2/qbft/storage"
 	"github.com/ssvlabs/ssv/storage/basedb"
@@ -70,24 +70,24 @@ func (i *ibftStorage) CleanAllInstances(msgID []byte) error {
 	return nil
 }
 
-func (i *ibftStorage) UpdateParticipants(identifier convert.MessageID, slot phase0.Slot, newParticipants []spectypes.OperatorID) (updated bool, err error) {
+func (i *ibftStorage) UpdateParticipants(identifier convert.MessageID, slot phase0.Slot, newParticipants qbftstorage.Quorum) (updated bool, err error) {
 	i.participantsMu.Lock()
 	defer i.participantsMu.Unlock()
 
 	txn := i.db.Begin()
 	defer txn.Discard()
 
-	existingParticipants, err := i.getParticipants(txn, identifier, slot)
+	existing, err := i.getParticipantsBitMask(txn, identifier, slot)
 	if err != nil {
 		return false, fmt.Errorf("get participants %w", err)
 	}
 
-	mergedParticipants := mergeParticipants(existingParticipants, newParticipants)
-	if slices.Equal(mergedParticipants, existingParticipants) {
+	merged := mergeParticipants(existing, newParticipants.ToBitMask())
+	if merged == existing {
 		return false, nil
 	}
 
-	if err := i.saveParticipants(txn, identifier, slot, mergedParticipants); err != nil {
+	if err := i.saveParticipantsBitMask(txn, identifier, slot, merged); err != nil {
 		return false, fmt.Errorf("save participants: %w", err)
 	}
 
@@ -98,11 +98,16 @@ func (i *ibftStorage) UpdateParticipants(identifier convert.MessageID, slot phas
 	return true, nil
 }
 
-func (i *ibftStorage) GetParticipantsInRange(identifier convert.MessageID, from, to phase0.Slot) ([]qbftstorage.ParticipantsRangeEntry, error) {
+func (i *ibftStorage) GetParticipantsInRange(
+	identifier convert.MessageID,
+	from,
+	to phase0.Slot,
+	committee []spectypes.OperatorID,
+) ([]qbftstorage.ParticipantsRangeEntry, error) {
 	participantsRange := make([]qbftstorage.ParticipantsRangeEntry, 0)
 
 	for slot := from; slot <= to; slot++ {
-		participants, err := i.GetParticipants(identifier, slot)
+		participants, err := i.GetParticipants(identifier, slot, committee)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get participants: %w", err)
 		}
@@ -121,39 +126,51 @@ func (i *ibftStorage) GetParticipantsInRange(identifier convert.MessageID, from,
 	return participantsRange, nil
 }
 
-func (i *ibftStorage) GetParticipants(identifier convert.MessageID, slot phase0.Slot) ([]spectypes.OperatorID, error) {
-	return i.getParticipants(nil, identifier, slot)
+func (i *ibftStorage) GetParticipants(
+	identifier convert.MessageID,
+	slot phase0.Slot,
+	committee []spectypes.OperatorID,
+) ([]spectypes.OperatorID, error) {
+	bm, err := i.getParticipantsBitMask(nil, identifier, slot)
+	if err != nil {
+		return nil, fmt.Errorf("get participants bit mask: %w", err)
+	}
+
+	return bm.Signers(committee), nil
 }
 
-func (i *ibftStorage) getParticipants(txn basedb.ReadWriter, identifier convert.MessageID, slot phase0.Slot) ([]spectypes.OperatorID, error) {
+func (i *ibftStorage) getParticipantsBitMask(
+	txn basedb.ReadWriter,
+	identifier convert.MessageID,
+	slot phase0.Slot,
+) (qbftstorage.OperatorsBitMask, error) {
 	val, found, err := i.get(txn, participantsKey, identifier[:], uInt64ToByteSlice(uint64(slot)))
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	if !found {
-		return nil, nil
+		return 0, nil
 	}
 
-	operators := decodeOperators(val)
-	return operators, nil
+	return qbftstorage.OperatorsBitMask(byteSliceToUInt16(val)), nil
 }
 
-func (i *ibftStorage) saveParticipants(txn basedb.ReadWriter, identifier convert.MessageID, slot phase0.Slot, operators []spectypes.OperatorID) error {
-	bytes, err := encodeOperators(operators)
-	if err != nil {
-		return fmt.Errorf("encode operators: %w", err)
-	}
-	if err := i.save(txn, bytes, participantsKey, identifier[:], uInt64ToByteSlice(uint64(slot))); err != nil {
+func (i *ibftStorage) saveParticipantsBitMask(
+	txn basedb.ReadWriter,
+	identifier convert.MessageID,
+	slot phase0.Slot,
+	operatorsBitMask qbftstorage.OperatorsBitMask,
+) error {
+	b := uInt16ToByteSlice(uint16(operatorsBitMask))
+	if err := i.save(txn, b, participantsKey, identifier[:], uInt64ToByteSlice(uint64(slot))); err != nil {
 		return fmt.Errorf("save to DB: %w", err)
 	}
 
 	return nil
 }
 
-func mergeParticipants(existingParticipants, newParticipants []spectypes.OperatorID) []spectypes.OperatorID {
-	allParticipants := slices.Concat(existingParticipants, newParticipants)
-	slices.Sort(allParticipants)
-	return slices.Compact(allParticipants)
+func mergeParticipants(existingParticipants, newParticipants qbftstorage.OperatorsBitMask) qbftstorage.OperatorsBitMask {
+	return existingParticipants | newParticipants
 }
 
 func (i *ibftStorage) save(txn basedb.ReadWriter, value []byte, id string, pk []byte, keyParams ...[]byte) error {
@@ -193,6 +210,16 @@ func uInt64ToByteSlice(n uint64) []byte {
 	b := make([]byte, 8)
 	binary.LittleEndian.PutUint64(b, n)
 	return b
+}
+
+func uInt16ToByteSlice(n uint16) []byte {
+	b := make([]byte, 2)
+	binary.LittleEndian.PutUint16(b, n)
+	return b
+}
+
+func byteSliceToUInt16(b []byte) uint16 {
+	return binary.LittleEndian.Uint16(b)
 }
 
 func encodeOperators(operators []spectypes.OperatorID) ([]byte, error) {

--- a/protocol/v2/qbft/storage/ibft_store_test.go
+++ b/protocol/v2/qbft/storage/ibft_store_test.go
@@ -1,0 +1,283 @@
+package qbftstorage
+
+import (
+	"testing"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Helper function to create a slice of OperatorIDs.
+func createOperatorIDs(ids ...uint64) []spectypes.OperatorID {
+	if len(ids) == 0 {
+		return make([]spectypes.OperatorID, 0)
+	}
+	return ids
+}
+
+// Helper function to create a Quorum instance.
+func newQuorum(signers, committee []spectypes.OperatorID) Quorum {
+	return Quorum{
+		Signers:   signers,
+		Committee: committee,
+	}
+}
+
+func TestQuorum_ToBitMask_NormalCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		quorum   Quorum
+		expected OperatorsBitMask
+	}{
+		{
+			name: "Single common element",
+			quorum: newQuorum(
+				createOperatorIDs(1),
+				createOperatorIDs(1, 2, 3, 4),
+			),
+			expected: 1 << 0, // 0b0000000000000001
+		},
+		{
+			name: "Multiple common elements",
+			quorum: newQuorum(
+				createOperatorIDs(1, 2),
+				createOperatorIDs(1, 2, 3, 4),
+			),
+			expected: (1 << 0) | (1 << 1), // 0b0000000000000011
+		},
+		{
+			name: "All committee members are signers",
+			quorum: newQuorum(
+				createOperatorIDs(1, 2, 3, 4),
+				createOperatorIDs(1, 2, 3, 4),
+			),
+			expected: (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3), // 0b0000000000001111
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.quorum.ToBitMask()
+			assert.Equal(t, tt.expected, result, "Bitmask does not match expected value")
+		})
+	}
+}
+
+func TestQuorum_ToBitMask_InvalidSizes(t *testing.T) {
+	tests := []struct {
+		name        string
+		quorum      Quorum
+		shouldPanic bool
+	}{
+		{
+			name: "Committee size exceeds maxCommitteeSize",
+			quorum: newQuorum(
+				createOperatorIDs(1, 2, 3),
+				func() []spectypes.OperatorID {
+					committee := make([]spectypes.OperatorID, maxCommitteeSize+1)
+					for i := 0; i < maxCommitteeSize+1; i++ {
+						committee[i] = spectypes.OperatorID(i + 1)
+					}
+					return committee
+				}(),
+			),
+			shouldPanic: true,
+		},
+		{
+			name: "Signers size exceeds maxCommitteeSize",
+			quorum: newQuorum(
+				func() []spectypes.OperatorID {
+					signers := make([]spectypes.OperatorID, maxCommitteeSize+1)
+					for i := 0; i < maxCommitteeSize+1; i++ {
+						signers[i] = spectypes.OperatorID(i + 1)
+					}
+					return signers
+				}(),
+				createOperatorIDs(1),
+			),
+			shouldPanic: true,
+		},
+		{
+			name: "Signers size greater than Committee size",
+			quorum: newQuorum(
+				createOperatorIDs(1, 2, 3),
+				createOperatorIDs(1, 2),
+			),
+			shouldPanic: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldPanic {
+				require.Panics(t, func() { _ = tt.quorum.ToBitMask() }, "Expected ToBitMask to panic")
+			} else {
+				require.NotPanics(t, func() { _ = tt.quorum.ToBitMask() }, "Did not expect ToBitMask to panic")
+			}
+		})
+	}
+}
+
+func TestQuorum_ToBitMask_EmptyArrays(t *testing.T) {
+	tests := []struct {
+		name     string
+		quorum   Quorum
+		expected OperatorsBitMask
+	}{
+		{
+			name: "Both Signers and Committee are empty",
+			quorum: newQuorum(
+				createOperatorIDs(),
+				createOperatorIDs(),
+			),
+			expected: 0, // 0b0000000000000000
+		},
+		{
+			name: "Signers empty, Committee non-empty",
+			quorum: newQuorum(
+				createOperatorIDs(),
+				createOperatorIDs(1, 2),
+			),
+			expected: 0, // 0b0000000000000000
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.quorum.ToBitMask()
+			assert.Equal(t, tt.expected, result, "Bitmask should be 0 when one or both arrays are empty")
+		})
+	}
+}
+
+func TestOperatorsBitMask_Signers_NormalCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		bitmask   OperatorsBitMask
+		committee []spectypes.OperatorID
+		expected  []spectypes.OperatorID
+	}{
+		{
+			name:      "Single bit set",
+			bitmask:   1 << 0, // Bit 0 set
+			committee: createOperatorIDs(1, 2, 3, 4),
+			expected:  createOperatorIDs(1),
+		},
+		{
+			name:      "Multiple bits set",
+			bitmask:   (1 << 0) | (1 << 2) | (1 << 4), // Bits 0, 2, 4 set
+			committee: createOperatorIDs(1, 2, 3, 4, 5, 6, 7),
+			expected:  createOperatorIDs(1, 3, 5),
+		},
+		{
+			name:      "All bits set",
+			bitmask:   0xFFFF, // All bits set
+			committee: createOperatorIDs(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13),
+			expected:  createOperatorIDs(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13),
+		},
+		{
+			name:      "No bits set",
+			bitmask:   0, // No bits set
+			committee: createOperatorIDs(1, 2, 3),
+			expected:  createOperatorIDs(),
+		},
+		{
+			name:      "Partial overlap",
+			bitmask:   (1 << 1) | (1 << 3), // Bits 1 and 3 set
+			committee: createOperatorIDs(10, 20, 30, 40),
+			expected:  createOperatorIDs(20, 40),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.bitmask.Signers(tt.committee)
+			assert.Equal(t, tt.expected, result, "Signers do not match expected values")
+		})
+	}
+}
+
+func TestOperatorsBitMask_Signers_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		bitmask   OperatorsBitMask
+		committee []spectypes.OperatorID
+		expected  []spectypes.OperatorID
+	}{
+		{
+			name:      "Empty committee",
+			bitmask:   1 << 0, // Bit 0 set
+			committee: createOperatorIDs(),
+			expected:  createOperatorIDs(),
+		},
+		{
+			name:      "Empty bitmask and committee",
+			bitmask:   0,
+			committee: createOperatorIDs(),
+			expected:  createOperatorIDs(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.bitmask.Signers(tt.committee)
+			assert.Equal(t, tt.expected, result, "Signers do not match expected values")
+		})
+	}
+}
+
+func TestOperatorsBitMask_Signers_InvalidSizes(t *testing.T) {
+	tests := []struct {
+		name        string
+		bitmask     OperatorsBitMask
+		committee   []spectypes.OperatorID
+		shouldPanic bool
+	}{
+		{
+			name:    "Committee size exceeds maxCommitteeSize",
+			bitmask: 1 << 0,
+			committee: func() []spectypes.OperatorID {
+				committee := make([]spectypes.OperatorID, maxCommitteeSize+1)
+				for i := 0; i < maxCommitteeSize+1; i++ {
+					committee[i] = spectypes.OperatorID(i + 1)
+				}
+				return committee
+			}(),
+			shouldPanic: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldPanic {
+				require.Panics(t, func() { _ = tt.bitmask.Signers(tt.committee) }, "Expected Signers to panic")
+			} else {
+				require.NotPanics(t, func() { _ = tt.bitmask.Signers(tt.committee) }, "Did not expect Signers to panic")
+			}
+		})
+	}
+}
+
+func TestOperatorsBitMask_Signers_PartialCommittee(t *testing.T) {
+	quorum := newQuorum(
+		createOperatorIDs(1, 2, 3, 4, 5),
+		createOperatorIDs(1, 3, 5, 7, 9),
+	)
+	// Bitmask: bits 0,2,4 set (corresponding to committee indices 0,2,4)
+	bitmask := OperatorsBitMask((1 << 0) | (1 << 2) | (1 << 4))
+	expected := createOperatorIDs(1, 5, 9)
+
+	result := bitmask.Signers(quorum.Committee)
+	assert.Equal(t, expected, result, "Expected signers do not match the bitmask")
+}
+
+func TestOperatorsBitMask_Signers_LargeOperatorIDs(t *testing.T) {
+	committee := createOperatorIDs(100, 200, 300)
+	// Bitmask: bits 0 and 2 set
+	bitmask := OperatorsBitMask((1 << 0) | (1 << 2))
+	expected := createOperatorIDs(100, 300)
+
+	result := bitmask.Signers(committee)
+	assert.Equal(t, expected, result, "Signers with large OperatorIDs should be correctly returned")
+}


### PR DESCRIPTION
Pyroscope shows that updating participants allocates a lot of memory and grows quickly. The PR changes the format of saved participants from the list of operator IDs converted to slice (8 byte each, 32-104 bytes total) to `uint16` (2 bytes) bitmask of indices without memory allocations

<img width="695" alt="image" src="https://github.com/user-attachments/assets/6a166cae-b1ca-439c-bb48-7ef281da1319">
