### PR TITLE
fix(eventsyncer): remove check for block below threshold in the sync history method

### DIFF
--- a/eth/eventsyncer/event_syncer.go
+++ b/eth/eventsyncer/event_syncer.go
@@ -130,12 +130,6 @@ func (es *EventSyncer) SyncHistory(ctx context.Context, fromBlock uint64) (lastP
 		return 0, fmt.Errorf("event replay: lastProcessedBlock (%d) is lower than fromBlock (%d)", lastProcessedBlock, fromBlock)
 	}
 
-	// Check if the block is too old.
-	b := new(big.Int).SetUint64(lastProcessedBlock)
-	if err := es.blockBelowThreshold(ctx, b); err != nil {
-		return 0, err
-	}
-
 	es.logger.Info("finished syncing historical events",
 		zap.Uint64("from_block", fromBlock),
 		zap.Uint64("last_processed_block", lastProcessedBlock))


### PR DESCRIPTION
temporarily remove the check while a proper solution is implemented