### PR TITLE
feat: (blossom) prepare to 1000 validators hardfork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/cobra v1.8.1
 	github.com/ssvlabs/eth2-key-manager v1.4.2
-	github.com/ssvlabs/ssv-spec v1.0.0
+	github.com/ssvlabs/ssv-spec v0.0.0-20241219094818-b5bd1d3f20cb
 	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.9.0
 	github.com/wealdtech/go-eth2-types/v2 v2.8.1

--- a/go.sum
+++ b/go.sum
@@ -734,8 +734,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.0.0/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/ssvlabs/eth2-key-manager v1.4.2 h1:YdeI7vk9jSa8vfSKogx2aSjtYz4eS9Bp85E0yfQF95o=
 github.com/ssvlabs/eth2-key-manager v1.4.2/go.mod h1:RqsGIMCsOeUJQmC2nytr82z5vqn5gN3i3VAoY0OydV8=
-github.com/ssvlabs/ssv-spec v1.0.0 h1:h/EoKLsLXVO6GIzKoBi1O05xdHlirpLi8DLhVcTSEBE=
-github.com/ssvlabs/ssv-spec v1.0.0/go.mod h1:lTqsNeTUIfpacMoztbN7YqvFttDigCLjINjy/8I2Wuc=
+github.com/ssvlabs/ssv-spec v0.0.0-20241219094818-b5bd1d3f20cb h1:bP0UHVWjGPhSKsk6HicZLhQ+oFebQJ2XSWZj+gaIs7k=
+github.com/ssvlabs/ssv-spec v0.0.0-20241219094818-b5bd1d3f20cb/go.mod h1:lTqsNeTUIfpacMoztbN7YqvFttDigCLjINjy/8I2Wuc=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -43,7 +43,9 @@ const (
 	maxPartialSignatureMsgsSizeOld     = partialSigMsgTypeSize + slotSize + maxSizePartialSignatureMessagesOld*maxSizePartialSignatureMessage + 4
 	maxEncodedPartialSignatureSizeOld  = maxPartialSignatureMsgsSizeOld + maxPartialSignatureMsgsSizeOld/encodingOverheadDivisor
 	///
-	maxSizePartialSignatureMessages = 1512
+	maxAttestations                 = 1000
+	maxSyncCommittees               = 512
+	maxSizePartialSignatureMessages = maxAttestations + maxSyncCommittees
 	partialSigMsgTypeSize           = 8 // uint64
 	maxPartialSignatureMsgsSize     = partialSigMsgTypeSize + slotSize + maxSizePartialSignatureMessages*maxSizePartialSignatureMessage + 4
 	maxEncodedPartialSignatureSize  = maxPartialSignatureMsgsSize + maxPartialSignatureMsgsSize/encodingOverheadDivisor

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -36,12 +36,12 @@ const (
 )
 
 const (
-	partialSignatureSize           = 96
-	partialSignatureMsgSize        = partialSignatureSize + rootSize + operatorIDSize + validatorIndexSize
-	maxPartialSignatureMessages    = 1000
-	partialSigMsgTypeSize          = 8 // uint64
-	maxPartialSignatureMsgsSize    = partialSigMsgTypeSize + slotSize + maxPartialSignatureMessages*partialSignatureMsgSize
-	maxEncodedPartialSignatureSize = maxPartialSignatureMsgsSize + maxPartialSignatureMsgsSize/encodingOverheadDivisor + 4
+	partialSignatureSize            = 96
+	maxSizePartialSignatureMessage  = partialSignatureSize + rootSize + operatorIDSize + validatorIndexSize
+	maxSizePartialSignatureMessages = 1512
+	partialSigMsgTypeSize           = 8 // uint64
+	maxPartialSignatureMsgsSize     = partialSigMsgTypeSize + slotSize + maxSizePartialSignatureMessages*maxSizePartialSignatureMessage + 4
+	maxEncodedPartialSignatureSize  = maxPartialSignatureMsgsSize + maxPartialSignatureMsgsSize/encodingOverheadDivisor
 )
 
 const (

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -36,8 +36,13 @@ const (
 )
 
 const (
-	partialSignatureSize            = 96
-	maxSizePartialSignatureMessage  = partialSignatureSize + rootSize + operatorIDSize + validatorIndexSize
+	partialSignatureSize           = 96
+	maxSizePartialSignatureMessage = partialSignatureSize + rootSize + operatorIDSize + validatorIndexSize
+	/// Pre fork values TODO remove after Blossom
+	maxSizePartialSignatureMessagesOld = 1000
+	maxPartialSignatureMsgsSizeOld     = partialSigMsgTypeSize + slotSize + maxSizePartialSignatureMessagesOld*maxSizePartialSignatureMessage + 4
+	maxEncodedPartialSignatureSizeOld  = maxPartialSignatureMsgsSizeOld + maxPartialSignatureMsgsSizeOld/encodingOverheadDivisor
+	///
 	maxSizePartialSignatureMessages = 1512
 	partialSigMsgTypeSize           = 8 // uint64
 	maxPartialSignatureMsgsSize     = partialSigMsgTypeSize + slotSize + maxSizePartialSignatureMessages*maxSizePartialSignatureMessage + 4

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -44,7 +44,7 @@ const (
 	maxEncodedPartialSignatureSizeOld  = maxPartialSignatureMsgsSizeOld + maxPartialSignatureMsgsSizeOld/encodingOverheadDivisor
 	///
 	maxAttestations                 = 1000
-	maxSyncCommittees               = 512
+	maxSyncCommittees               = syncCommitteeSize
 	maxSizePartialSignatureMessages = maxAttestations + maxSyncCommittees
 	partialSigMsgTypeSize           = 8 // uint64
 	maxPartialSignatureMsgsSize     = partialSigMsgTypeSize + slotSize + maxSizePartialSignatureMessages*maxSizePartialSignatureMessage + 4

--- a/message/validation/partial_validation.go
+++ b/message/validation/partial_validation.go
@@ -23,10 +23,15 @@ func (mv *messageValidator) validatePartialSignatureMessage(
 ) {
 	ssvMessage := signedSSVMessage.SSVMessage
 
-	if len(ssvMessage.Data) > maxEncodedPartialSignatureSize {
+	localMaxEncodedPartialSigSize := maxEncodedPartialSignatureSize
+	if mv.netCfg.Beacon.EpochStartTime(mv.netCfg.BlossomEpoch).Before(receivedAt) {
+		localMaxEncodedPartialSigSize = maxEncodedPartialSignatureSizeOld
+	}
+
+	if len(ssvMessage.Data) > localMaxEncodedPartialSigSize {
 		e := ErrSSVDataTooBig
 		e.got = len(ssvMessage.Data)
-		e.want = maxEncodedPartialSignatureSize
+		e.want = localMaxEncodedPartialSigSize
 		return nil, e
 	}
 

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -710,12 +710,12 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
 		msg := spectestingutils.PostConsensusAttestationMsg(ks.Shares[1], 1, specqbft.Height(slot))
-		for i := 0; i < 1000; i++ {
+		for i := 0; i < 1512; i++ {
 			msg.Messages = append(msg.Messages, msg.Messages[0])
 		}
 
 		_, err := msg.Encode()
-		require.ErrorContains(t, err, "max expected 1000 and 1001 found")
+		require.ErrorContains(t, err, "max expected 1512 and 1513 found")
 	})
 
 	// Get error when receiving message from operator who is not affiliated with the validator

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -710,7 +710,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
 		msg := spectestingutils.PostConsensusAttestationMsg(ks.Shares[1], 1, specqbft.Height(slot))
-		for i := 0; i < 1512; i++ {
+		for i := 0; i < maxSizePartialSignatureMessages; i++ {
 			msg.Messages = append(msg.Messages, msg.Messages[0])
 		}
 

--- a/networkconfig/config.go
+++ b/networkconfig/config.go
@@ -35,6 +35,7 @@ type NetworkConfig struct {
 	Beacon               beacon.BeaconNetwork
 	DomainType           spectypes.DomainType
 	GenesisEpoch         phase0.Epoch
+	BlossomEpoch         phase0.Epoch
 	RegistrySyncOffset   *big.Int
 	RegistryContractAddr string // TODO: ethcommon.Address
 	Bootnodes            []string

--- a/networkconfig/holesky-e2e.go
+++ b/networkconfig/holesky-e2e.go
@@ -13,6 +13,7 @@ var HoleskyE2E = NetworkConfig{
 	Beacon:               beacon.NewNetwork(spectypes.HoleskyNetwork),
 	DomainType:           spectypes.DomainType{0x0, 0x0, 0xee, 0x1},
 	GenesisEpoch:         1,
+	BlossomEpoch:         999999999,
 	RegistryContractAddr: "0x58410bef803ecd7e63b23664c586a6db72daf59c",
 	RegistrySyncOffset:   big.NewInt(405579),
 	Bootnodes:            []string{},

--- a/networkconfig/holesky-stage.go
+++ b/networkconfig/holesky-stage.go
@@ -13,6 +13,7 @@ var HoleskyStage = NetworkConfig{
 	Beacon:               beacon.NewNetwork(spectypes.HoleskyNetwork),
 	DomainType:           [4]byte{0x00, 0x00, 0x31, 0x13},
 	GenesisEpoch:         1,
+	BlossomEpoch:         999999999,
 	RegistrySyncOffset:   new(big.Int).SetInt64(84599),
 	RegistryContractAddr: "0x0d33801785340072C452b994496B19f196b7eE15",
 	DiscoveryProtocolID:  [6]byte{'s', 's', 'v', 'd', 'v', '5'},

--- a/networkconfig/holesky.go
+++ b/networkconfig/holesky.go
@@ -13,6 +13,7 @@ var Holesky = NetworkConfig{
 	Beacon:               beacon.NewNetwork(spectypes.HoleskyNetwork),
 	DomainType:           spectypes.DomainType{0x0, 0x0, 0x5, 0x2},
 	GenesisEpoch:         1,
+	BlossomEpoch:         999999999,
 	RegistrySyncOffset:   new(big.Int).SetInt64(181612),
 	RegistryContractAddr: "0x38A4794cCEd47d3baf7370CcC43B560D3a1beEFA",
 	DiscoveryProtocolID:  [6]byte{'s', 's', 'v', 'd', 'v', '5'},

--- a/networkconfig/local-testnet.go
+++ b/networkconfig/local-testnet.go
@@ -11,6 +11,7 @@ var LocalTestnet = NetworkConfig{
 	Beacon:               beacon.NewLocalTestNetwork(spectypes.PraterNetwork),
 	DomainType:           spectypes.DomainType{0x0, 0x0, spectypes.JatoV2NetworkID.Byte(), 0x2},
 	GenesisEpoch:         1,
+	BlossomEpoch:         999999999,
 	RegistryContractAddr: "0xC3CD9A0aE89Fff83b71b58b6512D43F8a41f363D",
 	Bootnodes: []string{
 		"enr:-Li4QLR4Y1VbwiqFYKy6m-WFHRNDjhMDZ_qJwIABu2PY9BHjIYwCKpTvvkVmZhu43Q6zVA29sEUhtz10rQjDJkK3Hd-GAYiGrW2Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhCLdu_SJc2VjcDI1NmsxoQJTcI7GHPw-ZqIflPZYYDK_guurp_gsAFF5Erns3-PAvIN0Y3CCE4mDdWRwgg-h",

--- a/networkconfig/mainnet.go
+++ b/networkconfig/mainnet.go
@@ -13,6 +13,7 @@ var Mainnet = NetworkConfig{
 	Beacon:               beacon.NewNetwork(spectypes.MainNetwork),
 	DomainType:           spectypes.AlanMainnet,
 	GenesisEpoch:         218450,
+	BlossomEpoch:         999999999,
 	RegistrySyncOffset:   new(big.Int).SetInt64(17507487),
 	RegistryContractAddr: "0xDD9BC35aE942eF0cFa76930954a156B3fF30a4E1",
 	DiscoveryProtocolID:  [6]byte{'s', 's', 'v', 'd', 'v', '5'},

--- a/networkconfig/test-network.go
+++ b/networkconfig/test-network.go
@@ -13,6 +13,7 @@ var TestNetwork = NetworkConfig{
 	Beacon:               beacon.NewNetwork(spectypes.BeaconTestNetwork),
 	DomainType:           spectypes.DomainType{0x0, 0x0, spectypes.JatoNetworkID.Byte(), 0x2},
 	GenesisEpoch:         152834,
+	BlossomEpoch:         999999999,
 	RegistrySyncOffset:   new(big.Int).SetInt64(9015219),
 	RegistryContractAddr: "0x4B133c68A084B8A88f72eDCd7944B69c8D545f03",
 	Bootnodes: []string{

--- a/utils/testutils.go
+++ b/utils/testutils.go
@@ -63,6 +63,12 @@ func SetupMockBeaconNetwork(t *testing.T, currentSlot *SlotValue) *mocknetwork.M
 			return beaconNetwork.FirstSlotAtEpoch(epoch)
 		},
 	).AnyTimes()
+	mockBeaconNetwork.EXPECT().EpochStartTime(gomock.Any()).DoAndReturn(
+		func(epoch phase0.Epoch) time.Time {
+			firstSlot := beaconNetwork.FirstSlotAtEpoch(epoch)
+			t := beaconNetwork.EstimatedTimeAtSlot(firstSlot)
+			return time.Unix(t, 0)
+		}).AnyTimes()
 	mockBeaconNetwork.EXPECT().IsFirstSlotOfEpoch(gomock.Any()).DoAndReturn(
 		func(slot phase0.Slot) bool {
 			return uint64(slot)%mockBeaconNetwork.SlotsPerEpoch() == 0


### PR DESCRIPTION
The PR prepares the codebase for the blossom hard fork, which increases the max validator count to 1000: https://github.com/ssvlabs/SIPs/pull/53

Changes:
- `message/validation`: adjust message sizes
- `networkconfig`: set blossom epoch