### PR TITLE
feat(metrics): OTeL - instrument Consensus Client

### DIFF
--- a/beacon/goclient/aggregator.go
+++ b/beacon/goclient/aggregator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
 )
 
 // SubmitAggregateSelectionProof returns an AggregateAndProof object
@@ -56,7 +57,7 @@ func (gc *GoClient) SubmitAggregateSelectionProof(slot phase0.Slot, committeeInd
 		return nil, DataVersionNil, fmt.Errorf("aggregate attestation data is nil")
 	}
 
-	metricsAggregatorDataRequest.Observe(time.Since(aggDataReqStart).Seconds())
+	recordAttestationDataRequest(gc.ctx, time.Since(aggDataReqStart), spectypes.BNRoleAggregator)
 
 	var selectionProof phase0.BLSSignature
 	copy(selectionProof[:], slotSig)

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -10,6 +10,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/jellydator/ttlcache/v3"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
 )
 
 // AttesterDuties returns attester duties for a given epoch.
@@ -53,7 +54,9 @@ func (gc *GoClient) GetAttestationData(slot phase0.Slot, committeeIndex phase0.C
 		resp, err := gc.client.AttestationData(gc.ctx, &api.AttestationDataOpts{
 			Slot: slot,
 		})
-		metricsAttesterDataRequest.Observe(time.Since(attDataReqStart).Seconds())
+
+		recordAttestationDataRequest(gc.ctx, time.Since(attDataReqStart), spectypes.BNRoleAttester)
+
 		if err != nil {
 			return nil, fmt.Errorf("failed to get attestation data: %w", err)
 		}

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -14,8 +14,6 @@ import (
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/jellydator/ttlcache/v3"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"github.com/ssvlabs/ssv/logging/fields"
@@ -23,6 +21,7 @@ import (
 	"github.com/ssvlabs/ssv/operator/slotticker"
 	beaconprotocol "github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	"github.com/ssvlabs/ssv/utils/casts"
+	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 	"tailscale.com/util/singleflight"
 )
@@ -36,45 +35,6 @@ const (
 	DefaultCommonTimeout = time.Second * 5  // For dialing and most requests.
 	DefaultLongTimeout   = time.Second * 60 // For long requests.
 )
-
-type beaconNodeStatus int32
-
-var (
-	allMetrics = []prometheus.Collector{
-		metricsBeaconNodeStatus,
-		metricsBeaconDataRequest,
-	}
-	metricsBeaconNodeStatus = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "ssv_beacon_status",
-		Help: "Status of the connected beacon node",
-	})
-
-	// metricsBeaconDataRequest is located here to avoid including waiting for 1/3 or 2/3 of slot time into request duration.
-	metricsBeaconDataRequest = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "ssv_beacon_data_request_duration_seconds",
-		Help:    "Beacon data request duration (seconds)",
-		Buckets: []float64{0.02, 0.05, 0.1, 0.2, 0.5, 1, 5},
-	}, []string{"role"})
-
-	metricsAttesterDataRequest                  = metricsBeaconDataRequest.WithLabelValues(spectypes.BNRoleAttester.String())
-	metricsAggregatorDataRequest                = metricsBeaconDataRequest.WithLabelValues(spectypes.BNRoleAggregator.String())
-	metricsProposerDataRequest                  = metricsBeaconDataRequest.WithLabelValues(spectypes.BNRoleProposer.String())
-	metricsSyncCommitteeDataRequest             = metricsBeaconDataRequest.WithLabelValues(spectypes.BNRoleSyncCommittee.String())
-	metricsSyncCommitteeContributionDataRequest = metricsBeaconDataRequest.WithLabelValues(spectypes.BNRoleSyncCommitteeContribution.String())
-
-	statusUnknown beaconNodeStatus = 0
-	statusSyncing beaconNodeStatus = 1
-	statusOK      beaconNodeStatus = 2
-)
-
-func init() {
-	logger := zap.L()
-	for _, c := range allMetrics {
-		if err := prometheus.Register(c); err != nil {
-			logger.Debug("could not register prometheus collector")
-		}
-	}
-}
 
 // NodeClient is the type of the Beacon node.
 type NodeClient string
@@ -249,22 +209,27 @@ func (gc *GoClient) NodeClient() NodeClient {
 func (gc *GoClient) Healthy(ctx context.Context) error {
 	nodeSyncingResp, err := gc.client.NodeSyncing(ctx, &api.NodeSyncingOpts{})
 	if err != nil {
-		// TODO: get rid of global variable, pass metrics to goClient
-		metricsBeaconNodeStatus.Set(float64(statusUnknown))
+		recordBeaconClientStatus(ctx, statusUnknown, gc.client.Address())
 		return fmt.Errorf("failed to obtain node syncing status: %w", err)
 	}
 	if nodeSyncingResp == nil {
-		metricsBeaconNodeStatus.Set(float64(statusUnknown))
+		recordBeaconClientStatus(ctx, statusUnknown, gc.client.Address())
 		return fmt.Errorf("node syncing response is nil")
 	}
 	if nodeSyncingResp.Data == nil {
-		metricsBeaconNodeStatus.Set(float64(statusUnknown))
+		recordBeaconClientStatus(ctx, statusUnknown, gc.client.Address())
 		return fmt.Errorf("node syncing data is nil")
 	}
 	syncState := nodeSyncingResp.Data
 
 	// TODO: also check if syncState.ElOffline when github.com/attestantio/go-eth2-client supports it
-	metricsBeaconNodeStatus.Set(float64(statusSyncing))
+	recordBeaconClientStatus(ctx, statusSyncing, gc.client.Address())
+
+	syncDistance := uint64(syncState.SyncDistance)
+	if syncDistance <= math.MaxInt64 {
+		syncingDistanceGauge.Record(ctx, int64(syncDistance), metric.WithAttributes(beaconClientAddrAttribute(gc.client.Address())))
+	}
+
 	if syncState.IsSyncing {
 		return fmt.Errorf("syncing")
 	}
@@ -272,7 +237,8 @@ func (gc *GoClient) Healthy(ctx context.Context) error {
 		return fmt.Errorf("optimistic")
 	}
 
-	metricsBeaconNodeStatus.Set(float64(statusOK))
+	recordBeaconClientStatus(ctx, statusSynced, gc.client.Address())
+
 	return nil
 }
 

--- a/beacon/goclient/observability.go
+++ b/beacon/goclient/observability.go
@@ -1,0 +1,85 @@
+package goclient
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ssvlabs/ssv-spec/types"
+	"github.com/ssvlabs/ssv/observability"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type beaconNodeStatus string
+
+const (
+	observabilityName      = "github.com/ssvlabs/ssv/beacon/goclient"
+	observabilityNamespace = "ssv.cl"
+
+	statusUnknown beaconNodeStatus = "unknown"
+	statusSyncing beaconNodeStatus = "syncing"
+	statusSynced  beaconNodeStatus = "synced"
+)
+
+var (
+	meter = otel.Meter(observabilityName)
+
+	attestationDataRequestHistogram = observability.NewMetric(
+		meter.Float64Histogram(
+			metricName("attestation_data_request.duration"),
+			metric.WithUnit("s"),
+			metric.WithDescription("beacon data request duration in seconds"),
+			metric.WithExplicitBucketBoundaries(observability.SecondsHistogramBuckets...)))
+
+	beaconNodeStatusGauge = observability.NewMetric(
+		meter.Int64Gauge(
+			metricName("sync.status"),
+			metric.WithDescription("beacon node status")))
+
+	syncingDistanceGauge = observability.NewMetric(
+		meter.Int64Gauge(
+			metricName("sync.distance"),
+			metric.WithUnit("{block}"),
+			metric.WithDescription("consensus client syncing distance which is a delta between highest and current blocks")))
+)
+
+func metricName(name string) string {
+	return fmt.Sprintf("%s.%s", observabilityNamespace, name)
+}
+
+func recordAttestationDataRequest(ctx context.Context, duration time.Duration, role types.BeaconRole) {
+	attestationDataRequestHistogram.Record(
+		ctx,
+		duration.Seconds(),
+		metric.WithAttributes(observability.BeaconRoleAttribute(role)))
+}
+
+func recordBeaconClientStatus(ctx context.Context, status beaconNodeStatus, nodeAddr string) {
+	resetBeaconClientStatusGauge(ctx, nodeAddr)
+
+	beaconNodeStatusGauge.Record(ctx, 1,
+		metric.WithAttributes(beaconClientAddrAttribute(nodeAddr)),
+		metric.WithAttributes(beaconClientStatusAttribute(status)),
+	)
+}
+
+func resetBeaconClientStatusGauge(ctx context.Context, nodeAddr string) {
+	for _, status := range []beaconNodeStatus{statusSynced, statusSyncing, statusUnknown} {
+		beaconNodeStatusGauge.Record(ctx, 0,
+			metric.WithAttributes(beaconClientAddrAttribute(nodeAddr)),
+			metric.WithAttributes(beaconClientStatusAttribute(status)),
+		)
+	}
+}
+
+func beaconClientStatusAttribute(value beaconNodeStatus) attribute.KeyValue {
+	eventNameAttrName := fmt.Sprintf("%s.sync.status", observabilityNamespace)
+	return attribute.String(eventNameAttrName, string(value))
+}
+
+func beaconClientAddrAttribute(value string) attribute.KeyValue {
+	eventNameAttrName := fmt.Sprintf("%s.addr", observabilityNamespace)
+	return attribute.String(eventNameAttrName, value)
+}

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -16,10 +16,9 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
-	"go.uber.org/zap"
-
 	"github.com/ssvlabs/ssv/logging/fields"
 	"github.com/ssvlabs/ssv/operator/slotticker"
+	"go.uber.org/zap"
 )
 
 const (
@@ -67,7 +66,8 @@ func (gc *GoClient) GetBeaconBlock(slot phase0.Slot, graffitiBytes, randao []byt
 		return nil, DataVersionNil, fmt.Errorf("proposal data is nil")
 	}
 
-	metricsProposerDataRequest.Observe(time.Since(reqStart).Seconds())
+	recordAttestationDataRequest(gc.ctx, time.Since(reqStart), spectypes.BNRoleProposer)
+
 	beaconBlock := proposalResp.Data
 
 	if beaconBlock.Blinded {

--- a/beacon/goclient/sync_committee.go
+++ b/beacon/goclient/sync_committee.go
@@ -10,6 +10,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
 )
 
 // SyncCommitteeDuties returns sync committee duties for a given epoch
@@ -43,7 +44,8 @@ func (gc *GoClient) GetSyncMessageBlockRoot(slot phase0.Slot) (phase0.Root, spec
 	if resp.Data == nil {
 		return phase0.Root{}, DataVersionNil, fmt.Errorf("beacon block root data is nil")
 	}
-	metricsSyncCommitteeDataRequest.Observe(time.Since(reqStart).Seconds())
+
+	recordAttestationDataRequest(gc.ctx, time.Since(reqStart), spectypes.BNRoleSyncCommittee)
 
 	return *resp.Data, spec.DataVersionAltair, nil
 }

--- a/beacon/goclient/sync_committee_contribution.go
+++ b/beacon/goclient/sync_committee_contribution.go
@@ -56,7 +56,8 @@ func (gc *GoClient) GetSyncCommitteeContribution(slot phase0.Slot, selectionProo
 		return nil, DataVersionNil, fmt.Errorf("beacon block root data is nil")
 	}
 
-	metricsSyncCommitteeDataRequest.Observe(time.Since(scDataReqStart).Seconds())
+	recordAttestationDataRequest(gc.ctx, time.Since(scDataReqStart), spectypes.BNRoleSyncCommittee)
+
 	blockRoot := beaconBlockRootResp.Data
 
 	gc.waitToSlotTwoThirds(slot)
@@ -96,7 +97,7 @@ func (gc *GoClient) GetSyncCommitteeContribution(slot phase0.Slot, selectionProo
 		return nil, DataVersionNil, err
 	}
 
-	metricsSyncCommitteeContributionDataRequest.Observe(time.Since(sccDataReqStart).Seconds())
+	recordAttestationDataRequest(gc.ctx, time.Since(sccDataReqStart), spectypes.BNRoleSyncCommitteeContribution)
 
 	return &contributions, spec.DataVersionAltair, nil
 }


### PR DESCRIPTION
**Metrics added**
- `ssv.cl.attestation_data_request.duration` (`ssv.beacon.role` attribute(global))
- `ssv.cl.sync.status` (`ssv.cl.addr`, `ssv.cl.sync.status` attributes)
- `ssv.cl.sync.distance` (`ssv.cl.addr` attribute) **(new!)**

**Metrics removed**
- `ssv_beacon_status`
- `ssv_beacon_data_request_duration_seconds` (`role` label)

**Questions and opinions**
- `ssv.cl.syncing` namespace name. Although, it is aligned with this [PR](https://github.com/ssvlabs/ssv/pull/1852). The alternative could be `ssv.cl.sync` (`ssv.cl.sync.status`).
- `ssv.beacon.role` attribute name. Alternatives: `ssv.consensus.role`, `ssv.validator.role`. What does sound more correct to you? Keep in mind that OTeL metric attributes also have a concept of _namespaces_, so in this case `ssv.consensus`, `ssv.beacon`, `ssv.validator` - are namespaces, which means they may contain more attributes.

NOTE: temporarily target `otel-metrics` branch until it is merged to `stage`