### PR TITLE
fix(exporter): missing identifier value

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -379,10 +379,8 @@ func (c *controller) handleWorkerMessages(msg network.DecodedSSVMessage) error {
 			SyncCommRoots:     c.syncCommRoots,
 			DomainCache:       c.domainCache,
 		}
-		msgID := ssvMsg.GetID()
-		identifier := msgID[:]
 		ncv = &committeeObserver{
-			CommitteeObserver: validator.NewCommitteeObserver(identifier, committeeObserverOptions),
+			CommitteeObserver: validator.NewCommitteeObserver(ssvMsg.GetID(), committeeObserverOptions),
 		}
 		ttlSlots := nonCommitteeValidatorTTLs[ssvMsg.MsgID.GetRoleType()]
 		c.committeesObservers.Set(

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -379,8 +379,10 @@ func (c *controller) handleWorkerMessages(msg network.DecodedSSVMessage) error {
 			SyncCommRoots:     c.syncCommRoots,
 			DomainCache:       c.domainCache,
 		}
+		msgID := ssvMsg.GetID()
+		identifier := msgID[:]
 		ncv = &committeeObserver{
-			CommitteeObserver: validator.NewCommitteeObserver(committeeObserverOptions),
+			CommitteeObserver: validator.NewCommitteeObserver(identifier, committeeObserverOptions),
 		}
 		ttlSlots := nonCommitteeValidatorTTLs[ssvMsg.MsgID.GetRoleType()]
 		c.committeesObservers.Set(

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -28,11 +28,11 @@ import (
 )
 
 type CommitteeObserver struct {
+	msgID                  spectypes.MessageID
 	logger                 *zap.Logger
 	Storage                *storage.ParticipantStores
 	beaconNetwork          beacon.BeaconNetwork
 	networkConfig          networkconfig.NetworkConfig
-	identifier             []byte
 	ValidatorStore         registrystorage.ValidatorStore
 	newDecidedHandler      qbftcontroller.NewDecidedHandler
 	attesterRoots          *ttlcache.Cache[phase0.Root, struct{}]
@@ -56,11 +56,11 @@ type CommitteeObserverOptions struct {
 	DomainCache       *DomainCache
 }
 
-func NewCommitteeObserver(identifier []byte, opts CommitteeObserverOptions) *CommitteeObserver {
+func NewCommitteeObserver(msgID spectypes.MessageID, opts CommitteeObserverOptions) *CommitteeObserver {
 	// TODO: does the specific operator matters?
 
 	return &CommitteeObserver{
-		identifier:             identifier,
+		msgID:                  msgID,
 		logger:                 opts.Logger,
 		Storage:                opts.Storage,
 		beaconNetwork:          opts.NetworkConfig.Beacon,
@@ -128,7 +128,7 @@ func (ncv *CommitteeObserver) ProcessMessage(msg *queue.SSVMessage) error {
 				fields.Validator(validator.ValidatorPubKey[:]),
 				zap.String("signers", strings.Join(operatorIDs, ", ")),
 				fields.BlockRoot(key.Root),
-				zap.String("qbft_ctrl_identifier", hex.EncodeToString(ncv.identifier)),
+				zap.String("qbft_ctrl_identifier", hex.EncodeToString(ncv.msgID[:])),
 			)
 		}
 

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -32,7 +32,7 @@ type CommitteeObserver struct {
 	Storage                *storage.ParticipantStores
 	beaconNetwork          beacon.BeaconNetwork
 	networkConfig          networkconfig.NetworkConfig
-	qbftController         *qbftcontroller.Controller
+	identifier             []byte
 	ValidatorStore         registrystorage.ValidatorStore
 	newDecidedHandler      qbftcontroller.NewDecidedHandler
 	attesterRoots          *ttlcache.Cache[phase0.Root, struct{}]
@@ -56,10 +56,11 @@ type CommitteeObserverOptions struct {
 	DomainCache       *DomainCache
 }
 
-func NewCommitteeObserver(opts CommitteeObserverOptions) *CommitteeObserver {
+func NewCommitteeObserver(identifier []byte, opts CommitteeObserverOptions) *CommitteeObserver {
 	// TODO: does the specific operator matters?
 
 	return &CommitteeObserver{
+		identifier:             identifier,
 		logger:                 opts.Logger,
 		Storage:                opts.Storage,
 		beaconNetwork:          opts.NetworkConfig.Beacon,
@@ -127,7 +128,7 @@ func (ncv *CommitteeObserver) ProcessMessage(msg *queue.SSVMessage) error {
 				fields.Validator(validator.ValidatorPubKey[:]),
 				zap.String("signers", strings.Join(operatorIDs, ", ")),
 				fields.BlockRoot(key.Root),
-				zap.String("qbft_ctrl_identifier", hex.EncodeToString(ncv.qbftController.Identifier)),
+				zap.String("qbft_ctrl_identifier", hex.EncodeToString(ncv.identifier)),
 			)
 		}
 


### PR DESCRIPTION
Log line refers to a previously removed field causing a `panic`. Fixed by passing the missing value.