### PR TITLE
feat(metrics) - Beacon client 'Validators' endpoint request duration metric

### DIFF
--- a/beacon/goclient/validator.go
+++ b/beacon/goclient/validator.go
@@ -2,6 +2,8 @@ package goclient
 
 import (
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/attestantio/go-eth2-client/api"
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
@@ -11,11 +13,13 @@ import (
 
 // GetValidatorData returns metadata (balance, index, status, more) for each pubkey from the node
 func (gc *GoClient) GetValidatorData(validatorPubKeys []phase0.BLSPubKey) (map[phase0.ValidatorIndex]*eth2apiv1.Validator, error) {
+	reqStart := time.Now()
 	resp, err := gc.client.Validators(gc.ctx, &api.ValidatorsOpts{
 		State:   "head", // TODO maybe need to get the chainId (head) as var
 		PubKeys: validatorPubKeys,
 		Common:  api.CommonOpts{Timeout: gc.longTimeout},
 	})
+	recordRequestDuration(gc.ctx, "Validators", gc.client.Address(), http.MethodPost, time.Since(reqStart), err)
 	if err != nil {
 		gc.log.Error(clResponseErrMsg,
 			zap.String("api", "Validators"),


### PR DESCRIPTION
**Description:**

Durations of all outgoing HTTP requests to _Consensus Node_ are monitored via metrics. This particular endpoint was previously missing