### PR TITLE
chore(dependabot) - change dependabot target branch to 'Stage'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,6 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    target-branch: stage
     schedule:
       interval: weekly


### PR DESCRIPTION
By default, dependabot targets `default` branch which in our case is `main`.
Following our workflow, we want dependabot to target `stage` branch instead.
Configuration [description](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#target-branch-)