### PR TITLE
chore(discovery): double discovery interval

### DIFF
--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/ssvlabs/ssv/utils/ttl"
 	"net"
 	"time"
+
+	"github.com/ssvlabs/ssv/utils/ttl"
 
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -23,7 +24,7 @@ import (
 )
 
 const (
-	defaultDiscoveryInterval = time.Millisecond * 1
+	defaultDiscoveryInterval = time.Millisecond * 2
 	publishENRTimeout        = time.Minute
 )
 


### PR DESCRIPTION
We've received complaints about discovery traffic from bootnode operators. This should reduce it by a bit.