### PR TITLE
fix: bump spec to v1.1.3 and add pectra block size check

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -268,6 +268,7 @@ var StartNodeCmd = &cobra.Command{
 			nodeStorage.ValidatorStore(),
 			dutyStore,
 			signatureVerifier,
+			consensusClient.ForkEpochElectra,
 			validation.WithLogger(logger),
 		)
 

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/cobra v1.8.1
 	github.com/ssvlabs/eth2-key-manager v1.5.1
-	github.com/ssvlabs/ssv-spec v0.0.0-20250219144831-3a9cb8e35c0c
+	github.com/ssvlabs/ssv-spec v1.1.3
 	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.9.0
 	github.com/wealdtech/go-eth2-types/v2 v2.8.1

--- a/go.sum
+++ b/go.sum
@@ -745,8 +745,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.0.0/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/ssvlabs/eth2-key-manager v1.5.1 h1:fijves+7CarWW8GlCuCXhLZFxOH4qv8J+NSchPBdntA=
 github.com/ssvlabs/eth2-key-manager v1.5.1/go.mod h1:yeUzAP+SBJXgeXPiGBrLeLuHIQCpeJZV7Jz3Fwzm/zk=
-github.com/ssvlabs/ssv-spec v0.0.0-20250219144831-3a9cb8e35c0c h1:3ijOHIppBuQfi8S43R3IZv9xcfy8KhFjel9gOAIOlT8=
-github.com/ssvlabs/ssv-spec v0.0.0-20250219144831-3a9cb8e35c0c/go.mod h1:pto7dDv99uVfCZidiLrrKgFR6VYy6WY3PGI1TiGCsIU=
+github.com/ssvlabs/ssv-spec v1.1.3 h1:46K31kI4/vA7Vp3DaOuN7t2IABAmzeiMniCqYfzzpo8=
+github.com/ssvlabs/ssv-spec v1.1.3/go.mod h1:pto7dDv99uVfCZidiLrrKgFR6VYy6WY3PGI1TiGCsIU=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -52,16 +52,21 @@ const (
 )
 
 const (
-	msgTypeSize       = 8 // uint64
-	maxSignaturesSize = maxSignatures * rsaSignatureSize
-	maxOperatorIDSize = maxSignatures * operatorIDSize
-	maxFullDataSize   = 5243144 // from spectypes.SignedSSVMessage
+	msgTypeSize           = 8 // uint64
+	maxSignaturesSize     = maxSignatures * rsaSignatureSize
+	maxOperatorIDSize     = maxSignatures * operatorIDSize
+	maxFullDataSize       = 5243144 // from old spectypes.SignedSSVMessage 4194532
+	pectraMaxFullDataSize = 8388836 // from spectypes.SignedSSVMessage
 )
 
 const (
-	maxPayloadDataSize = max(maxEncodedConsensusMsgSize, maxEncodedPartialSignatureSize)
-	maxSignedMsgSize   = maxSignaturesSize + maxOperatorIDSize + msgTypeSize + identifierSize + maxPayloadDataSize + maxFullDataSize
+	maxPayloadDataSize     = max(maxEncodedConsensusMsgSize, maxEncodedPartialSignatureSize)
+	maxSignedMsgSize       = maxSignaturesSize + maxOperatorIDSize + msgTypeSize + identifierSize + maxPayloadDataSize + maxFullDataSize
+	pectraMaxSignedMsgSize = maxSignaturesSize + maxOperatorIDSize + msgTypeSize + identifierSize + maxPayloadDataSize + pectraMaxFullDataSize
 )
 
 // MaxEncodedMsgSize defines max pubsub message size
 const MaxEncodedMsgSize = maxSignedMsgSize + maxSignedMsgSize/encodingOverheadDivisor + 4
+
+// PecraMaxEncodedMsgSize defines max pubsub message size for pectra
+const PecraMaxEncodedMsgSize = pectraMaxSignedMsgSize + pectraMaxSignedMsgSize/encodingOverheadDivisor + 4

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -55,7 +55,7 @@ const (
 	msgTypeSize           = 8 // uint64
 	maxSignaturesSize     = maxSignatures * rsaSignatureSize
 	maxOperatorIDSize     = maxSignatures * operatorIDSize
-	maxFullDataSize       = 5243144 // from old spectypes.SignedSSVMessage 4194532
+	maxFullDataSize       = 5243144 // from old spectypes.SignedSSVMessage
 	pectraMaxFullDataSize = 8388836 // from spectypes.SignedSSVMessage
 )
 

--- a/message/validation/const.go
+++ b/message/validation/const.go
@@ -60,13 +60,14 @@ const (
 )
 
 const (
-	maxPayloadDataSize     = max(maxEncodedConsensusMsgSize, maxEncodedPartialSignatureSize)
-	maxSignedMsgSize       = maxSignaturesSize + maxOperatorIDSize + msgTypeSize + identifierSize + maxPayloadDataSize + maxFullDataSize
-	pectraMaxSignedMsgSize = maxSignaturesSize + maxOperatorIDSize + msgTypeSize + identifierSize + maxPayloadDataSize + pectraMaxFullDataSize
+	maxPayloadDataSize           = max(maxEncodedConsensusMsgSize, maxEncodedPartialSignatureSize)
+	maxSignedMsgSizeBeforePectra = maxSignaturesSize + maxOperatorIDSize + msgTypeSize + identifierSize + maxPayloadDataSize + maxFullDataSize
+	maxSignedMsgSize             = maxSignaturesSize + maxOperatorIDSize + msgTypeSize + identifierSize + maxPayloadDataSize + pectraMaxFullDataSize
 )
 
-// MaxEncodedMsgSize defines max pubsub message size
-const MaxEncodedMsgSize = maxSignedMsgSize + maxSignedMsgSize/encodingOverheadDivisor + 4
+// TODO: Remove this after pectra fork
+// MaxEncodedMsgSizeBeforePectra defines max pubsub message size
+const MaxEncodedMsgSizeBeforePectra = maxSignedMsgSizeBeforePectra + maxSignedMsgSizeBeforePectra/encodingOverheadDivisor + 4
 
-// PecraMaxEncodedMsgSize defines max pubsub message size for pectra
-const PecraMaxEncodedMsgSize = pectraMaxSignedMsgSize + pectraMaxSignedMsgSize/encodingOverheadDivisor + 4
+// MaxEncodedMsgSize defines max pubsub message size for pectra
+const MaxEncodedMsgSize = maxSignedMsgSize + maxSignedMsgSize/encodingOverheadDivisor + 4

--- a/message/validation/pubsub_validation.go
+++ b/message/validation/pubsub_validation.go
@@ -10,8 +10,14 @@ func (mv *messageValidator) validatePubSubMessage(pMsg *pubsub.Message) error {
 		return ErrPubSubMessageHasNoData
 	}
 
+	maxMsgSize := MaxEncodedMsgSize
+
+	if mv.netCfg.Beacon.EstimatedCurrentEpoch() >= mv.pectraForkEpoch {
+		maxMsgSize = PecraMaxEncodedMsgSize
+	}
+
 	// Rule: Pubsub.Message.Message.Data size upper limit
-	if len(pMsg.GetData()) > MaxEncodedMsgSize {
+	if len(pMsg.GetData()) > maxMsgSize {
 		e := ErrPubSubDataTooBig
 		e.got = len(pMsg.GetData())
 		return e

--- a/message/validation/pubsub_validation.go
+++ b/message/validation/pubsub_validation.go
@@ -10,10 +10,10 @@ func (mv *messageValidator) validatePubSubMessage(pMsg *pubsub.Message) error {
 		return ErrPubSubMessageHasNoData
 	}
 
-	maxMsgSize := MaxEncodedMsgSize
+	maxMsgSize := MaxEncodedMsgSizeBeforePectra
 
 	if mv.netCfg.Beacon.EstimatedCurrentEpoch() >= mv.pectraForkEpoch {
-		maxMsgSize = PecraMaxEncodedMsgSize
+		maxMsgSize = MaxEncodedMsgSize
 	}
 
 	// Rule: Pubsub.Message.Message.Data size upper limit

--- a/message/validation/validation.go
+++ b/message/validation/validation.go
@@ -38,6 +38,7 @@ type messageValidator struct {
 	validatorStore        storage.ValidatorStore
 	dutyStore             *dutystore.Store
 	signatureVerifier     signatureverifier.SignatureVerifier // TODO: use spectypes.SignatureVerifier
+	pectraForkEpoch       phase0.Epoch
 
 	// validationLocks is a map of lock per SSV message ID to
 	// prevent concurrent access to the same state.
@@ -54,6 +55,7 @@ func New(
 	validatorStore storage.ValidatorStore,
 	dutyStore *dutystore.Store,
 	signatureVerifier signatureverifier.SignatureVerifier,
+	pectraForkEpoch phase0.Epoch,
 	opts ...Option,
 ) MessageValidator {
 	mv := &messageValidator{
@@ -64,6 +66,7 @@ func New(
 		validatorStore:      validatorStore,
 		dutyStore:           dutyStore,
 		signatureVerifier:   signatureVerifier,
+		pectraForkEpoch:     pectraForkEpoch,
 	}
 
 	for _, opt := range opts {

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -233,7 +233,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
 		topic := commons.GetTopicFullName(commons.CommitteeTopicID(committeeID)[0])
-		msgSize := maxSignedMsgSize*2 + MessageOffset
+		msgSize := maxSignedMsgSizeBeforePectra*2 + MessageOffset
 
 		pmsg := &pubsub.Message{
 			Message: &pspb.Message{

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -123,7 +123,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Message validation happy flow, messages are not ignored or rejected and there are no errors
 	t.Run("happy flow", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
@@ -136,7 +136,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Make sure messages are incremented and throw an ignore message if more than 1 for a commit
 	t.Run("message counts", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		height := specqbft.Height(slot)
@@ -214,7 +214,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send a pubsub message with no data should cause an error
 	t.Run("pubsub message has no data", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -228,7 +228,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send a pubsub message where there is too much data should cause an error
 	t.Run("pubsub data too big", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -253,7 +253,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send a malformed pubsub message (empty message) should return an error
 	t.Run("empty pubsub message", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -274,7 +274,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send a message with incorrect data (unable to decode incorrect message type)
 	t.Run("bad data format", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -290,7 +290,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send a message with no data should return an error
 	t.Run("no data", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -309,7 +309,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send a message where there is too much data should cause an error
 	t.Run("data too big", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -330,7 +330,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send exact allowed data size amount but with invalid data (fails to decode)
 	t.Run("data size borderline / malformed message", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -346,7 +346,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send an invalid SSV message type returns an error
 	t.Run("invalid SSV message type", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -360,7 +360,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Generate random validator and validate it is unknown to the network
 	t.Run("unknown validator", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -382,7 +382,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Generate random committee ID and validate it is unknown to the network
 	t.Run("unknown committee ID", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -399,7 +399,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Make sure messages are dropped if on the incorrect network
 	t.Run("wrong domain", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -419,7 +419,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send message with a value that refers to a non-existent role
 	t.Run("invalid role", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -434,7 +434,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Perform validator registration or voluntary exit with a consensus type message will give an error
 	t.Run("unexpected consensus message", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -458,7 +458,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Ignore messages related to a validator that is liquidated
 	t.Run("liquidated validator", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -474,7 +474,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Ignore messages related to a validator with unknown state
 	t.Run("unknown state validator", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -490,7 +490,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Ignore messages related to a validator that in pending queued state
 	t.Run("pending queued state validator", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -508,7 +508,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 	// Don't ignore messages related to a validator that in pending queued state (in case metadata is not updated),
 	// but it is active (activation epoch <= current epoch)
 	t.Run("active validator with pending queued state", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.EstimatedCurrentSlot()
 
@@ -536,7 +536,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Unable to process a message with a validator that is not on the network
 	t.Run("no share metadata", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -551,7 +551,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive error if more than 2 attestation duties in an epoch
 	t.Run("too many duties", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		epoch := phase0.Epoch(1)
 		slot := netCfg.Beacon.FirstSlotAtEpoch(epoch)
@@ -606,7 +606,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		ds.Proposer.Set(epoch, []dutystore.StoreDuty[eth2apiv1.ProposerDuty]{
 			{Slot: slot, ValidatorIndex: shares.active.ValidatorIndex + 1, Duty: &eth2apiv1.ProposerDuty{}, InCommittee: true},
 		})
-		validator := New(netCfg, validatorStore, ds, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, ds, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		identifier := spectypes.NewMsgID(netCfg.DomainType, ks.ValidatorPK.Serialize(), spectypes.RoleProposer)
 		signedSSVMessage := generateSignedMessage(ks, identifier, slot)
@@ -619,7 +619,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		ds.Proposer.Set(epoch, []dutystore.StoreDuty[eth2apiv1.ProposerDuty]{
 			{Slot: slot, ValidatorIndex: shares.active.ValidatorIndex, Duty: &eth2apiv1.ProposerDuty{}, InCommittee: true},
 		})
-		validator = New(netCfg, validatorStore, ds, signatureVerifier).(*messageValidator)
+		validator = New(netCfg, validatorStore, ds, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 		_, err = validator.handleSignedSSVMessage(signedSSVMessage, topicID, netCfg.Beacon.GetSlotStartTime(slot))
 		require.NoError(t, err)
 	})
@@ -635,7 +635,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		ds := dutystore.New()
 
-		validator := New(mockNetworkConfig, validatorStore, ds, signatureVerifier).(*messageValidator)
+		validator := New(mockNetworkConfig, validatorStore, ds, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		messages := generateRandaoMsg(ks.Shares[1], 1, epoch, currentSlot.GetSlot())
 		encodedMessages, err := messages.Encode()
@@ -671,7 +671,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		ds := dutystore.New()
 		ds.Proposer.Set(epoch, make([]dutystore.StoreDuty[eth2apiv1.ProposerDuty], 0))
 
-		validator := New(mockNetworkConfig, validatorStore, ds, signatureVerifier).(*messageValidator)
+		validator := New(mockNetworkConfig, validatorStore, ds, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		messages := generateRandaoMsg(ks.Shares[1], 1, epoch, currentSlot.GetSlot())
 		encodedMessages, err := messages.Encode()
@@ -709,7 +709,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Get error when receiving message from operator who is not affiliated with the validator
 	t.Run("signer ID not in committee", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.EstimatedCurrentSlot()
 
@@ -735,7 +735,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Get error when receiving message from operator who is non-existent (operator id 0)
 	t.Run("partial zero signer ID", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -750,7 +750,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Get error when receiving partial signature message from operator who is the incorrect signer
 	t.Run("partial inconsistent signer ID", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -770,7 +770,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive error when "partialSignatureMessages" does not contain any "partialSignatureMessage"
 	t.Run("no partial signature messages", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -788,7 +788,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive error when the partial RSA signature message is not enough bytes
 	t.Run("partial wrong RSA signature size", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -828,7 +828,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 						})
 						ds.VoluntaryExit.AddDuty(spectestingutils.TestingDutySlot, phase0.BLSPubKey(shares.active.ValidatorPubKey))
 
-						validator := New(netCfg, validatorStore, ds, signatureVerifier).(*messageValidator)
+						validator := New(netCfg, validatorStore, ds, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 						messages := spectestingutils.PostConsensusAggregatorMsg(ks.Shares[1], 1, spec.DataVersionPhase0)
 						messages.Type = msgType
@@ -861,7 +861,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 		// Get error when receiving a message with an incorrect message type
 		t.Run("invalid message type", func(t *testing.T) {
-			validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+			validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 			messages := spectestingutils.PostConsensusAggregatorMsg(ks.Shares[1], 1, spec.DataVersionPhase0)
 			messages.Type = math.MaxUint64
@@ -907,7 +907,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 							{ValidatorIndex: shares.active.ValidatorIndex, Duty: &eth2apiv1.SyncCommitteeDuty{}, InCommittee: true},
 						})
 
-						validator := New(netCfg, validatorStore, ds, signatureVerifier).(*messageValidator)
+						validator := New(netCfg, validatorStore, ds, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 						messages := spectestingutils.PostConsensusAggregatorMsg(ks.Shares[1], 1, spec.DataVersionPhase0)
 						messages.Type = msgType
@@ -940,7 +940,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Get error when receiving QBFT message with an invalid type
 	t.Run("invalid QBFT message type", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
@@ -956,7 +956,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Get error when receiving an incorrect signature size (too small)
 	t.Run("wrong signature size", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
@@ -970,7 +970,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Get error when receiving a message with an empty list of signers
 	t.Run("no signers", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
@@ -985,7 +985,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 	// Get error when receiving a message with more signers than committee size.
 	// It tests ErrMoreSignersThanCommitteeSize from knowledge base.
 	t.Run("more signers than committee size", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
@@ -1006,7 +1006,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Get error when receiving a consensus message with zero signer
 	t.Run("consensus zero signer", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
@@ -1020,7 +1020,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Get error when receiving a message with duplicated signers
 	t.Run("non unique signer", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		signedSSVMessage := generateMultiSignedMessage(ks, committeeIdentifier, slot)
@@ -1034,7 +1034,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Get error when receiving a message with non-sorted signers
 	t.Run("signers not sorted", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		signedSSVMessage := generateMultiSignedMessage(ks, committeeIdentifier, slot)
@@ -1048,7 +1048,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Get error when receiving message with different amount of signers and signatures
 	t.Run("wrong signers/signatures length", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		signedSSVMessage := generateMultiSignedMessage(ks, committeeIdentifier, slot)
@@ -1063,7 +1063,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Get error when receiving message from less than quorum size amount of signers
 	t.Run("decided too few signers", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		signedSSVMessage := generateMultiSignedMessage(ks, committeeIdentifier, slot)
@@ -1079,7 +1079,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Get error when receiving a non decided message with multiple signers
 	t.Run("non decided with multiple signers", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		signedSSVMessage := generateMultiSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
@@ -1108,7 +1108,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 			{ValidatorIndex: shares.active.ValidatorIndex, Duty: &eth2apiv1.SyncCommitteeDuty{}, InCommittee: true},
 		})
 
-		validator := New(netCfg, validatorStore, ds, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, ds, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		tests := map[spectypes.RunnerRole]time.Time{
 			spectypes.RoleCommittee:                 netCfg.Beacon.GetSlotStartTime(slot + 35),
@@ -1137,7 +1137,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send early message for all roles before the duty start and receive early message error
 	t.Run("early message", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
@@ -1151,7 +1151,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send message from non-leader acting as a leader should receive an error
 	t.Run("not a leader", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot)
@@ -1165,7 +1165,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send wrong size of data (8 bytes) for a prepare justification message should receive an error
 	t.Run("malformed prepare justification", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 		signedSSVMessage := generateSignedMessage(ks, committeeIdentifier, slot, func(message *specqbft.Message) {
@@ -1182,7 +1182,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send prepare justification message without a proposal message should receive an error
 	t.Run("non-proposal with prepare justification", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1205,7 +1205,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send round change justification message without a proposal message should receive an error
 	t.Run("non-proposal with round change justification", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1228,7 +1228,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send round change justification message with a malformed message (1 byte) should receive an error
 	t.Run("malformed round change justification", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1246,7 +1246,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send message root hash that doesn't match the expected root hash should receive an error
 	t.Run("wrong root hash", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1263,7 +1263,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive proposal from same operator twice with different messages (same round) should receive an error
 	t.Run("double proposal with different data", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1288,7 +1288,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive prepare from same operator twice with different messages (same round) should receive an error
 	t.Run("double prepare", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1311,7 +1311,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive commit from same operator twice with different messages (same round) should receive an error
 	t.Run("double commit", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1333,7 +1333,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive round change from same operator twice with different messages (same round) should receive an error
 	t.Run("double round change", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1355,7 +1355,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Decided with same signers should receive an error
 	t.Run("decided with same signers", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1376,7 +1376,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send message with a slot lower than in the previous message
 	t.Run("slot already advanced", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1399,7 +1399,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Send message with a round lower than in the previous message
 	t.Run("round already advanced", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1433,7 +1433,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 			{ValidatorIndex: shares.active.ValidatorIndex, Duty: &eth2apiv1.SyncCommitteeDuty{}, InCommittee: true},
 		})
 
-		validator := New(netCfg, validatorStore, ds, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, ds, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		tests := map[spectypes.RunnerRole]specqbft.Round{
 			spectypes.RoleCommittee:                 13,
@@ -1478,7 +1478,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive an event message from an operator that is not myself should receive an error
 	t.Run("event message", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1494,7 +1494,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive a unknown message type from an operator that is not myself should receive an error
 	t.Run("unknown type message", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1511,7 +1511,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive a message with a wrong signature
 	t.Run("wrong signature", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, wrongSignatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, wrongSignatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1526,7 +1526,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive a message with an incorrect topic
 	t.Run("incorrect topic", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1541,7 +1541,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive nil signed ssv message
 	t.Run("nil signed ssv message", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1553,7 +1553,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive nil ssv message
 	t.Run("nil ssv message", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1568,7 +1568,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive zero round
 	t.Run("zero round", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1584,7 +1584,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive a message with no signatures
 	t.Run("no signatures", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1599,7 +1599,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive a message with mismatched identifier
 	t.Run("mismatched identifier", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1617,7 +1617,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive a prepare/commit message with FullData
 	t.Run("prepare/commit with FullData", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1639,7 +1639,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive a non-consensus message with FullData
 	t.Run("non-consensus with FullData", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1656,7 +1656,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive a partial signature message with multiple signers
 	t.Run("partial signature with multiple signers", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1674,7 +1674,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive a partial signature message with too many signers
 	t.Run("partial signature with too many messages", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1702,7 +1702,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive a partial signature message with triple validator index
 	t.Run("partial signature with triple validator index", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 
@@ -1730,7 +1730,7 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 	// Receive a partial signature message with validator index mismatch
 	t.Run("partial signature with validator index mismatch", func(t *testing.T) {
-		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier).(*messageValidator)
+		validator := New(netCfg, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0)).(*messageValidator)
 
 		slot := netCfg.Beacon.FirstSlotAtEpoch(1)
 

--- a/network/p2p/test_utils.go
+++ b/network/p2p/test_utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -184,6 +185,7 @@ func (ln *LocalNet) NewTestP2pNetwork(ctx context.Context, nodeIndex uint64, key
 		nodeStorage.ValidatorStore(),
 		dutyStore,
 		signatureVerifier,
+		phase0.Epoch(0),
 	)
 	cfg.Network = networkconfig.TestNetwork
 	if options.TotalValidators > 0 {
@@ -209,6 +211,7 @@ func (ln *LocalNet) NewTestP2pNetwork(ctx context.Context, nodeIndex uint64, key
 			nodeStorage.ValidatorStore(),
 			dutyStore,
 			signatureVerifier,
+			phase0.Epoch(0),
 			validation.WithSelfAccept(selfPeerID, true),
 		)
 	}

--- a/network/topics/controller_test.go
+++ b/network/topics/controller_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/libp2p/go-libp2p"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -82,7 +83,7 @@ func TestTopicManager(t *testing.T) {
 		validatorStore := mocks.NewMockValidatorStore(ctrl)
 		signatureVerifier := signatureverifier.NewMockSignatureVerifier(ctrl)
 
-		validator := validation.New(networkconfig.TestNetwork, validatorStore, dutyStore, signatureVerifier)
+		validator := validation.New(networkconfig.TestNetwork, validatorStore, dutyStore, signatureVerifier, phase0.Epoch(0))
 
 		scoreMap := map[peer.ID]*pubsub.PeerScoreSnapshot{}
 		var scoreMapMu sync.Mutex

--- a/network/topics/msg_validator_test.go
+++ b/network/topics/msg_validator_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	v1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	ps_pb "github.com/libp2p/go-libp2p-pubsub/pb"
@@ -48,7 +49,7 @@ func TestMsgValidator(t *testing.T) {
 	committeeID := share.CommitteeID()
 
 	signatureVerifier := signatureverifier.NewSignatureVerifier(ns)
-	mv := validation.New(networkconfig.TestNetwork, ns.ValidatorStore(), dutystore.New(), signatureVerifier)
+	mv := validation.New(networkconfig.TestNetwork, ns.ValidatorStore(), dutystore.New(), signatureVerifier, phase0.Epoch(0), validation.WithLogger(logger))
 	require.NotNil(t, mv)
 
 	slot := networkconfig.TestNetwork.Beacon.GetBeaconNetwork().EstimatedCurrentSlot()


### PR DESCRIPTION
### Description 

In this PR we use the new spec version which include new sizes for block SSZ encoding which accounts for new blob sizes and exec payloads in pectra. It also addresses a possible attack vector by not accepting big messages in validation before pectra fork epoch.