### PR TITLE
fix: double eventsyncer stalenessThreshold

### DIFF
--- a/eth/eventsyncer/event_syncer.go
+++ b/eth/eventsyncer/event_syncer.go
@@ -58,7 +58,7 @@ func New(nodeStorage nodestorage.Storage, executionClient ExecutionClient, event
 		eventHandler:    eventHandler,
 
 		logger:             zap.NewNop(),
-		stalenessThreshold: 240 * time.Second,
+		stalenessThreshold: 384 * time.Second,
 	}
 
 	for _, opt := range opts {

--- a/eth/eventsyncer/event_syncer.go
+++ b/eth/eventsyncer/event_syncer.go
@@ -58,7 +58,7 @@ func New(nodeStorage nodestorage.Storage, executionClient ExecutionClient, event
 		eventHandler:    eventHandler,
 
 		logger:             zap.NewNop(),
-		stalenessThreshold: 300 * time.Second,
+		stalenessThreshold: 240 * time.Second,
 	}
 
 	for _, opt := range opts {

--- a/eth/eventsyncer/event_syncer.go
+++ b/eth/eventsyncer/event_syncer.go
@@ -22,6 +22,10 @@ import (
 // TODO: check if something from these PRs need to be ported:
 // https://github.com/ssvlabs/ssv/pull/1053
 
+const (
+	defaultStalenessThreshold = 300 * time.Second
+)
+
 var (
 	// ErrNodeNotReady is returned when node is not ready.
 	ErrNodeNotReady = fmt.Errorf("node not ready")
@@ -58,7 +62,7 @@ func New(nodeStorage nodestorage.Storage, executionClient ExecutionClient, event
 		eventHandler:    eventHandler,
 
 		logger:             zap.NewNop(),
-		stalenessThreshold: 300 * time.Second,
+		stalenessThreshold: defaultStalenessThreshold,
 	}
 
 	for _, opt := range opts {

--- a/eth/eventsyncer/event_syncer.go
+++ b/eth/eventsyncer/event_syncer.go
@@ -58,7 +58,7 @@ func New(nodeStorage nodestorage.Storage, executionClient ExecutionClient, event
 		eventHandler:    eventHandler,
 
 		logger:             zap.NewNop(),
-		stalenessThreshold: 384 * time.Second,
+		stalenessThreshold: 300 * time.Second,
 	}
 
 	for _, opt := range opts {

--- a/eth/eventsyncer/event_syncer.go
+++ b/eth/eventsyncer/event_syncer.go
@@ -58,7 +58,7 @@ func New(nodeStorage nodestorage.Storage, executionClient ExecutionClient, event
 		eventHandler:    eventHandler,
 
 		logger:             zap.NewNop(),
-		stalenessThreshold: 150 * time.Second,
+		stalenessThreshold: 300 * time.Second,
 	}
 
 	for _, opt := range opts {

--- a/eth/eventsyncer/event_syncer_test.go
+++ b/eth/eventsyncer/event_syncer_test.go
@@ -256,14 +256,14 @@ func TestBlockBelowThreshold(t *testing.T) {
 	})
 
 	t.Run("fails if outside threshold", func(t *testing.T) {
-		header := &ethtypes.Header{Time: uint64(time.Now().Add(-(defaultStalenessThreshold + 1*time.Second)).Unix())}
+		header := &ethtypes.Header{Time: uint64(time.Now().Add(-(defaultStalenessThreshold + time.Second)).Unix())}
 		m.EXPECT().HeaderByNumber(ctx, big.NewInt(1)).Return(header, nil)
 		err := s.blockBelowThreshold(ctx, big.NewInt(1))
 		require.Error(t, err)
 	})
 
 	t.Run("success", func(t *testing.T) {
-		header := &ethtypes.Header{Time: uint64(time.Now().Add(-(defaultStalenessThreshold - 1*time.Second)).Unix())}
+		header := &ethtypes.Header{Time: uint64(time.Now().Add(-(defaultStalenessThreshold - time.Second)).Unix())}
 		m.EXPECT().HeaderByNumber(ctx, big.NewInt(1)).Return(header, nil)
 		err := s.blockBelowThreshold(ctx, big.NewInt(1))
 		require.NoError(t, err)

--- a/eth/eventsyncer/event_syncer_test.go
+++ b/eth/eventsyncer/event_syncer_test.go
@@ -255,15 +255,15 @@ func TestBlockBelowThreshold(t *testing.T) {
 		require.ErrorIs(t, err, err1)
 	})
 
-	t.Run("fails if outside threashold", func(t *testing.T) {
-		header := &ethtypes.Header{Time: uint64(time.Now().Add(-151 * time.Second).Unix())}
+	t.Run("fails if outside threshold", func(t *testing.T) {
+		header := &ethtypes.Header{Time: uint64(time.Now().Add(-(defaultStalenessThreshold + 1*time.Second)).Unix())}
 		m.EXPECT().HeaderByNumber(ctx, big.NewInt(1)).Return(header, nil)
 		err := s.blockBelowThreshold(ctx, big.NewInt(1))
 		require.Error(t, err)
 	})
 
 	t.Run("success", func(t *testing.T) {
-		header := &ethtypes.Header{Time: uint64(time.Now().Add(-149 * time.Second).Unix())}
+		header := &ethtypes.Header{Time: uint64(time.Now().Add(-(defaultStalenessThreshold - 1*time.Second)).Unix())}
 		m.EXPECT().HeaderByNumber(ctx, big.NewInt(1)).Return(header, nil)
 		err := s.blockBelowThreshold(ctx, big.NewInt(1))
 		require.NoError(t, err)


### PR DESCRIPTION
This PR doubles the stalenessThreshold to prevent crashing when there are too many missed blocks in the network (such as recently witnessed on Holesky).