### PR TITLE
refactor: optimize subnet calculations using big.Int for reduced memory usage

### DIFF
--- a/network/commons/common.go
+++ b/network/commons/common.go
@@ -25,6 +25,13 @@ const (
 	topicPrefix = "ssv.v2"
 )
 
+// BigIntSubnetsCount is the big.Int representation of SubnetsCount
+var bigIntSubnetsCount *big.Int
+
+func init() {
+	bigIntSubnetsCount = new(big.Int).SetUint64(SubnetsCount)
+}
+
 const (
 	signatureSize    = 256
 	signatureOffset  = 0
@@ -57,8 +64,14 @@ func GetTopicBaseName(topicName string) string {
 
 // CommitteeSubnet returns the subnet for the given committee
 func CommitteeSubnet(cid spectypes.CommitteeID) uint64 {
-	subnet := new(big.Int).Mod(new(big.Int).SetBytes(cid[:]), new(big.Int).SetUint64(SubnetsCount))
+	subnet := new(big.Int).Mod(new(big.Int).SetBytes(cid[:]), bigIntSubnetsCount)
 	return subnet.Uint64()
+}
+
+// SetCommitteeSubnet returns the subnet for the given committee, it doesn't allocate memory but uses the passed in big.Int
+func SetCommitteeSubnet(bigInst *big.Int, cid spectypes.CommitteeID) uint64 {
+	bigInst.SetBytes(cid[:])
+	return bigInst.Mod(bigInst, bigIntSubnetsCount).Uint64()
 }
 
 // MsgIDFunc is the function that maps a message to a msg_id

--- a/network/commons/common.go
+++ b/network/commons/common.go
@@ -69,9 +69,9 @@ func CommitteeSubnet(cid spectypes.CommitteeID) uint64 {
 }
 
 // SetCommitteeSubnet returns the subnet for the given committee, it doesn't allocate memory but uses the passed in big.Int
-func SetCommitteeSubnet(bigInst *big.Int, cid spectypes.CommitteeID) uint64 {
+func SetCommitteeSubnet(bigInst *big.Int, cid spectypes.CommitteeID) {
 	bigInst.SetBytes(cid[:])
-	return bigInst.Mod(bigInst, bigIntSubnetsCount).Uint64()
+	bigInst.Set(bigInst.Mod(bigInst, bigIntSubnetsCount))
 }
 
 // MsgIDFunc is the function that maps a message to a msg_id

--- a/network/commons/common.go
+++ b/network/commons/common.go
@@ -71,7 +71,7 @@ func CommitteeSubnet(cid spectypes.CommitteeID) uint64 {
 // SetCommitteeSubnet returns the subnet for the given committee, it doesn't allocate memory but uses the passed in big.Int
 func SetCommitteeSubnet(bigInst *big.Int, cid spectypes.CommitteeID) {
 	bigInst.SetBytes(cid[:])
-	bigInst.Set(bigInst.Mod(bigInst, bigIntSubnetsCount))
+	bigInst.Mod(bigInst, bigIntSubnetsCount)
 }
 
 // MsgIDFunc is the function that maps a message to a msg_id

--- a/network/commons/common_test.go
+++ b/network/commons/common_test.go
@@ -12,6 +12,7 @@ import (
 func TestCommitteeSubnet(t *testing.T) {
 	require.Equal(t, Subnets(), int(bigIntSubnetsCount.Uint64()))
 
+	bigInst := new(big.Int)
 	for i := 0; i < Subnets()*2; i++ {
 		var cid spectypes.CommitteeID
 		if _, err := rand.Read(cid[:]); err != nil {
@@ -22,12 +23,9 @@ func TestCommitteeSubnet(t *testing.T) {
 		expected := CommitteeSubnet(cid)
 
 		// Get result from SetCommitteeSubnet
-		bigInst := new(big.Int)
 		SetCommitteeSubnet(bigInst, cid)
 		actual := bigInst.Uint64()
 
-		if expected != actual {
-			t.Errorf("Results don't match for committee ID %x: expected %d, got %d", cid, expected, actual)
-		}
+		require.Equal(t, expected, actual)
 	}
 }

--- a/network/commons/common_test.go
+++ b/network/commons/common_test.go
@@ -1,0 +1,33 @@
+package commons
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommitteeSubnet(t *testing.T) {
+	require.Equal(t, Subnets(), int(bigIntSubnetsCount.Uint64()))
+
+	for i := 0; i < Subnets()*2; i++ {
+		var cid spectypes.CommitteeID
+		if _, err := rand.Read(cid[:]); err != nil {
+			t.Fatal(err)
+		}
+
+		// Get result from CommitteeSubnet
+		expected := CommitteeSubnet(cid)
+
+		// Get result from SetCommitteeSubnet
+		bigInst := new(big.Int)
+		SetCommitteeSubnet(bigInst, cid)
+		actual := bigInst.Uint64()
+
+		if expected != actual {
+			t.Errorf("Results don't match for committee ID %x: expected %d, got %d", cid, expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
### Description

I observed high memory usage and a lot of allocations stemming from the `CommitteeSubnet` code used to calculate the subnets for which validators we should pull metadata for (Changed in #1787)

### Changes

- Initialized a global `SubnetsCount` `big.Int` representation to reduce allocations.
- Created `SetCommitteeSubnet` which receives a `big.Int` instance and uses it instead of allocating new ints.
- Used the new function in all the metadata collection loop calls to CommitteeSubnet.