### PR TITLE
fix(pubsub): increase subscription buffer size to prevent message drops

### DIFF
--- a/network/topics/container.go
+++ b/network/topics/container.go
@@ -6,6 +6,9 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
 
+// Increased from the default (32) to reduce message drops caused by slow subscribers.
+const subscriptionBufferSize = 128
+
 type onTopicJoined func(ps *pubsub.PubSub, topic *pubsub.Topic)
 
 type topicsContainer struct {
@@ -93,6 +96,8 @@ func (tc *topicsContainer) Subscribe(name string, opts ...pubsub.SubOpt) (*pubsu
 	if err != nil {
 		return nil, err
 	}
+
+	opts = append(opts, pubsub.WithBufferSize(subscriptionBufferSize))
 
 	s, err := topic.Subscribe(opts...)
 	if err != nil {


### PR DESCRIPTION
**Problem**
Messages from `libp2p` were being validated successfully but were not reaching the message queue.
Upon enabling logs for the `libp2p pubsub` package, it was discovered that the following error was causing message drops:
```
Can't deliver message to subscription for topic ssv.v2....; subscriber too slow
```
This occurred because the default subscription buffer size was too small (32), resulting in messages being dropped when the buffer was full.

**Solution**
 - Increased the subscription buffer size to `128` to handle bursts of incoming messages and reduce message drops.
 - The value 128 was chosen based on:
   - It provides 4x the default buffer size, which is sufficient for moderate workloads.
   - it balances memory usage and burst tolerance without overcommitting resources.

After increasing the subscription buffer size to **128**, we observed a **drop in transmit bandwidth and rate of transmitted packets** (see attached screenshot). This is a positive outcome, as the change mitigates message loss by providing more time for subscribers to process messages under load. The reduced bandwidth usage likely results from fewer message drops and retries, as the larger buffer prevents the "subscriber too slow" errors that previously caused excessive retransmissions.
![Screenshot 2025-01-19 at 14 04 29](https://github.com/user-attachments/assets/cb82103a-d2e4-4eba-a684-45f2d2b11275)

Additionally, the CPU usage dropped slightly but not significantly, and memory usage remained unchanged. These resource metrics suggest the fix improved message handling efficiency without introducing notable overhead.
Further tuning may still be required based on actual workload
