### PR TITLE
chore(discovery): re-enable post-fork discovery and NextDomainType

### DIFF
--- a/network/discovery/forking_dv5_listener.go
+++ b/network/discovery/forking_dv5_listener.go
@@ -1,0 +1,103 @@
+package discovery
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ssvlabs/ssv/networkconfig"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultIteratorTimeout = 5 * time.Second
+)
+
+// forkingDV5Listener wraps a pre-fork and a post-fork listener.
+// Before the fork, it performs operations on both services.
+// Aftet the fork, it performs operations only on the post-fork service.
+type forkingDV5Listener struct {
+	logger           *zap.Logger
+	preForkListener  Listener
+	postForkListener Listener
+	iteratorTimeout  time.Duration
+	netCfg           networkconfig.NetworkConfig
+}
+
+func NewForkingDV5Listener(logger *zap.Logger, preFork, postFork Listener, iteratorTimeout time.Duration, netConfig networkconfig.NetworkConfig) *forkingDV5Listener {
+	if iteratorTimeout == 0 {
+		iteratorTimeout = defaultIteratorTimeout
+	}
+	return &forkingDV5Listener{
+		logger:           logger,
+		preForkListener:  preFork,
+		postForkListener: postFork,
+		iteratorTimeout:  iteratorTimeout,
+		netCfg:           netConfig,
+	}
+}
+
+// Before the fork, returns the result of a Lookup in both pre and post-fork services.
+// After the fork, returns only the result from the post-fork service.
+func (l *forkingDV5Listener) Lookup(id enode.ID) []*enode.Node {
+	nodes := l.postForkListener.Lookup(id)
+	nodes = append(nodes, l.preForkListener.Lookup(id)...)
+	return nodes
+}
+
+// Before the fork, returns an iterator for both pre and post-fork services.
+// After the fork, returns only the iterator from the post-fork service.
+func (l *forkingDV5Listener) RandomNodes() enode.Iterator {
+	fairMix := enode.NewFairMix(l.iteratorTimeout)
+	fairMix.AddSource(&annotatedIterator{l.postForkListener.RandomNodes(), "post"})
+	fairMix.AddSource(&annotatedIterator{l.preForkListener.RandomNodes(), "pre"})
+	return fairMix
+}
+
+// Before the fork, returns all nodes from the pre and post-fork listeners.
+// After the fork, returns only the result from the post-fork service.
+func (l *forkingDV5Listener) AllNodes() []*enode.Node {
+	enodes := l.postForkListener.AllNodes()
+	enodes = append(enodes, l.preForkListener.AllNodes()...)
+	return enodes
+}
+
+// Sends a ping in the post-fork service.
+// Before the fork, it also tries to ping with the pre-fork service in case of error.
+func (l *forkingDV5Listener) Ping(node *enode.Node) error {
+	err := l.postForkListener.Ping(node)
+	if err != nil {
+		return l.preForkListener.Ping(node)
+	}
+	return nil
+}
+
+// Returns the LocalNode using the post-fork listener.
+// Both pre and post-fork listeners should have the same LocalNode.
+func (l *forkingDV5Listener) LocalNode() *enode.LocalNode {
+	return l.postForkListener.LocalNode()
+}
+
+// Closes both listeners
+func (l *forkingDV5Listener) Close() {
+	l.closePreForkListener()
+	l.postForkListener.Close()
+}
+
+// closePreForkListener ensures preForkListener is closed once
+func (l *forkingDV5Listener) closePreForkListener() {
+	l.preForkListener.Close()
+}
+
+// annotatedIterator wraps an enode.Iterator with metrics collection.
+type annotatedIterator struct {
+	enode.Iterator
+	fork string
+}
+
+func (i *annotatedIterator) Next() bool {
+	if !i.Iterator.Next() {
+		return false
+	}
+	metricIterations.WithLabelValues(i.fork).Inc()
+	return true
+}

--- a/network/discovery/forking_dv5_listener_test.go
+++ b/network/discovery/forking_dv5_listener_test.go
@@ -1,0 +1,267 @@
+package discovery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ssvlabs/ssv/networkconfig"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+const iteratorTimeout = 5 * time.Millisecond
+
+func TestForkListener_Create(t *testing.T) {
+	localNode := NewLocalNode(t)
+
+	preForkListener := NewMockListener(localNode, []*enode.Node{})
+	postForkListener := NewMockListener(localNode, []*enode.Node{})
+
+	t.Run("Pre-Fork", func(t *testing.T) {
+		netCfg := PreForkNetworkConfig()
+		_ = NewForkingDV5Listener(zap.NewNop(), preForkListener, postForkListener, iteratorTimeout, netCfg)
+
+		assert.False(t, preForkListener.closed)
+		assert.False(t, postForkListener.closed)
+	})
+
+	t.Run("Post-Fork", func(t *testing.T) {
+		netCfg := PostForkNetworkConfig()
+		_ = NewForkingDV5Listener(zap.NewNop(), preForkListener, postForkListener, iteratorTimeout, netCfg)
+
+		assert.False(t, preForkListener.closed)
+		assert.False(t, postForkListener.closed)
+	})
+}
+
+func TestForkListener_Lookup(t *testing.T) {
+	nodeFromPreForkListener := NewTestingNode(t)  // pre-fork node
+	nodeFromPostForkListener := NewTestingNode(t) // post-fork node
+	localNode := NewLocalNode(t)
+
+	preForkListener := NewMockListener(localNode, []*enode.Node{nodeFromPreForkListener})
+	postForkListener := NewMockListener(localNode, []*enode.Node{nodeFromPostForkListener})
+
+	t.Run("Pre-Fork", func(t *testing.T) {
+		netCfg := PreForkNetworkConfig()
+		forkListener := NewForkingDV5Listener(zap.NewNop(), preForkListener, postForkListener, iteratorTimeout, netCfg)
+
+		nodes := forkListener.Lookup(enode.ID{})
+		assert.Len(t, nodes, 2)
+		// post-fork nodes are set first
+		assert.Equal(t, nodes[0], nodeFromPostForkListener)
+		assert.Equal(t, nodes[1], nodeFromPreForkListener)
+	})
+
+	t.Run("Post-Fork", func(t *testing.T) {
+		netCfg := PostForkNetworkConfig()
+		forkListener := NewForkingDV5Listener(zap.NewNop(), preForkListener, postForkListener, iteratorTimeout, netCfg)
+
+		nodes := forkListener.Lookup(enode.ID{})
+		assert.Len(t, nodes, 2)
+		// post-fork nodes are set first
+		assert.Equal(t, nodes[0], nodeFromPostForkListener)
+		assert.Equal(t, nodes[1], nodeFromPreForkListener)
+	})
+}
+
+func TestForkListener_RandomNodes(t *testing.T) {
+	nodeFromPreForkListener := NewTestingNode(t)  // pre-fork node
+	nodeFromPostForkListener := NewTestingNode(t) // post-fork node
+	localNode := NewLocalNode(t)
+
+	t.Run("Pre-Fork", func(t *testing.T) {
+		preForkListener := NewMockListener(localNode, []*enode.Node{nodeFromPreForkListener})
+		postForkListener := NewMockListener(localNode, []*enode.Node{nodeFromPostForkListener})
+
+		netCfg := PreForkNetworkConfig()
+		forkListener := NewForkingDV5Listener(zap.NewNop(), preForkListener, postForkListener, iteratorTimeout, netCfg)
+
+		iter := forkListener.RandomNodes()
+		defer iter.Close()
+		var nodes []*enode.Node
+		for i := 0; i < 2; i++ {
+			require.True(t, iter.Next())
+			nodes = append(nodes, iter.Node())
+		}
+
+		assert.Len(t, nodes, 2)
+		// post-fork nodes are set first
+		assert.Equal(t, nodes[0], nodeFromPreForkListener)
+		assert.Equal(t, nodes[1], nodeFromPostForkListener)
+
+		// No more next
+		requireNextTimeout(t, false, iter, 10*time.Millisecond)
+	})
+
+	t.Run("Post-Fork", func(t *testing.T) {
+		preForkListener := NewMockListener(localNode, []*enode.Node{nodeFromPreForkListener})
+		postForkListener := NewMockListener(localNode, []*enode.Node{nodeFromPostForkListener})
+
+		netCfg := PostForkNetworkConfig()
+		forkListener := NewForkingDV5Listener(zap.NewNop(), preForkListener, postForkListener, iteratorTimeout, netCfg)
+
+		iter := forkListener.RandomNodes()
+		defer iter.Close()
+		var nodes []*enode.Node
+		for i := 0; i < 2; i++ {
+			require.True(t, iter.Next())
+			nodes = append(nodes, iter.Node())
+		}
+
+		// there should be no difference between pre-fork and post-fork
+		assert.Equal(t, nodes[0], nodeFromPreForkListener)
+		assert.Equal(t, nodes[1], nodeFromPostForkListener)
+
+		// No more next
+		requireNextTimeout(t, false, iter, 10*time.Millisecond)
+	})
+}
+
+func TestForkListener_AllNodes(t *testing.T) {
+	nodeFromPreForkListener := NewTestingNode(t)  // pre-fork node
+	nodeFromPostForkListener := NewTestingNode(t) // post-fork node
+	localNode := NewLocalNode(t)
+
+	preForkListener := NewMockListener(localNode, []*enode.Node{nodeFromPreForkListener})
+	postForkListener := NewMockListener(localNode, []*enode.Node{nodeFromPostForkListener})
+
+	t.Run("Pre-Fork", func(t *testing.T) {
+		netCfg := PreForkNetworkConfig()
+		forkListener := NewForkingDV5Listener(zap.NewNop(), preForkListener, postForkListener, iteratorTimeout, netCfg)
+
+		nodes := forkListener.AllNodes()
+		assert.Len(t, nodes, 2)
+		// post-fork nodes are set first
+		assert.Equal(t, nodes[0], nodeFromPostForkListener)
+		assert.Equal(t, nodes[1], nodeFromPreForkListener)
+	})
+
+	t.Run("Post-Fork", func(t *testing.T) {
+		netCfg := PostForkNetworkConfig()
+		forkListener := NewForkingDV5Listener(zap.NewNop(), preForkListener, postForkListener, iteratorTimeout, netCfg)
+
+		nodes := forkListener.AllNodes()
+		assert.Len(t, nodes, 2)
+		// there should be no difference between pre-fork and post-fork
+		assert.Equal(t, nodes[0], nodeFromPostForkListener)
+		assert.Equal(t, nodes[1], nodeFromPreForkListener)
+	})
+}
+
+func TestForkListener_PingPreFork(t *testing.T) {
+	for _, netCfg := range []networkconfig.NetworkConfig{PreForkNetworkConfig(), PostForkNetworkConfig()} {
+		pingPeer := NewTestingNode(t) // any peer to ping
+		localNode := NewLocalNode(t)
+
+		preForkListener := NewMockListener(localNode, []*enode.Node{})
+		postForkListener := NewMockListener(localNode, []*enode.Node{})
+
+		forkListener := NewForkingDV5Listener(zap.NewNop(), preForkListener, postForkListener, iteratorTimeout, netCfg)
+
+		t.Run("Post-Fork succeeds", func(t *testing.T) {
+			postForkListener.SetNodesForPingError([]*enode.Node{})
+			preForkListener.SetNodesForPingError([]*enode.Node{pingPeer})
+			err := forkListener.Ping(pingPeer)
+			assert.NoError(t, err)
+		})
+
+		t.Run("Post-Fork fails and Pre-Fork succeeds", func(t *testing.T) {
+			postForkListener.SetNodesForPingError([]*enode.Node{pingPeer})
+			preForkListener.SetNodesForPingError([]*enode.Node{})
+			err := forkListener.Ping(pingPeer)
+			assert.NoError(t, err)
+		})
+
+		t.Run("Post-Fork and Pre-Fork fails", func(t *testing.T) {
+			postForkListener.SetNodesForPingError([]*enode.Node{pingPeer})
+			preForkListener.SetNodesForPingError([]*enode.Node{pingPeer})
+			err := forkListener.Ping(pingPeer)
+			assert.ErrorContains(t, err, "failed ping")
+		})
+	}
+}
+
+func TestForkListener_LocalNode(t *testing.T) {
+	localNode := NewLocalNode(t)
+
+	preForkListener := NewMockListener(localNode, []*enode.Node{})
+	postForkListener := NewMockListener(localNode, []*enode.Node{})
+
+	t.Run("Pre-Fork", func(t *testing.T) {
+		netCfg := PreForkNetworkConfig()
+		forkListener := NewForkingDV5Listener(zap.NewNop(), preForkListener, postForkListener, iteratorTimeout, netCfg)
+
+		assert.Equal(t, localNode, forkListener.LocalNode())
+	})
+
+	t.Run("Post-Fork", func(t *testing.T) {
+		netCfg := PostForkNetworkConfig()
+		forkListener := NewForkingDV5Listener(zap.NewNop(), preForkListener, postForkListener, iteratorTimeout, netCfg)
+
+		assert.Equal(t, localNode, forkListener.LocalNode())
+	})
+}
+
+func TestForkListener_Close(t *testing.T) {
+	for name, netCfg := range map[string]networkconfig.NetworkConfig{
+		"Pre-Fork":  PreForkNetworkConfig(),
+		"Post-Fork": PostForkNetworkConfig(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			preForkListener := NewMockListener(&enode.LocalNode{}, []*enode.Node{})
+			postForkListener := NewMockListener(&enode.LocalNode{}, []*enode.Node{})
+
+			forkListener := NewForkingDV5Listener(zap.NewNop(), preForkListener, postForkListener, iteratorTimeout, netCfg)
+
+			// Call any method so that it will check whether to close the pre-fork listener
+			_ = forkListener.AllNodes()
+
+			assert.False(t, preForkListener.closed)
+			assert.False(t, postForkListener.closed)
+
+			// Close
+			forkListener.Close()
+
+			assert.True(t, preForkListener.closed)
+			assert.True(t, postForkListener.closed)
+		})
+	}
+}
+
+func requireNextTimeout(t *testing.T, expected bool, iter enode.Iterator, timeout time.Duration) {
+	const maxTries = 10
+	var deadline = time.After(timeout)
+	next := make(chan bool)
+	go func() {
+		defer close(next)
+		for {
+			ok := iter.Next()
+			select {
+			case next <- ok:
+			case <-deadline:
+				return
+			}
+			if ok {
+				return
+			}
+			time.Sleep(timeout / maxTries)
+		}
+	}()
+	for {
+		select {
+		case ok := <-next:
+			require.Equal(t, expected, ok, "expected next to be %v", expected)
+			if ok {
+				return
+			}
+		case <-deadline:
+			if expected {
+				require.Fail(t, "expected next to be %v", expected)
+			}
+			return
+		}
+	}
+}

--- a/network/discovery/iterator_test.go
+++ b/network/discovery/iterator_test.go
@@ -1,0 +1,123 @@
+package discovery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFairMixIterator_Next(t *testing.T) {
+	// Mock iterators
+	preforkNodes := NewTestingNodes(t, 2)
+	postForkNodes := NewTestingNodes(t, 2)
+
+	iterator := enode.NewFairMix(5 * time.Millisecond)
+	defer iterator.Close()
+	iterator.AddSource(NewMockIterator(preforkNodes))
+	iterator.AddSource(NewMockIterator(postForkNodes))
+
+	expectedNodes := append(preforkNodes, postForkNodes...)
+	actualNodes := make([]*enode.Node, 0, len(expectedNodes))
+	for i := 0; i < 4; i++ {
+		require.True(t, iterator.Next())
+		actualNodes = append(actualNodes, iterator.Node())
+	}
+	require.ElementsMatch(t, expectedNodes, actualNodes)
+
+	// No more elements
+	requireNextTimeout(t, false, iterator, 15*time.Millisecond)
+}
+
+func TestFairMixIterator_Next_False(t *testing.T) {
+	// Mock iterators
+	// Nil means return false on Next()
+	preforkNodes := []*enode.Node{NewTestingNode(t), nil, NewTestingNode(t)}
+	postForkNodes := []*enode.Node{NewTestingNode(t), NewTestingNode(t), nil}
+	preFork := NewMockIterator(preforkNodes)
+	postFork := NewMockIterator(postForkNodes)
+
+	iterator := enode.NewFairMix(5 * time.Millisecond)
+	defer iterator.Close()
+	iterator.AddSource(preFork)
+	iterator.AddSource(postFork)
+
+	var expectedNodes []*enode.Node
+	for _, node := range preforkNodes {
+		if node == nil {
+			break
+		}
+		expectedNodes = append(expectedNodes, node)
+	}
+	for _, node := range postForkNodes {
+		if node == nil {
+			break
+		}
+		expectedNodes = append(expectedNodes, node)
+	}
+
+	var actualNodes []*enode.Node
+	for i := 0; i < len(expectedNodes); i++ {
+		requireNextTimeout(t, true, iterator, 10*time.Millisecond)
+		actualNodes = append(actualNodes, iterator.Node())
+	}
+	require.ElementsMatch(t, expectedNodes, actualNodes)
+
+	// No more elements
+	requireNextTimeout(t, false, iterator, 15*time.Millisecond)
+}
+
+func TestFairMixIterator_PostForkEmpty(t *testing.T) {
+	// Mock nodes
+	node1 := NewTestingNode(t)
+	node2 := NewTestingNode(t)
+
+	// Mock iterators
+	preFork := NewMockIterator([]*enode.Node{node2, node1}) // preFork has 2 nodes
+	postFork := NewMockIterator([]*enode.Node{})            // postFork has no node
+
+	iterator := enode.NewFairMix(5 * time.Millisecond)
+	defer iterator.Close()
+	iterator.AddSource(preFork)
+	iterator.AddSource(postFork)
+
+	require.False(t, postFork.closed) // postFork iterator must start openened
+
+	// First check: preFork first node after switch
+	requireNextTimeout(t, true, iterator, 10*time.Millisecond)
+	require.Equal(t, node2, iterator.Node())
+
+	// Second check: preFork second node
+	requireNextTimeout(t, true, iterator, 10*time.Millisecond)
+	require.Equal(t, node1, iterator.Node())
+
+	// No more elements
+	requireNextTimeout(t, false, iterator, 15*time.Millisecond)
+}
+
+func TestFairMixIterator_PreForkEmpty(t *testing.T) {
+	// Mock nodes
+	node1 := NewTestingNode(t)
+	node2 := NewTestingNode(t)
+
+	// Mock iterators
+	preFork := NewMockIterator([]*enode.Node{})              // preFork has no node
+	postFork := NewMockIterator([]*enode.Node{node1, node2}) // postFork has 2 nodes
+
+	iterator := enode.NewFairMix(5 * time.Millisecond)
+	defer iterator.Close()
+	iterator.AddSource(preFork)
+	iterator.AddSource(postFork)
+
+	// First check: postFork first node
+	requireNextTimeout(t, true, iterator, 10*time.Millisecond)
+	require.Equal(t, node1, iterator.Node())
+
+	// Second check: postFork second node
+	requireNextTimeout(t, true, iterator, 10*time.Millisecond)
+	require.Equal(t, node2, iterator.Node())
+
+	// No more elements even after switch
+	requireNextTimeout(t, false, iterator, 15*time.Millisecond)
+}

--- a/network/discovery/options.go
+++ b/network/discovery/options.go
@@ -4,12 +4,14 @@ import (
 	"crypto/ecdsa"
 	"net"
 
+	"github.com/ssvlabs/ssv/logging"
+	compatible_logger "github.com/ssvlabs/ssv/network/discovery/logger"
+
+	"github.com/ssvlabs/ssv/network/commons"
+
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/pkg/errors"
-	"github.com/ssvlabs/ssv/logging"
-	"github.com/ssvlabs/ssv/network/commons"
-	compatible_logger "github.com/ssvlabs/ssv/network/discovery/logger"
 	"go.uber.org/zap"
 )
 

--- a/network/discovery/shared_conn.go
+++ b/network/discovery/shared_conn.go
@@ -12,7 +12,7 @@ import (
 // messages that were found unprocessable and sent to the unhandled channel by the primary listener.
 // It's copied from https://github.com/ethereum/go-ethereum/blob/v1.14.8/p2p/server.go#L435
 type SharedUDPConn struct {
-	UDPConn   *net.UDPConn // not using embedding to make sure go-ethereum doesn't use unwrapped net.UDPConn's methods
+	*net.UDPConn
 	Unhandled chan discover.ReadPacket
 }
 
@@ -28,14 +28,6 @@ func (s *SharedUDPConn) ReadFromUDPAddrPort(b []byte) (n int, addr netip.AddrPor
 	}
 	copy(b[:l], packet.Data[:l])
 	return l, packet.Addr, nil
-}
-
-func (s *SharedUDPConn) WriteToUDPAddrPort(b []byte, addr netip.AddrPort) (n int, err error) {
-	return s.UDPConn.WriteToUDPAddrPort(b, addr)
-}
-
-func (s *SharedUDPConn) LocalAddr() net.Addr {
-	return s.UDPConn.LocalAddr()
 }
 
 // Close implements discover.UDPConn

--- a/network/discovery/util_test.go
+++ b/network/discovery/util_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
@@ -18,12 +19,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-bitfield"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-
 	"github.com/ssvlabs/ssv/network/peers"
 	"github.com/ssvlabs/ssv/network/records"
 	"github.com/ssvlabs/ssv/networkconfig"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 var (
@@ -88,9 +88,56 @@ func testingDiscovery(t *testing.T) *DiscV5Service {
 	return testingDiscoveryWithNetworkConfig(t, testNetConfig)
 }
 
+// NetworkConfig with fork epoch
+func testingNetConfigWithForkEpoch(forkEpoch phase0.Epoch) networkconfig.NetworkConfig {
+	n := networkconfig.HoleskyStage
+	return networkconfig.NetworkConfig{
+		Name:                 n.Name,
+		Beacon:               n.Beacon,
+		DomainType:           n.DomainType,
+		GenesisEpoch:         n.GenesisEpoch,
+		RegistrySyncOffset:   n.RegistrySyncOffset,
+		RegistryContractAddr: n.RegistryContractAddr,
+		Bootnodes:            n.Bootnodes,
+	}
+}
+
+// NetworkConfig for staying in pre-fork
+func PreForkNetworkConfig() networkconfig.NetworkConfig {
+	forkEpoch := networkconfig.HoleskyStage.Beacon.EstimatedCurrentEpoch() + 1000
+	return testingNetConfigWithForkEpoch(forkEpoch)
+}
+
+// NetworkConfig for staying in post-fork
+func PostForkNetworkConfig() networkconfig.NetworkConfig {
+	forkEpoch := networkconfig.HoleskyStage.Beacon.EstimatedCurrentEpoch() - 1000
+	return testingNetConfigWithForkEpoch(forkEpoch)
+}
+
+// Testing LocalNode
+func NewLocalNode(t *testing.T) *enode.LocalNode {
+	// Generate key
+	nodeKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	// Create local node
+	localNode, err := records.CreateLocalNode(nodeKey, t.TempDir(), net.IP(testIP), testPort, testTCPPort)
+	require.NoError(t, err)
+
+	// Set entries
+	err = records.SetDomainTypeEntry(localNode, records.KeyDomainType, testNetConfig.DomainType)
+	require.NoError(t, err)
+	err = records.SetDomainTypeEntry(localNode, records.KeyNextDomainType, testNetConfig.DomainType)
+	require.NoError(t, err)
+	err = records.SetSubnetsEntry(localNode, mockSubnets(1))
+	require.NoError(t, err)
+
+	return localNode
+}
+
 // Testing node
 func NewTestingNode(t *testing.T) *enode.Node {
-	return CustomNode(t, true, testNetConfig.DomainType, true, mockSubnets(1))
+	return CustomNode(t, true, testNetConfig.DomainType, true, testNetConfig.DomainType, true, mockSubnets(1))
 }
 
 func NewTestingNodes(t *testing.T, count int) []*enode.Node {
@@ -102,32 +149,33 @@ func NewTestingNodes(t *testing.T, count int) []*enode.Node {
 }
 
 func NodeWithoutDomain(t *testing.T) *enode.Node {
-	return CustomNode(t, false, spectypes.DomainType{}, true, mockSubnets(1))
+	return CustomNode(t, false, spectypes.DomainType{}, true, testNetConfig.DomainType, true, mockSubnets(1))
+}
+
+func NodeWithoutNextDomain(t *testing.T) *enode.Node {
+	return CustomNode(t, true, testNetConfig.DomainType, false, spectypes.DomainType{}, true, mockSubnets(1))
 }
 
 func NodeWithoutSubnets(t *testing.T) *enode.Node {
-	return CustomNode(t, true, testNetConfig.DomainType, false, nil)
+	return CustomNode(t, true, testNetConfig.DomainType, true, testNetConfig.DomainType, false, nil)
 }
 
-func NodeWithCustomDomain(t *testing.T, domainType spectypes.DomainType) *enode.Node {
-	return CustomNode(t, true, domainType, true, mockSubnets(1))
+func NodeWithCustomDomains(t *testing.T, domainType spectypes.DomainType, nextDomainType spectypes.DomainType) *enode.Node {
+	return CustomNode(t, true, domainType, true, nextDomainType, true, mockSubnets(1))
 }
 
 func NodeWithZeroSubnets(t *testing.T) *enode.Node {
-	return CustomNode(t, true, testNetConfig.DomainType, true, zeroSubnets)
+	return CustomNode(t, true, testNetConfig.DomainType, true, testNetConfig.DomainType, true, zeroSubnets)
 }
 
 func NodeWithCustomSubnets(t *testing.T, subnets []byte) *enode.Node {
-	return CustomNode(t, true, testNetConfig.DomainType, true, subnets)
+	return CustomNode(t, true, testNetConfig.DomainType, true, testNetConfig.DomainType, true, subnets)
 }
 
-func CustomNode(
-	t *testing.T,
-	setDomainType bool,
-	domainType spectypes.DomainType,
-	setSubnets bool,
-	subnets []byte,
-) *enode.Node {
+func CustomNode(t *testing.T,
+	setDomainType bool, domainType spectypes.DomainType,
+	setNextDomainType bool, nextDomainType spectypes.DomainType,
+	setSubnets bool, subnets []byte) *enode.Node {
 
 	// Generate key
 	nodeKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -149,6 +197,12 @@ func CustomNode(
 		record.Set(records.DomainTypeEntry{
 			Key:        records.KeyDomainType,
 			DomainType: domainType,
+		})
+	}
+	if setNextDomainType {
+		record.Set(records.DomainTypeEntry{
+			Key:        records.KeyNextDomainType,
+			DomainType: nextDomainType,
 		})
 	}
 	if setSubnets {

--- a/network/records/entries.go
+++ b/network/records/entries.go
@@ -15,7 +15,8 @@ import (
 type ENRKey string
 
 const (
-	KeyDomainType = "domaintype"
+	KeyDomainType     = "domaintype"
+	KeyNextDomainType = "next_domaintype"
 )
 
 var ErrEntryNotFound = errors.New("not found")


### PR DESCRIPTION
### Description

We noticed that Discovery isn't working as expected after #1820 , after some testing we realized there's some issue also present from previous versions but the dual discovery in alan works as a workaround. So this change basically brings back this part of the code (dual discovery) with some adjustment to the new domain type code.