### PR TITLE
fix: flaky `TestScheduler_Committee_Early_Block_Attester_Only` (#1924)

### DIFF
--- a/operator/duties/committee_test.go
+++ b/operator/duties/committee_test.go
@@ -1007,11 +1007,12 @@ func TestScheduler_Committee_Early_Block_Attester_Only(t *testing.T) {
 	// STEP 3: wait for attester duties to be executed faster than 1/3 of the slot duration
 	startTime := time.Now()
 	currentSlot.Set(phase0.Slot(2))
-	ticker.Send(currentSlot.Get())
 
 	aDuties, _ := attDuties.Get(0)
 	committeeMap := commHandler.buildCommitteeDuties(aDuties, nil, 0, currentSlot.Get())
 	setExecuteDutyFuncs(scheduler, executeDutiesCall, len(committeeMap))
+
+	ticker.Send(currentSlot.Get())
 
 	// STEP 4: trigger head event (block arrival)
 	e := &eth2apiv1.Event{
@@ -1082,10 +1083,11 @@ func TestScheduler_Committee_Early_Block(t *testing.T) {
 	// STEP 3: wait for committee duty to be executed faster than 1/3 of the slot duration
 	startTime = time.Now()
 	currentSlot.Set(phase0.Slot(2))
-	ticker.Send(currentSlot.Get())
 
 	committeeMap = commHandler.buildCommitteeDuties(nil, sDuties, 0, currentSlot.Get())
 	setExecuteDutyFuncs(scheduler, executeDutiesCall, len(committeeMap))
+
+	ticker.Send(currentSlot.Get())
 
 	// STEP 4: trigger head event (block arrival)
 	e := &eth2apiv1.Event{


### PR DESCRIPTION
fix https://github.com/ssvlabs/ssv/issues/1924

Fixes a race condition in `TestScheduler_Committee_Early_Block_Attester_Only` where `ExecuteDuty` was sometimes called before mock expectations were set. The issue was resolved by ensuring `setExecuteDutyFuncs` is executed before ticking the slot.
