### PR TITLE
beacon-client: fix concurrency issues in tests

### DIFF
--- a/beacon/goclient/events_test.go
+++ b/beacon/goclient/events_test.go
@@ -21,7 +21,7 @@ func TestSubscribeToHeadEvents(t *testing.T) {
 	t.Run("Should launch event listener when go client is instantiated", func(t *testing.T) {
 		eventsEndpointSubscribedCh := make(chan any)
 
-		server := tests.MockServer(t, func(r *http.Request, resp json.RawMessage) (json.RawMessage, error) {
+		server := tests.MockServer(func(r *http.Request, resp json.RawMessage) (json.RawMessage, error) {
 			if strings.Contains(r.URL.Path, "/eth/v1/events") {
 				eventsEndpointSubscribedCh <- struct{}{}
 			}
@@ -44,7 +44,7 @@ func TestSubscribeToHeadEvents(t *testing.T) {
 	})
 
 	t.Run("Should create subscriber", func(t *testing.T) {
-		server := tests.MockServer(t, nil)
+		server := tests.MockServer(nil)
 		client := eventsTestClient(t, server.URL)
 		defer server.Close()
 
@@ -58,7 +58,7 @@ func TestSubscribeToHeadEvents(t *testing.T) {
 	})
 
 	t.Run("Should not create subscriber and return error when supported topics does not contain HeadEventTopic", func(t *testing.T) {
-		server := tests.MockServer(t, nil)
+		server := tests.MockServer(nil)
 		client := eventsTestClient(t, server.URL)
 		client.supportedTopics = []EventTopic{}
 		defer server.Close()

--- a/beacon/goclient/goclient_test.go
+++ b/beacon/goclient/goclient_test.go
@@ -26,7 +26,7 @@ func TestHealthy(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	undialableServer := tests.MockServer(t, nil)
+	undialableServer := tests.MockServer(nil)
 	c, err := mockClient(ctx, undialableServer.URL, commonTimeout, longTimeout)
 	require.NoError(t, err)
 
@@ -79,7 +79,7 @@ func TestTimeouts(t *testing.T) {
 
 	// Too slow to dial.
 	{
-		undialableServer := tests.MockServer(t, func(r *http.Request, resp json.RawMessage) (json.RawMessage, error) {
+		undialableServer := tests.MockServer(func(r *http.Request, resp json.RawMessage) (json.RawMessage, error) {
 			time.Sleep(commonTimeout * 2)
 			return resp, nil
 		})
@@ -89,7 +89,7 @@ func TestTimeouts(t *testing.T) {
 
 	// Too slow to respond to the Validators request.
 	{
-		unresponsiveServer := tests.MockServer(t, func(r *http.Request, resp json.RawMessage) (json.RawMessage, error) {
+		unresponsiveServer := tests.MockServer(func(r *http.Request, resp json.RawMessage) (json.RawMessage, error) {
 			switch r.URL.Path {
 			case "/eth/v2/debug/beacon/states/head":
 				time.Sleep(longTimeout / 2)
@@ -119,7 +119,7 @@ func TestTimeouts(t *testing.T) {
 
 	// Too slow to respond to proposer duties request.
 	{
-		unresponsiveServer := tests.MockServer(t, func(r *http.Request, resp json.RawMessage) (json.RawMessage, error) {
+		unresponsiveServer := tests.MockServer(func(r *http.Request, resp json.RawMessage) (json.RawMessage, error) {
 			switch r.URL.Path {
 			case "/eth/v1/validator/duties/proposer/" + fmt.Sprint(mockServerEpoch):
 				time.Sleep(longTimeout * 2)
@@ -135,7 +135,7 @@ func TestTimeouts(t *testing.T) {
 
 	// Fast enough.
 	{
-		fastServer := tests.MockServer(t, func(r *http.Request, resp json.RawMessage) (json.RawMessage, error) {
+		fastServer := tests.MockServer(func(r *http.Request, resp json.RawMessage) (json.RawMessage, error) {
 			time.Sleep(commonTimeout / 2)
 			switch r.URL.Path {
 			case "/eth/v2/debug/beacon/states/head":
@@ -175,7 +175,7 @@ func TestAssertSameGenesisVersionWhenSame(t *testing.T) {
 			return resp, nil
 		}
 
-		server := tests.MockServer(t, callback)
+		server := tests.MockServer(callback)
 		defer server.Close()
 		t.Run(fmt.Sprintf("When genesis versions are the same (%s)", string(network)), func(t *testing.T) {
 			c, err := mockClientWithNetwork(ctx, server.URL, 100*time.Millisecond, 500*time.Millisecond, network)
@@ -195,7 +195,7 @@ func TestAssertSameGenesisVersionWhenDifferent(t *testing.T) {
 
 	t.Run("When genesis versions are different", func(t *testing.T) {
 		ctx := context.Background()
-		server := tests.MockServer(t, nil)
+		server := tests.MockServer(nil)
 		defer server.Close()
 		c, err := mockClientWithNetwork(ctx, server.URL, 100*time.Millisecond, 500*time.Millisecond, network)
 		require.NoError(t, err, "failed to create client")

--- a/beacon/goclient/tests/shared.go
+++ b/beacon/goclient/tests/shared.go
@@ -2,15 +2,14 @@ package tests
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"testing"
 	"time"
 
 	"github.com/ssvlabs/ssv-spec/types"
 	"github.com/ssvlabs/ssv/operator/slotticker"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -24,34 +23,34 @@ func (m MockDataStore) AwaitOperatorID() types.OperatorID {
 
 type requestCallback = func(r *http.Request, resp json.RawMessage) (json.RawMessage, error)
 
-func MockServer(t *testing.T, onRequestFn requestCallback) *httptest.Server {
+func MockServer(onRequestFn requestCallback) *httptest.Server {
 	var mockResponses map[string]json.RawMessage
 	f, err := os.Open("./tests/mock-beacon-responses.json")
-	require.NoError(t, err)
-	require.NoError(t, json.NewDecoder(f).Decode(&mockResponses))
+	if err != nil {
+		panic(fmt.Sprintf("os.Open returned error: %v", err))
+	}
+	err = json.NewDecoder(f).Decode(&mockResponses)
+	if err != nil {
+		panic(fmt.Sprintf("couldn't decode json file: %v", err))
+	}
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Logf("mock server handling request: %s", r.URL.Path)
-
 		resp, ok := mockResponses[r.URL.Path]
 		if !ok {
-			require.FailNowf(t, "unexpected request", "unexpected request: %s", r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-			return
+			panic(fmt.Sprintf("unexpected request: %s", r.URL.Path))
 		}
 
 		var err error
 		if onRequestFn != nil {
 			resp, err = onRequestFn(r, resp)
-			require.NoError(t, err)
+			if err != nil {
+				panic(fmt.Sprintf("onRequestFn returned error: %v", err))
+			}
 		}
-
-		require.NoError(t, err)
 
 		w.Header().Set("Content-Type", "application/json")
 		if _, err := w.Write(resp); err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
+			panic(fmt.Sprintf("got error writing response: %v", err))
 		}
 	}))
 }


### PR DESCRIPTION
I've noticed there are couple of issues:
- `t *testing.T` is not meant to be used concurrently:
```go
// T is a type passed to Test functions to manage test state and support formatted test logs.
//
// A test ends when its Test function returns or calls any of the methods
// FailNow, Fatal, Fatalf, SkipNow, Skip, or Skipf. Those methods, as well as
// the Parallel method, must be called only from the goroutine running the
// Test function.
//
// The other reporting methods, such as the variations of Log and Error,
// may be called simultaneously from multiple goroutines.
type T struct {
```
- and there is also this error (see https://stackoverflow.com/questions/57828645/how-to-handle-superfluous-response-writeheader-call-in-order-to-return-500 for more details):
```
2025/02/27 10:15:16 http: superfluous response.WriteHeader call from github.com/ssvlabs/ssv/beacon/goclient.mockServer.func1 (goclient_test.go:264)
```

this PR should address both