### PR TITLE
fix(metrics):  ssv.duty.scheduler.executions - replace attribute

### DIFF
--- a/operator/duties/observability.go
+++ b/operator/duties/observability.go
@@ -37,9 +37,9 @@ func metricName(name string) string {
 	return fmt.Sprintf("%s.%s", observabilityNamespace, name)
 }
 
-func recordDutyExecuted(ctx context.Context, beaconRole types.BeaconRole) {
+func recordDutyExecuted(ctx context.Context, role types.RunnerRole) {
 	dutiesExecutedCounter.Add(ctx, 1,
 		metric.WithAttributes(
-			observability.BeaconRoleAttribute(beaconRole),
+			observability.RunnerRoleAttribute(role),
 		))
 }

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -371,7 +371,7 @@ func (s *Scheduler) ExecuteDuties(ctx context.Context, logger *zap.Logger, dutie
 			if duty.Type == spectypes.BNRoleAttester || duty.Type == spectypes.BNRoleSyncCommittee {
 				s.waitOneThirdOrValidBlock(duty.Slot)
 			}
-			recordDutyExecuted(ctx, duty.Type)
+			recordDutyExecuted(ctx, duty.RunnerRole())
 			s.dutyExecutor.ExecuteDuty(ctx, logger, duty)
 		}()
 	}
@@ -392,7 +392,7 @@ func (s *Scheduler) ExecuteCommitteeDuties(ctx context.Context, logger *zap.Logg
 		slotDelayHistogram.Record(ctx, slotDelay.Seconds())
 		go func() {
 			s.waitOneThirdOrValidBlock(duty.Slot)
-			recordDutyExecuted(ctx, spectypes.BNRoleSyncCommittee)
+			recordDutyExecuted(ctx, duty.RunnerRole())
 			s.dutyExecutor.ExecuteCommitteeDuty(ctx, logger, committee.id, duty)
 		}()
 	}


### PR DESCRIPTION
`ssv.beacon.role` was not set correctly, hence there is an option of using `ssv.runner.role` instead. 
To keep `ssv.beacon.role` it would be required to iterate over all duties within Committee Duty object, which would add `O(n)` where `n` is a number of duties time complexity to the duty scheduling, which is a trade-off. I am incline towards switching to `ssv.runner.role` attribute