### PR TITLE
eth/executionclient: rate limit multi client Healthy call

### DIFF
--- a/eth/executionclient/defaults.go
+++ b/eth/executionclient/defaults.go
@@ -8,7 +8,7 @@ const (
 	DefaultConnectionTimeout           = 10 * time.Second
 	DefaultReconnectionInitialInterval = 1 * time.Second
 	DefaultReconnectionMaxInterval     = 64 * time.Second
-	DefaultHealthInvalidationInterval  = 10 * time.Second // TODO: decide on this value, for now choosing a bit less than block interval
+	DefaultHealthInvalidationInterval  = 24 * time.Second // TODO: decide on this value, for now choosing the node prober interval but it should probably be a bit less than block interval
 	DefaultFollowDistance              = 8
 	// TODO ALAN: revert
 	DefaultHistoricalLogsBatchSize = 500

--- a/eth/executionclient/multi_client.go
+++ b/eth/executionclient/multi_client.go
@@ -279,7 +279,7 @@ func (mc *MultiClient) StreamLogs(ctx context.Context, fromBlock uint64) <-chan 
 
 // Healthy returns if execution client is currently healthy: responds to requests and not in the syncing state.
 func (mc *MultiClient) Healthy(ctx context.Context) error {
-	if time.Since(time.Unix(mc.lastHealthy.Load(), 0)) <= mc.healthInvalidationInterval {
+	if time.Since(time.Unix(mc.lastHealthy.Load(), 0)) < mc.healthInvalidationInterval {
 		return nil
 	}
 


### PR DESCRIPTION
No limit overloads the node