### PR TITLE
Disable e2e CI workflow triggers

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,13 +1,10 @@
 name: E2E Test
 
 on:
-  workflow_run:
-    workflows: [Lint, Unit tests]
-    types: [completed]
-    branches: [stage, main]
-  #  pull_request:
-  #    branches:
-  #      - "**"
+  # workflow_run:
+  #   workflows: [Lint, Unit tests]
+  #   types: [completed]
+  #   branches: [stage, main]
 
   workflow_dispatch:
 


### PR DESCRIPTION
Currently, E2E tests are not functioning, leading to pipeline failures. This PR disables the pipeline triggers. Once the E2E tests are fixed, the triggers can be re-enabled.