### PR TITLE
fix(GoClient) - fix race condition

### DIFF
--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -322,6 +322,7 @@ func (gc *GoClient) singleClientHooks() *eth2clienthttp.Hooks {
 				)
 				return
 			}
+			gc.ForkLock.RLock()
 			gc.log.Info("retrieved fork epochs",
 				zap.String("node_addr", s.Address()),
 				zap.Uint64("current_data_version", uint64(gc.DataVersion(gc.network.EstimatedCurrentEpoch()))),
@@ -331,6 +332,7 @@ func (gc *GoClient) singleClientHooks() *eth2clienthttp.Hooks {
 				zap.Uint64("deneb", uint64(gc.ForkEpochDeneb)),
 				zap.Uint64("electra", uint64(gc.ForkEpochElectra)),
 			)
+			gc.ForkLock.RUnlock()
 		},
 		OnInactive: func(ctx context.Context, s *eth2clienthttp.Service) {
 			gc.log.Warn("consensus client disconnected",


### PR DESCRIPTION
The race condition was caught by the [test from the feature branch](https://github.com/ssvlabs/ssv/actions/runs/13518370221/job/37776658631?pr=2018#step:5:22). That particular test instantiates GoClient with multiple Beacon Servers. This issue occurs when there are two or more Beacon Servers used by the GoClient