### PR TITLE
fix(Exporter): set fixed subnets to all subnets if exporter is set

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -274,6 +274,10 @@ var StartNodeCmd = &cobra.Command{
 		cfg.P2pNetworkConfig.MessageValidator = messageValidator
 		cfg.SSVOptions.ValidatorOptions.MessageValidator = messageValidator
 
+		if cfg.SSVOptions.ValidatorOptions.Exporter {
+			cfg.P2pNetworkConfig.Subnets = records.AllSubnets
+		}
+
 		p2pNetwork := setupP2P(logger, db)
 
 		cfg.SSVOptions.Context = cmd.Context()


### PR DESCRIPTION
### Description

We added a separate metadata syncer component in #1712 , We copied over the logic for `FixedSubnets`, but we called p2p to get it, but since `p2p` we only setup later, the value was empty.

### Solution

This PR parses the fixed subnets separately for the syncer, and sets it to all subnets for an Exporter.