### PR TITLE
fix(metrics) - Drop unused prometheus metric

### DIFF
--- a/ibft/storage/store.go
+++ b/ibft/storage/store.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/zap"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
@@ -26,20 +24,6 @@ const (
 	instanceKey        = "instance"
 	participantsKey    = "pt"
 )
-
-var (
-	metricsHighestDecided = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "ssv:validator:ibft_highest_decided",
-		Help: "The highest decided sequence number",
-	}, []string{"identifier", "pubKey"})
-)
-
-func init() {
-	logger := zap.L()
-	if err := prometheus.Register(metricsHighestDecided); err != nil {
-		logger.Debug("could not register prometheus collector")
-	}
-}
 
 // participantStorage struct
 // instanceType is what separates different iBFT eth2 duty types (attestation, proposal and aggregation)


### PR DESCRIPTION
This metric was not migrated to OTeL because it was not used and was high cardinality metric. It should have been removed