### PR TITLE
Fix: Add a command line flag to allow signing slashable attestations for Holesky

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -94,7 +94,9 @@ type config struct {
 	SSVAPIPort                   int                              `yaml:"SSVAPIPort" env:"SSV_API_PORT" env-description:"Port to listen on for the SSV API."`
 	LocalEventsPath              string                           `yaml:"LocalEventsPath" env:"EVENTS_PATH" env-description:"path to local events"`
 	EnableDoppelgangerProtection bool                             `yaml:"EnableDoppelgangerProtection" env:"ENABLE_DOPPELGANGER_PROTECTION" env-description:"Flag to enable Doppelganger protection for validators."`
-	AllowSigningSlashable        bool                             `yaml:"AllowSigningSlashableAttestations" env:"ALLOW_SIGNING_SLASHABLE_ATTESTATIONS" env-description:"allow the node to sign slashable attestations"`
+
+	// This may be needed in cases where finality has been lost due to failure of a large portion of the network such as the Holesky Pectra fork.
+	AllowSigningSlashable bool `yaml:"AllowSigningSlashableAttestations" env:"ALLOW_SIGNING_SLASHABLE_ATTESTATIONS" env-description:"allow the node to sign slashable attestations"`
 }
 
 var cfg config

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -94,6 +94,7 @@ type config struct {
 	SSVAPIPort                   int                              `yaml:"SSVAPIPort" env:"SSV_API_PORT" env-description:"Port to listen on for the SSV API."`
 	LocalEventsPath              string                           `yaml:"LocalEventsPath" env:"EVENTS_PATH" env-description:"path to local events"`
 	EnableDoppelgangerProtection bool                             `yaml:"EnableDoppelgangerProtection" env:"ENABLE_DOPPELGANGER_PROTECTION" env-description:"Flag to enable Doppelganger protection for validators."`
+	AllowSigningSlashable        bool                             `yaml:"AllowSigningSlashableAttestations" env:"CAN_SIGN_SLASHABLE_ATTESTATIONS" env-description:"allow the node to sign slashable attestations"`
 }
 
 var cfg config
@@ -188,7 +189,14 @@ var StartNodeCmd = &cobra.Command{
 			logger.Fatal("could not get operator private key hash", zap.Error(err))
 		}
 
-		keyManager, err := ekm.NewETHKeyManagerSigner(logger, db, networkConfig, ekmHashedKey)
+		if cfg.AllowSigningSlashable {
+			logger.Warn("    --------------------- ! WARNING ! ---------------------")
+			logger.Warn("This node is configured to allow signing slashable attesations.")
+			logger.Warn("          DO NOT RUN THIS IN A PRODUCTION ENVIRONMENT")
+			logger.Warn("    --------------------- ! WARNING ! ---------------------")
+		}
+
+		keyManager, err := ekm.NewETHKeyManagerSigner(logger, db, networkConfig, ekmHashedKey, cfg.AllowSigningSlashable)
 		if err != nil {
 			logger.Fatal("could not create new eth-key-manager signer", zap.Error(err))
 		}

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -94,7 +94,7 @@ type config struct {
 	SSVAPIPort                   int                              `yaml:"SSVAPIPort" env:"SSV_API_PORT" env-description:"Port to listen on for the SSV API."`
 	LocalEventsPath              string                           `yaml:"LocalEventsPath" env:"EVENTS_PATH" env-description:"path to local events"`
 	EnableDoppelgangerProtection bool                             `yaml:"EnableDoppelgangerProtection" env:"ENABLE_DOPPELGANGER_PROTECTION" env-description:"Flag to enable Doppelganger protection for validators."`
-	AllowSigningSlashable        bool                             `yaml:"AllowSigningSlashableAttestations" env:"CAN_SIGN_SLASHABLE_ATTESTATIONS" env-description:"allow the node to sign slashable attestations"`
+	AllowSigningSlashable        bool                             `yaml:"AllowSigningSlashableAttestations" env:"ALLOW_SIGNING_SLASHABLE_ATTESTATIONS" env-description:"allow the node to sign slashable attestations"`
 }
 
 var cfg config
@@ -189,11 +189,10 @@ var StartNodeCmd = &cobra.Command{
 			logger.Fatal("could not get operator private key hash", zap.Error(err))
 		}
 
-		if cfg.AllowSigningSlashable {
-			logger.Warn("    --------------------- ! WARNING ! ---------------------")
+		if cfg.AllowSigningSlashable && networkConfig.Name == "mainnet" {
+			logger.Fatal("This node is configured to allow signing slashable attesations, however it appears to be running on mainnet.")
+		} else if cfg.AllowSigningSlashable {
 			logger.Warn("This node is configured to allow signing slashable attesations.")
-			logger.Warn("          DO NOT RUN THIS IN A PRODUCTION ENVIRONMENT")
-			logger.Warn("    --------------------- ! WARNING ! ---------------------")
 		}
 
 		keyManager, err := ekm.NewETHKeyManagerSigner(logger, db, networkConfig, ekmHashedKey, cfg.AllowSigningSlashable)

--- a/ekm/eth_key_manager_signer.go
+++ b/ekm/eth_key_manager_signer.go
@@ -244,12 +244,12 @@ func (km *ethKeyManagerSigner) signBeaconObject(obj ssz.HashRoot, domain phase0.
 }
 
 func (km *ethKeyManagerSigner) IsAttestationSlashable(pk spectypes.ShareValidatorPK, data *phase0.AttestationData) error {
+	if km.canSignSlashable {
+		return nil
+	}
 	if val, err := km.slashingProtector.IsSlashableAttestation(pk, data); err != nil || val != nil {
 		if err != nil {
 			return err
-		}
-		if km.canSignSlashable {
-			return nil
 		}
 		return errors.Errorf("slashable attestation (%s), not signing", val.Status)
 	}

--- a/ekm/signer_key_manager_test.go
+++ b/ekm/signer_key_manager_test.go
@@ -54,7 +54,7 @@ func testKeyManager(t *testing.T, network *networkconfig.NetworkConfig) KeyManag
 		}
 	}
 
-	km, err := NewETHKeyManagerSigner(logger, db, *network, "")
+	km, err := NewETHKeyManagerSigner(logger, db, *network, "", false)
 	require.NoError(t, err)
 
 	sk1 := &bls.SecretKey{}

--- a/eth/ethtest/utils_test.go
+++ b/eth/ethtest/utils_test.go
@@ -165,7 +165,7 @@ func setupEventHandler(
 	operatorDataStore := operatordatastore.New(operatorData)
 	testNetworkConfig := networkconfig.TestNetwork
 
-	keyManager, err := ekm.NewETHKeyManagerSigner(logger, db, testNetworkConfig, "")
+	keyManager, err := ekm.NewETHKeyManagerSigner(logger, db, testNetworkConfig, "", false)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -1363,7 +1363,7 @@ func setupEventHandler(t *testing.T, ctx context.Context, logger *zap.Logger, ne
 		}
 	}
 
-	keyManager, err := ekm.NewETHKeyManagerSigner(logger, db, *network, "")
+	keyManager, err := ekm.NewETHKeyManagerSigner(logger, db, *network, "", false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/eth/eventsyncer/event_syncer_test.go
+++ b/eth/eventsyncer/event_syncer_test.go
@@ -155,7 +155,7 @@ func setupEventHandler(
 	operatorDataStore := operatordatastore.New(operatorData)
 	testNetworkConfig := networkconfig.TestNetwork
 
-	keyManager, err := ekm.NewETHKeyManagerSigner(logger, db, testNetworkConfig, "")
+	keyManager, err := ekm.NewETHKeyManagerSigner(logger, db, testNetworkConfig, "", false)
 	if err != nil {
 		logger.Fatal("could not create new eth-key-manager signer", zap.Error(err))
 	}

--- a/operator/validator/controller_test.go
+++ b/operator/validator/controller_test.go
@@ -949,7 +949,7 @@ func setupCommonTestComponents(t *testing.T) (*gomock.Controller, *zap.Logger, *
 
 	db, err := getBaseStorage(logger)
 	require.NoError(t, err)
-	km, err := ekm.NewETHKeyManagerSigner(logger, db, networkconfig.TestNetwork, "")
+	km, err := ekm.NewETHKeyManagerSigner(logger, db, networkconfig.TestNetwork, "", false)
 	require.NoError(t, err)
 	return ctrl, logger, sharesStorage, network, km, recipientStorage, bc
 }


### PR DESCRIPTION
Node operators need to delete their slashing DB (on Holesky), this is currently impossible in the SSV client. This adds a config entry that can disable attestation slashing protections. It also adds a rather large warning against doing this.

See: https://github.com/ethereum/pm/issues/1337 