### PR TITLE
chore(dependabot) - Dependabot config github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/spec-alignment.yml
+++ b/.github/workflows/spec-alignment.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Upload output.diff
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: output.diff
           path: ./scripts/spec-alignment/output.diff


### PR DESCRIPTION
Some of our pipelines started to fail, because of outdated GitHub Actions, hence I am adding this dependabot config so it can keep it up to date.
Also, I think we should add dependabot config for stuff like Docker, Go deps, etc. Not adding it now, since it will spam a lot of PRs, so probably we need to discuss that beforehand

**Update:**  
After this PR is merged into the **main** branch, Dependabot will create PRs on a weekly basis for updates to the GitHub Actions used in this repository. It’s unlikely to generate new PRs every week, as new releases for GitHub Actions are not frequent.