### PR TITLE
fix: (p2p) init random subnets to prevent crash on random subnets.

### DIFF
--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -136,6 +136,7 @@ func New(
 		msgValidator:            cfg.MessageValidator,
 		state:                   stateClosed,
 		activeCommittees:        hashmap.New[string, validatorStatus](),
+		activeSubnets:           make([]byte, commons.SubnetsCount),
 		nodeStorage:             cfg.NodeStorage,
 		operatorPKHashToPKCache: hashmap.New[string, []byte](),
 		operatorSigner:          cfg.OperatorSigner,


### PR DESCRIPTION
### Description 

`SubscribeRandoms` is used in cases where the operator still doesn't have any validators according to the contract but we still want it to participate in the p2p network. In this case it will find random subnets and connect their peers.

### The Bug

Changes in the way we subscribe to subnets have created a scenario that when `SubscribeRandoms` tried to check the `activeSubents` its still not initialized. This caused the node to panic on out of bounds index when running with no validators ( A very rare case, this is why we haven't noticed it.)

This change initializes active subnets with 0's on the initialization on the node.