### PR TITLE
hoodi: feature(goclient/attest:go): log client_addr for simple get attestation

### DIFF
--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -3,9 +3,10 @@ package goclient
 import (
 	"context"
 	"fmt"
-	"github.com/ssvlabs/ssv/logging/fields"
 	"net/http"
 	"time"
+
+	"github.com/ssvlabs/ssv/logging/fields"
 
 	"github.com/attestantio/go-eth2-client/api"
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
@@ -87,8 +88,8 @@ func (gc *GoClient) GetAttestationData(slot phase0.Slot) (
 		gc.log.Debug("successfully fetched attestation data",
 			fields.Slot(resp.Data.Slot),
 			zap.Duration("elapsed", time.Since(attDataReqStart)),
-			zap.String("client_addr", gc.multiClient.Address()))
-
+			zap.String("client_addr", gc.multiClient.Address()),
+			fields.BlockRoot(resp.Data.BeaconBlockRoot))
 		// Caching resulting value here (as part of inflight request) guarantees only 1 request
 		// will ever be done for a given slot.
 		gc.attestationDataCache.Set(slot, resp.Data, ttlcache.DefaultTTL)

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -3,6 +3,7 @@ package goclient
 import (
 	"context"
 	"fmt"
+	"github.com/ssvlabs/ssv/logging/fields"
 	"net/http"
 	"time"
 
@@ -82,6 +83,11 @@ func (gc *GoClient) GetAttestationData(slot phase0.Slot) (
 			)
 			return nil, fmt.Errorf("attestation data is nil")
 		}
+
+		gc.log.Debug("successfully fetched attestation data",
+			fields.Slot(resp.Data.Slot),
+			zap.Duration("elapsed", time.Since(attDataReqStart)),
+			zap.String("client_addr", gc.multiClient.Address()))
 
 		// Caching resulting value here (as part of inflight request) guarantees only 1 request
 		// will ever be done for a given slot.


### PR DESCRIPTION
### Description

Exposes which client was used to get attestation data for which slot. This helps when trying to figure out which client performed badly or returned stale block roots, especially when using multiclient.

*NOTE*: this is a pr for hoodi-stable which is based on a different version of attest.go (without weighted attestations #2018)