### PR TITLE
config: p2p, fix parsing HostDNS

### DIFF
--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -154,7 +154,7 @@ func (c *Config) configureAddrs(logger *zap.Logger, opts []libp2p.Option) ([]lib
 		opts = append(opts, libp2p.AddrsFactory(func(addrs []ma.Multiaddr) []ma.Multiaddr {
 			external, err := ma.NewMultiaddr(fmt.Sprintf("/dns4/%s/tcp/%d", c.HostDNS, c.TCPPort))
 			if err != nil {
-				logger.Warn("unable to create external multiaddress", zap.Error(err))
+				logger.Error("unable to create external multiaddress", zap.Error(err))
 			} else {
 				addrs = append(addrs, external)
 			}

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -40,8 +40,8 @@ type Config struct {
 
 	TCPPort     uint16 `yaml:"TcpPort" env:"TCP_PORT" env-default:"13001" env-description:"TCP port for p2p transport"`
 	UDPPort     uint16 `yaml:"UdpPort" env:"UDP_PORT" env-default:"12001" env-description:"UDP port for discovery"`
-	HostAddress string `yaml:"HostAddress" env:"HOST_ADDRESS" env-description:"External ip node is exposed for discovery"`
-	HostDNS     string `yaml:"HostDNS" env:"HOST_DNS" env-description:"External DNS node is exposed for discovery"`
+	HostAddress string `yaml:"HostAddress" env:"HOST_ADDRESS" env-description:"External ip node is exposed for discovery, can be overridden by HostDNS"`
+	HostDNS     string `yaml:"HostDNS" env:"HOST_DNS" env-description:"External DNS node is exposed for discovery, overrides HostAddress if both are specified"`
 
 	RequestTimeout   time.Duration `yaml:"RequestTimeout" env:"P2P_REQUEST_TIMEOUT"  env-default:"10s"`
 	MaxBatchResponse uint64        `yaml:"MaxBatchResponse" env:"P2P_MAX_BATCH_RESPONSE" env-default:"25" env-description:"Maximum number of returned objects in a batch"`
@@ -149,24 +149,23 @@ func (c *Config) configureAddrs(logger *zap.Logger, opts []libp2p.Option) ([]lib
 	}
 	opts = append(opts, libp2p.ListenAddrs(addrs...))
 
-	// AddrFactory for host address if provided
-	if c.HostAddress != "" {
+	if c.HostDNS != "" {
+		// AddrFactory for DNS address if provided
 		opts = append(opts, libp2p.AddrsFactory(func(addrs []ma.Multiaddr) []ma.Multiaddr {
-			external, err := commons.BuildMultiAddress(c.HostAddress, "tcp", uint(c.TCPPort), "")
+			external, err := ma.NewMultiaddr(fmt.Sprintf("/dns4/%s/tcp/%d", c.HostDNS, c.TCPPort))
 			if err != nil {
-				logger.Error("unable to create external multiaddress", zap.Error(err))
+				logger.Warn("unable to create external multiaddress", zap.Error(err))
 			} else {
 				addrs = append(addrs, external)
 			}
 			return addrs
 		}))
-	}
-	// AddrFactory for DNS address if provided
-	if c.HostDNS != "" {
+	} else if c.HostAddress != "" {
+		// AddrFactory for host address if provided
 		opts = append(opts, libp2p.AddrsFactory(func(addrs []ma.Multiaddr) []ma.Multiaddr {
-			external, err := ma.NewMultiaddr(fmt.Sprintf("/dns4/%s/tcp/%d", c.HostDNS, c.TCPPort))
+			external, err := commons.BuildMultiAddress(c.HostAddress, "tcp", uint(c.TCPPort), "")
 			if err != nil {
-				logger.Warn("unable to create external multiaddress", zap.Error(err))
+				logger.Error("unable to create external multiaddress", zap.Error(err))
 			} else {
 				addrs = append(addrs, external)
 			}

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -149,6 +149,8 @@ func (c *Config) configureAddrs(logger *zap.Logger, opts []libp2p.Option) ([]lib
 	}
 	opts = append(opts, libp2p.ListenAddrs(addrs...))
 
+	// note, only one of (HostDNS, HostAddress) can be used with libp2p - if multiple of these
+	// are set we have to prioritize between them.
 	if c.HostDNS != "" {
 		// AddrFactory for DNS address if provided
 		opts = append(opts, libp2p.AddrsFactory(func(addrs []ma.Multiaddr) []ma.Multiaddr {


### PR DESCRIPTION
Originally this issue was raised by Kraken team, namely they couldn't set `HostDNS` such that it would work - it would fail with:
```
2025-01-21T12:58:53.223889Z	FATAL	failed to setup network	{"error": "could not create p2p host: cannot specify multiple address factories", "errorVerbose": "cannot specify multiple address factories\ncould not create p2p host\ngithub.com/ssvlabs/ssv/network/p2p.(*p2pNetwork).SetupHost\n\t/go/src/github.com/ssvlabs/ssv/network/p2p/p2p_setup.go:136\ngithub.com/ssvlabs/ssv/network/p2p.(*p2pNetwork).Setup\n\t/go/src/github.com/ssvlabs/ssv/network/p2p/p2p_setup.go:67\ngithub.com/ssvlabs/ssv/cli/operator.init.func2\n\t/go/src/github.com/ssvlabs/ssv/cli/operator/node.go:445\ngithub.com/spf13/cobra.(*Command).execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117\ngithub.com/spf13/cobra.(*Command).Execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041\ngithub.com/ssvlabs/ssv/cli.Execute\n\t/go/src/github.com/ssvlabs/ssv/cli/cli.go:27\nmain.main\n\t/go/src/github.com/ssvlabs/ssv/cmd/ssvnode/main.go:20\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:271\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1222"}
make: *** [Makefile:105: start-node] Error 1
make: *** [docker] Error 2
```

the root cause was due to them also specifying `HostAddress` in addition to `HostDNS` without knowing about it (due to them using our Makefile to start SSV node - with our Makefile [defining](https://github.com/ssvlabs/ssv/blob/b4e8e0997e0b744dc24cb0a8b88ed22edc6116cc/Makefile#L6-L9) env variable to set default value for `HostAddress`), and our code registering both values with `libp2p` which doesn't tolerate the usage of more than 1

this PR resolves the issue by making sure only one of conflicting p2p settings is used with `libp2p` prioritizing `HostDNS` over `HostAddress` (which seems what we wanna be doing).