### PR TITLE
fix: (exporter) memory leak in partial sig container

### DIFF
--- a/message/validation/common_checks.go
+++ b/message/validation/common_checks.go
@@ -38,9 +38,9 @@ func (mv *messageValidator) messageLateness(slot phase0.Slot, role spectypes.Run
 	var ttl phase0.Slot
 	switch role {
 	case spectypes.RoleProposer, spectypes.RoleSyncCommitteeContribution:
-		ttl = 1 + lateSlotAllowance
+		ttl = 1 + LateSlotAllowance
 	case spectypes.RoleCommittee, spectypes.RoleAggregator:
-		ttl = phase0.Slot(mv.netCfg.Beacon.SlotsPerEpoch()) + lateSlotAllowance
+		ttl = phase0.Slot(mv.netCfg.Beacon.SlotsPerEpoch()) + LateSlotAllowance
 	case spectypes.RoleValidatorRegistration, spectypes.RoleVoluntaryExit:
 		return 0
 	}

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -13,7 +13,7 @@ const (
 	clockErrorTolerance     = time.Millisecond * 50
 	allowedRoundsInFuture   = 1
 	allowedRoundsInPast     = 2
-	lateSlotAllowance       = 2
+	LateSlotAllowance       = 2
 	syncCommitteeSize       = 512
 	rsaSignatureSize        = 256
 	operatorIDSize          = 8 // uint64

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -3,10 +3,11 @@ package validator
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/ssvlabs/ssv/message/validation"
 	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/ssvlabs/ssv/message/validation"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/herumi/bls-eth-go-binary/bls"

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -7,13 +7,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ssvlabs/ssv/message/validation"
-
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/jellydator/ttlcache/v3"
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/ssvlabs/ssv/message/validation"
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/ibft/storage"

--- a/protocol/v2/ssv/validator/non_committee_validator.go
+++ b/protocol/v2/ssv/validator/non_committee_validator.go
@@ -12,11 +12,11 @@ import (
 	"github.com/jellydator/ttlcache/v3"
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
-	"github.com/ssvlabs/ssv/message/validation"
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/ibft/storage"
 	"github.com/ssvlabs/ssv/logging/fields"
+	"github.com/ssvlabs/ssv/message/validation"
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	qbftcontroller "github.com/ssvlabs/ssv/protocol/v2/qbft/controller"


### PR DESCRIPTION
### Description
I already fixed it in #1859, but we haven't merged it so we kept running with the leak.