### PR TITLE
feat: do not crush unsynced slots/blocks if withing given limits

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -205,6 +205,7 @@ var StartNodeCmd = &cobra.Command{
 			executionclient.WithConnectionTimeout(cfg.ExecutionClient.ConnectionTimeout),
 			executionclient.WithReconnectionInitialInterval(executionclient.DefaultReconnectionInitialInterval),
 			executionclient.WithReconnectionMaxInterval(executionclient.DefaultReconnectionMaxInterval),
+			executionclient.WithAllowUnsyncedBlocks(cfg.ExecutionClient.AllowUnsyncedBlocks),
 		)
 		if err != nil {
 			logger.Fatal("could not connect to execution client", zap.Error(err))

--- a/eth/executionclient/config.go
+++ b/eth/executionclient/config.go
@@ -8,6 +8,7 @@ import (
 
 // ExecutionOptions contains config configurations related to Ethereum execution client.
 type ExecutionOptions struct {
-	Addr              string        `yaml:"ETH1Addr" env:"ETH_1_ADDR" env-required:"true" env-description:"Execution client WebSocket address"`
-	ConnectionTimeout time.Duration `yaml:"ETH1ConnectionTimeout" env:"ETH_1_CONNECTION_TIMEOUT" env-default:"10s" env-description:"Execution client connection timeout"`
+	Addr                string        `yaml:"ETH1Addr" env:"ETH_1_ADDR" env-required:"true" env-description:"Execution client WebSocket address"`
+	ConnectionTimeout   time.Duration `yaml:"ETH1ConnectionTimeout" env:"ETH_1_CONNECTION_TIMEOUT" env-default:"10s" env-description:"Execution client connection timeout"`
+	AllowUnsyncedBlocks uint64        `yaml:"AllowUnsyncedBlocksCount" env:"ALLOW_UNSYNCED_BLOCKS" env-default:"2" env-description:"The numbers of blocks we are allowed to lag behind"`
 }

--- a/eth/executionclient/execution_client_test.go
+++ b/eth/executionclient/execution_client_test.go
@@ -2,6 +2,7 @@ package executionclient
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"net/http/httptest"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -603,6 +605,91 @@ func TestSimSSV(t *testing.T) {
 
 	require.NoError(t, client.Close())
 	require.NoError(t, sim.Close())
+}
+
+func TestSyncProgress(t *testing.T) {
+	const testTimeout = 1 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	// Create simulator instance
+	sim := simTestBackend(testAddr)
+
+	// Create JSON-RPC handler
+	rpcServer, _ := sim.Node().RPCHandler()
+	// Expose handler on a test server with ws open
+	httpsrv := httptest.NewServer(rpcServer.WebsocketHandler([]string{"*"}))
+	defer rpcServer.Stop()
+	defer httpsrv.Close()
+	addr := httpToWebSocketURL(httpsrv.URL)
+
+	parsed, _ := abi.JSON(strings.NewReader(simcontract.SimcontractMetaData.ABI))
+	auth, _ := bind.NewKeyedTransactorWithChainID(testKey, big.NewInt(1337))
+	contractAddr, _, _, err := bind.DeployContract(auth, parsed, ethcommon.FromHex(simcontract.SimcontractMetaData.Bin), sim.Client())
+	if err != nil {
+		t.Errorf("deploying contract: %v", err)
+	}
+	sim.Commit()
+
+	// Check contract code at the simulated blockchain
+	contractCode, err := sim.Client().CodeAt(ctx, contractAddr, nil)
+	if err != nil {
+		t.Errorf("getting contract code: %v", err)
+	}
+	require.NotEmpty(t, contractCode)
+
+	// Create a client and connect to the simulator
+	client, err := New(ctx, addr, contractAddr)
+	require.NoError(t, err)
+
+	err = client.Healthy(ctx)
+	require.NoError(t, err)
+
+	t.Run("can't get block number", func(t *testing.T) {
+		client.syncProgressFn = func(context.Context) (*ethereum.SyncProgress, error) {
+			return new(ethereum.SyncProgress), nil
+		}
+
+		client.blockNumberFn = func(ctx context.Context) (uint64, error) {
+			return 0, errors.New("some err")
+		}
+
+		err = client.Healthy(ctx)
+		require.ErrorIs(t, err, errSyncing)
+	})
+
+	t.Run("out of sync", func(t *testing.T) {
+		client.syncProgressFn = func(context.Context) (*ethereum.SyncProgress, error) {
+			p := new(ethereum.SyncProgress)
+			p.CurrentBlock = 5
+			return p, nil
+		}
+
+		client.blockNumberFn = func(ctx context.Context) (uint64, error) {
+			return 6, nil
+		}
+
+		err = client.Healthy(ctx)
+		require.ErrorIs(t, err, errSyncing)
+	})
+
+	t.Run("within tolerable limits", func(t *testing.T) {
+		client, err := New(ctx, addr, contractAddr, WithAllowUnsyncedBlocks(2))
+		require.NoError(t, err)
+
+		client.syncProgressFn = func(context.Context) (*ethereum.SyncProgress, error) {
+			p := new(ethereum.SyncProgress)
+			p.CurrentBlock = 5
+			return p, nil
+		}
+
+		client.blockNumberFn = func(ctx context.Context) (uint64, error) {
+			return 7, nil
+		}
+
+		err = client.Healthy(ctx)
+		require.NoError(t, err)
+	})
 }
 
 func httpToWebSocketURL(url string) string {

--- a/eth/executionclient/options.go
+++ b/eth/executionclient/options.go
@@ -58,3 +58,10 @@ func WithLogBatchSize(size uint64) Option {
 		s.logBatchSize = size
 	}
 }
+
+// WithAllowUnsyncedBlocks sets the number of blocks that is acceptable to lag behind.
+func WithAllowUnsyncedBlocks(count uint64) Option {
+	return func(s *ExecutionClient) {
+		s.allowUnsyncedBlocks = count
+	}
+}

--- a/protocol/v2/blockchain/beacon/client.go
+++ b/protocol/v2/blockchain/beacon/client.go
@@ -64,6 +64,9 @@ type Options struct {
 	Network        Network
 	BeaconNodeAddr string `yaml:"BeaconNodeAddr" env:"BEACON_NODE_ADDR" env-required:"true"`
 	GasLimit       uint64
-	CommonTimeout  time.Duration // Optional.
-	LongTimeout    time.Duration // Optional.
+
+	AllowUnsyncedSlots uint64 `yaml:"AllowUnsyncedSlots" env:"ALLOW_UNSYNCED_SLOTS" env-required:"false"`
+
+	CommonTimeout time.Duration // Optional.
+	LongTimeout   time.Duration // Optional.
 }


### PR DESCRIPTION
Introduces two configuration parameters to allow specifying how many slots/blocks we're allowed to be behind the chain without halting.