### PR TITLE
chore: set log to debug level [main]

### DIFF
--- a/protocol/v2/ssv/validator/timer.go
+++ b/protocol/v2/ssv/validator/timer.go
@@ -92,10 +92,11 @@ func (v *Committee) onTimeout(logger *zap.Logger, identifier spectypes.MessageID
 		//	return
 		//}
 		dr := v.Runners[phase0.Slot(height)]
-		if dr == nil {
-			logger.Warn("❗no committee runner found for slot", fields.Slot(phase0.Slot(height)))
+		if dr == nil { // only happens when we prune expired runners
+			logger.Debug("❗no committee runner found for slot", fields.Slot(phase0.Slot(height)))
 			return
 		}
+
 		hasDuty := dr.HasRunningDuty()
 		if !hasDuty {
 			return


### PR DESCRIPTION
The warning `no committee runner found for slot` is only encountered after we prune the runners after a round timed out.

This PR changes the log level for the message.
