### PR TITLE
 fix(Exporter): set fixed subnets to all subnets if exporter is set #2025 

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -331,13 +331,24 @@ var StartNodeCmd = &cobra.Command{
 		cfg.SSVOptions.ValidatorOptions.ValidatorStore = nodeStorage.ValidatorStore()
 		cfg.SSVOptions.ValidatorOptions.OperatorSigner = types.NewSsvOperatorSigner(operatorPrivKey, operatorDataStore.GetOperatorID)
 
+		fixedSubnets, err := records.Subnets{}.FromString(cfg.P2pNetworkConfig.Subnets)
+		if err != nil {
+			logger.Fatal("failed to parse fixed subnets", zap.Error(err))
+		}
+		if cfg.SSVOptions.ValidatorOptions.Exporter {
+			fixedSubnets, err = records.Subnets{}.FromString(records.AllSubnets)
+			if err != nil {
+				logger.Fatal("failed to parse fixed subnets", zap.Error(err))
+			}
+		}
+
 		metadataSyncer := metadata.NewSyncer(
 			logger,
 			nodeStorage.Shares(),
 			nodeStorage.ValidatorStore().WithOperatorID(operatorDataStore.GetOperatorID),
 			networkConfig.Beacon,
 			consensusClient,
-			p2pNetwork.FixedSubnets(),
+			fixedSubnets,
 			metadata.WithSyncInterval(cfg.SSVOptions.ValidatorOptions.MetadataUpdateInterval),
 		)
 		cfg.SSVOptions.ValidatorOptions.ValidatorSyncer = metadataSyncer

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -338,7 +338,7 @@ var StartNodeCmd = &cobra.Command{
 		if cfg.SSVOptions.ValidatorOptions.Exporter {
 			fixedSubnets, err = records.Subnets{}.FromString(records.AllSubnets)
 			if err != nil {
-				logger.Fatal("failed to parse fixed subnets", zap.Error(err))
+				logger.Fatal("failed to parse all fixed subnets", zap.Error(err))
 			}
 		}
 


### PR DESCRIPTION
### Description

We added a separate metadata syncer component in #1712 , We copied over the logic for `FixedSubnets`, but we called p2p to get it, but since `p2p` we only setup later, the value was empty.

### Solution

This PR parses the fixed subnets separately for the syncer, and sets it to all subnets for an Exporter.