### PR TITLE
fix(metrics): set epoch when reset submissions gauge, refactor validator status names

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -1055,13 +1055,13 @@ func (c *controller) ReportValidatorStatuses(ctx context.Context) {
 					continue
 				}
 				if share.IsParticipating(c.beacon.GetBeaconNetwork().EstimatedCurrentEpoch()) {
-					validatorsPerStatus[statusActive]++
+					validatorsPerStatus[statusParticipating]++
 				}
 				meta := share.BeaconMetadata
 				if meta == nil {
 					validatorsPerStatus[statusNotFound]++
 				} else if meta.IsActive() {
-					validatorsPerStatus[statusReady]++
+					validatorsPerStatus[statusActive]++
 				} else if meta.Slashed() {
 					validatorsPerStatus[statusSlashed]++
 				} else if meta.Exiting() {

--- a/operator/validator/observability.go
+++ b/operator/validator/observability.go
@@ -19,15 +19,15 @@ const (
 type validatorStatus string
 
 const (
-	statusActive       validatorStatus = "active"
-	statusNotFound     validatorStatus = "not_found"
-	statusReady        validatorStatus = "ready"
-	statusSlashed      validatorStatus = "slashed"
-	statusExiting      validatorStatus = "exiting"
-	statusNotActivated validatorStatus = "not_activated"
-	statusPending      validatorStatus = "pending"
-	statusNoIndex      validatorStatus = "no_index"
-	statusUnknown      validatorStatus = "unknown"
+	statusParticipating validatorStatus = "participating"
+	statusNotFound      validatorStatus = "not_found"
+	statusActive        validatorStatus = "active"
+	statusSlashed       validatorStatus = "slashed"
+	statusExiting       validatorStatus = "exiting"
+	statusNotActivated  validatorStatus = "not_activated"
+	statusPending       validatorStatus = "pending"
+	statusNoIndex       validatorStatus = "no_index"
+	statusUnknown       validatorStatus = "unknown"
 )
 
 var (

--- a/protocol/v2/ssv/runner/observability.go
+++ b/protocol/v2/ssv/runner/observability.go
@@ -91,7 +91,9 @@ func recordSuccessfulSubmission(ctx context.Context, count uint32, epoch phase0.
 	}
 
 	for _, r := range rolesToReset {
-		submissions[r] = submissionsMetric{}
+		submissions[r] = submissionsMetric{
+			epoch: epoch,
+		}
 	}
 
 	submission := submissions[role]


### PR DESCRIPTION
```
epoch 1
role: Proposer
nrOfSubmissions: 1
```
Should result in gauge record being set to 1. _Works_
On new epoch start should reset map to 0. _Works_

```
epoch 2
role: Proposer
nrOfSubmissions: 0
```
Should result in gauge record  being set to 0. _Dot not work_. Reason: `submission.epoch != 0` return `false`, because reset set epoch to 0.

Rename some of the validator statuses