### PR TITLE
fix: (committee.go) log correct total consensus time

### DIFF
--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -518,7 +518,7 @@ func (cr *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 			fields.Round(cr.BaseRunner.State.RunningInstance.State.Round),
 			fields.BlockRoot(attData.BeaconBlockRoot),
 			fields.SubmissionTime(time.Since(submissionStart)),
-			fields.TotalConsensusTime(time.Since(cr.measurements.consensusStart)))
+			fields.TotalConsensusTime(cr.measurements.ConsensusTime()))
 
 		// Record successful submissions
 		for validator := range attestationsToSubmit {
@@ -555,7 +555,7 @@ func (cr *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 			fields.Round(cr.BaseRunner.State.RunningInstance.State.Round),
 			fields.BlockRoot(syncCommitteeMessages[0].BeaconBlockRoot),
 			fields.SubmissionTime(time.Since(submissionStart)),
-			fields.TotalConsensusTime(time.Since(cr.measurements.consensusStart)))
+			fields.TotalConsensusTime(cr.measurements.ConsensusTime()))
 
 		// Record successful submissions
 		for validator := range syncCommitteeMessagesToSubmit {


### PR DESCRIPTION
### Description 

We were logging `time.Since(measurements.consensusStart)` while when we called `EndConsensus` `consensusTime` was reset, meaning we printed `maxInt64` value of duration instead of real duration. This PR changes to use the `measurements.ConsensusTime()` function instead which inside uses the `consensusDuration` var which is set with `time.Since(measurements.consensusStart)` before it is reset.  Also using the function makes sure to adhere to any future changes internal to the `measurements` struct.

https://github.com/ssvlabs/ssv/blob/62bda6701775b8e4e870db662963fa8ae25903a0/protocol/v2/ssv/runner/measurements.go#L59-L66


**NOTE**: I think we could've just not reset the `consensusStart` instead, but this is something we do for some reason even with other fields in `measurements` so I decided to keep it simple and not change it for now.