### PR TITLE
perf: weighted attestation data enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ UNFORMATTED=$(shell gofmt -l .)
 .PHONY: lint-prepare
 lint-prepare:
 	@echo "Preparing Linter"
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s latest
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.64.8
 
 .PHONY: lint
 lint:

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -352,7 +352,7 @@ func (gc *GoClient) scoreAttestationData(ctx context.Context,
 	defer ticker.Stop()
 
 	var (
-		retries uint8
+		retries uint32
 		start   = time.Now()
 	)
 
@@ -378,14 +378,14 @@ func (gc *GoClient) scoreAttestationData(ctx context.Context,
 		select {
 		case <-ctx.Done():
 			logger.
-				With(zap.Uint8("retry_count", retries)).
+				With(zap.Uint32("try", retries)).
 				With(zap.Duration("total_elapsed", time.Since(start))).
 				Error("timeout for obtaining slot for block root was reached. Returning base score")
 			return score
 		case <-ticker.C:
 			retries++
 			logger.
-				With(zap.Uint8("retry_count", retries)).
+				With(zap.Uint32("try", retries)).
 				With(zap.Duration("total_elapsed", time.Since(start))).
 				Warn("retrying to obtain slot for block root")
 		}

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -432,10 +432,7 @@ func (gc *GoClient) blockRootToSlot(ctx context.Context, client Client, root pha
 }
 
 func isBlockHeaderResponseValid(response *api.Response[*eth2apiv1.BeaconBlockHeader]) bool {
-	if response == nil || response.Data == nil || response.Data.Header == nil || response.Data.Header.Message == nil {
-		return false
-	}
-	return true
+	return response != nil && response.Data != nil && response.Data.Header != nil && response.Data.Header.Message != nil
 }
 
 func weightedAttestationDataRequestIDField(id uuid.UUID) zap.Field {

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -320,6 +320,8 @@ func (gc *GoClient) fetchWeightedAttestationData(ctx context.Context,
 		return
 	}
 
+	logger = logger.With(fields.BlockRoot(attestationData.BeaconBlockRoot))
+
 	logger.Debug("scoring attestation data")
 	score := gc.scoreAttestationData(ctx, client, attestationData, logger)
 
@@ -337,10 +339,6 @@ func (gc *GoClient) scoreAttestationData(ctx context.Context,
 	attestationData *phase0.AttestationData,
 	logger *zap.Logger,
 ) float64 {
-	logger = logger.With(
-		fields.BlockRoot(attestationData.BeaconBlockRoot),
-		zap.Uint64("attestation_data_slot", uint64(attestationData.Slot)))
-
 	// Initial score is based on height of source and target epochs.
 	score := float64(attestationData.Source.Epoch + attestationData.Target.Epoch)
 	logger.

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -143,7 +143,7 @@ func (gc *GoClient) weightedAttestationData(slot phase0.Slot) (*phase0.Attestati
 				zap.Int("errored", errored),
 			).Debug("response received")
 
-			if resp.score > bestScore {
+			if bestAttestationData == nil || resp.score > bestScore {
 				if bestAttestationData != nil {
 					logger.Info("updating best attestation data because of higher score",
 						zap.String("client_addr", resp.clientAddr),

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -267,8 +267,8 @@ func (gc *GoClient) simpleAttestationData(slot phase0.Slot) (*phase0.Attestation
 	logger.With(
 		zap.Duration("elapsed", time.Since(attDataReqStart)),
 		zap.Bool("with_weighted_attestation_data", false),
-		zap.String("client_addr", gc.multiClient.Address),
-		fields.BlockRoot(resp.Data.BeaconBlockRoot)
+		zap.String("client_addr", gc.multiClient.Address()),
+		fields.BlockRoot(resp.Data.BeaconBlockRoot),
 	).Debug("successfully fetched attestation data")
 
 	return resp.Data, nil

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -353,7 +353,7 @@ func (gc *GoClient) scoreAttestationData(ctx context.Context,
 	score := float64(attestationData.Source.Epoch + attestationData.Target.Epoch)
 	logger.
 		With(zap.Float64("base_score", score)).
-		Info("base score was set. Fetching slot for block root")
+		Debug("base score was set. Fetching slot for block root")
 
 	ctx, cancel := context.WithTimeout(ctx, gc.weightedAttestationDataSoftTimeout/2)
 	defer cancel()
@@ -447,8 +447,7 @@ func weightedAttestationDataRequestIDField(id uuid.UUID) zap.Field {
 	return zap.String("weighted_data_request_id", id.String())
 }
 
-// multiClientSubmit is a generic function that submits data to multiple clients concurrently.
-// If any client succeeds, the remaining submissions are cancelled.
+// multiClientSubmit is a generic function that submits data to multiple beacon clients concurrently.
 // Returns nil if at least one client successfully submitted the data.
 func (gc *GoClient) multiClientSubmit(
 	operationName string,

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -405,7 +405,7 @@ func (gc *GoClient) blockRootToSlot(ctx context.Context, client Client, root pha
 		return cachedSlot, nil
 	}
 
-	logger.Debug("slot was not found in cache. Fetching from the client")
+	logger.Debug("slot was not found in cache, fetching from the client")
 
 	timeoutContext, cancel := context.WithTimeout(ctx, gc.weightedAttestationDataSoftTimeout/4)
 	defer cancel()

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -147,7 +147,7 @@ func (gc *GoClient) weightedAttestationData(slot phase0.Slot) (*phase0.Attestati
 
 			if bestAttestationData == nil || resp.score > bestScore {
 				if bestAttestationData != nil {
-					logger.Info("updating best attestation data because of higher score",
+					logger.Debug("updating best attestation data because of higher score",
 						zap.String("client_addr", resp.clientAddr),
 						zap.Float64("score", resp.score),
 						fields.Root(resp.attestationData.BeaconBlockRoot),
@@ -189,7 +189,15 @@ func (gc *GoClient) weightedAttestationData(slot phase0.Slot) (*phase0.Attestati
 					zap.Int("succeeded", succeeded),
 					zap.Int("errored", errored),
 				).Debug("response received")
+
 				if bestAttestationData == nil || resp.score > bestScore {
+					if bestAttestationData != nil {
+						logger.Debug("updating best attestation data because of higher score",
+							zap.String("client_addr", resp.clientAddr),
+							zap.Float64("score", resp.score),
+							fields.Root(resp.attestationData.BeaconBlockRoot),
+						)
+					}
 					bestAttestationData = resp.attestationData
 					bestScore = resp.score
 					bestClientAddr = resp.clientAddr

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -370,7 +370,15 @@ func (gc *GoClient) scoreAttestationData(ctx context.Context,
 		slot, err := gc.blockRootToSlot(ctx, client, attestationData.BeaconBlockRoot, logger)
 		if err == nil {
 			// Increase score based on the nearness of the head slot.
-			score += float64(1) / float64(1+attestationData.Slot-slot)
+			denominator := float64(1 + attestationData.Slot - slot)
+			if denominator > 0 {
+				score += float64(1) / denominator
+			} else {
+				logger.
+					With(zap.Float64("denominator", denominator)).
+					Warn("denominator had unexpected value, score was not be updated")
+			}
+
 			logger.With(
 				zap.Duration("elapsed", time.Since(start)),
 				zap.Uint64("head_slot", uint64(slot)),

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -267,6 +267,8 @@ func (gc *GoClient) simpleAttestationData(slot phase0.Slot) (*phase0.Attestation
 	logger.With(
 		zap.Duration("elapsed", time.Since(attDataReqStart)),
 		zap.Bool("with_weighted_attestation_data", false),
+		zap.String("client_addr", gc.multiClient.Address),
+		fields.BlockRoot(resp.Data.BeaconBlockRoot)
 	).Debug("successfully fetched attestation data")
 
 	return resp.Data, nil

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -376,7 +376,7 @@ func (gc *GoClient) scoreAttestationData(ctx context.Context,
 			} else {
 				logger.
 					With(zap.Float64("denominator", denominator)).
-					Warn("denominator had unexpected value, score was not be updated")
+					Warn("denominator had unexpected value, score was not updated")
 			}
 
 			logger.With(

--- a/beacon/goclient/attest_test.go
+++ b/beacon/goclient/attest_test.go
@@ -31,7 +31,7 @@ var (
 	epochs = []phase0.Epoch{318584, 318585, 318586, 318587, 318588}
 
 	defaultHardTimeout = time.Second * 2
-	defaultSoftTimeout = defaultHardTimeout / 2
+	defaultSoftTimeout = time.Duration(float64(defaultHardTimeout) / 2.5)
 
 	// roots is a bunch of random roots.
 	roots = []string{
@@ -384,8 +384,7 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		startTime := time.Now()
 		client.GetAttestationData(phase0.Slot(100))
 
-		softTimeout := client.commonTimeout / 2
-		require.Less(t, time.Since(startTime), softTimeout)
+		require.Less(t, time.Since(startTime), defaultSoftTimeout)
 	})
 
 	t.Run("multiple beacon clients: awaits for soft timeout when one of the servers is a slow responder", func(t *testing.T) {
@@ -405,10 +404,9 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		_, _, err = client.GetAttestationData(phase0.Slot(100))
 
 		require.NoError(t, err)
-		softTimeout := client.commonTimeout / 2
 		timeElapsed := time.Since(startTime)
-		require.GreaterOrEqual(t, timeElapsed, softTimeout)
-		require.LessOrEqual(t, timeElapsed, softTimeout+(softTimeout/10)) //time elapsed should not be greater than soft timeout + 10%
+		require.GreaterOrEqual(t, timeElapsed, defaultSoftTimeout)
+		require.LessOrEqual(t, timeElapsed, defaultSoftTimeout+(defaultSoftTimeout/10)) //time elapsed should not be greater than soft timeout + 10%
 	})
 
 	t.Run("multiple beacon clients: awaits for hard timeout when no responses after soft timeout reached", func(t *testing.T) {

--- a/beacon/goclient/attest_test.go
+++ b/beacon/goclient/attest_test.go
@@ -317,7 +317,7 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("single beacon client: populates boolRootToSlot cache", func(t *testing.T) {
+	t.Run("single beacon client: populates blockRootToSlot cache", func(t *testing.T) {
 		expectedCachedSlot := phase0.Slot(500)
 		beaconServer, _ := createBeaconServer(t, beaconServerResponseOptions{
 			SlotReturnedFromHeaderEndpoint: expectedCachedSlot,

--- a/beacon/goclient/attest_test.go
+++ b/beacon/goclient/attest_test.go
@@ -460,26 +460,6 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		require.Equal(t, bestSourceEpoch, response.Source.Epoch)
 		require.Equal(t, testSlot, response.Slot)
 	})
-
-	t.Run("multiple beacon clients: succeeds within soft timeout when BeaconBlockHeader(scoring) has timeout higher than hard timeout", func(t *testing.T) {
-		const numberOfServers = 3
-		var beaconServersURLs []string
-		for i := 0; i < numberOfServers; i++ {
-			server, _ := createBeaconServer(t, beaconServerResponseOptions{BeaconHeadersResponseDuration: defaultHardTimeout * 2})
-			beaconServersURLs = append(beaconServersURLs, server.URL)
-		}
-		client, err := createClient(ctx, strings.Join(beaconServersURLs, ";"), withWeightedAttestationData)
-		require.NoError(t, err)
-
-		startTime := time.Now()
-		response, version, err := client.GetAttestationData(phase0.Slot(100))
-
-		require.NoError(t, err)
-		require.NotNil(t, response)
-		require.Equal(t, spec.DataVersionPhase0, version)
-		timeElapsed := time.Since(startTime)
-		require.LessOrEqual(t, timeElapsed, client.weightedAttestationDataSoftTimeout)
-	})
 }
 
 func createClient(

--- a/beacon/goclient/attest_test.go
+++ b/beacon/goclient/attest_test.go
@@ -317,6 +317,23 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("single beacon client: populates boolRootToSlot cache", func(t *testing.T) {
+		expectedCachedSlot := phase0.Slot(500)
+		beaconServer, _ := createBeaconServer(t, beaconServerResponseOptions{
+			SlotReturnedFromHeaderEndpoint: expectedCachedSlot,
+		})
+		client, err := createClient(ctx, beaconServer.URL, withWeightedAttestationData)
+		require.NoError(t, err)
+
+		client.GetAttestationData(phase0.Slot(100))
+
+		require.Equal(t, 1, client.blockRootToSlotCache.Len())
+		for root, item := range client.blockRootToSlotCache.Items() {
+			require.Contains(t, roots, "0x"+hex.EncodeToString(root[:]))
+			require.Equal(t, expectedCachedSlot, item.Value())
+		}
+	})
+
 	t.Run("multiple beacon clients: does not await for soft timeout when all servers respond", func(t *testing.T) {
 		const numberOfBeaconServers = 3
 		var beaconServersURLs []string
@@ -443,6 +460,26 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		require.Equal(t, bestSourceEpoch, response.Source.Epoch)
 		require.Equal(t, testSlot, response.Slot)
 	})
+
+	t.Run("multiple beacon clients: succeeds within soft timeout when BeaconBlockHeader(scoring) has timeout higher than hard timeout", func(t *testing.T) {
+		const numberOfServers = 3
+		var beaconServersURLs []string
+		for i := 0; i < numberOfServers; i++ {
+			server, _ := createBeaconServer(t, beaconServerResponseOptions{BeaconHeadersResponseDuration: defaultHardTimeout * 2})
+			beaconServersURLs = append(beaconServersURLs, server.URL)
+		}
+		client, err := createClient(ctx, strings.Join(beaconServersURLs, ";"), withWeightedAttestationData)
+		require.NoError(t, err)
+
+		startTime := time.Now()
+		response, version, err := client.GetAttestationData(phase0.Slot(100))
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		require.Equal(t, spec.DataVersionPhase0, version)
+		timeElapsed := time.Since(startTime)
+		require.LessOrEqual(t, timeElapsed, client.weightedAttestationDataSoftTimeout)
+	})
 }
 
 func createClient(
@@ -476,7 +513,8 @@ type beaconServerResponseOptions struct {
 	BeaconHeadersResponseDuration,
 	// AttestationDataResponseDuration helps configure scenarios where the '/eth/v1/validator/attestation_data' Beacon endpoint responds with a delay specified by this variable.
 	AttestationDataResponseDuration time.Duration
-	AttestationDataResponse []byte
+	AttestationDataResponse        []byte
+	SlotReturnedFromHeaderEndpoint phase0.Slot
 }
 
 func createBeaconServer(t *testing.T, options beaconServerResponseOptions) (*httptest.Server, *hashmap.Map[phase0.Slot, int]) {
@@ -493,6 +531,38 @@ func createBeaconServer(t *testing.T, options beaconServerResponseOptions) (*htt
 				}
 				return
 			}
+		}
+
+		//this endpoint is not called for simple attestation data
+		if strings.HasPrefix(r.URL.Path, "/eth/v1/beacon/headers") {
+			time.Sleep(options.BeaconHeadersResponseDuration)
+			if options.WithHeaderEndpointError {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			resp := []byte(fmt.Sprintf(`{
+				"execution_optimistic": false,
+				"finalized": false,
+				"data": {
+					"header": {
+						"message": {
+							"slot": "%d",
+							"proposer_index": "595427",
+							"parent_root": "0xba8c80a13eecced00fe61d628d15d471694a2d253c0a9d9157055a6f19941fee",
+							"state_root": "0x9689b331f33a227d54ad7c4c17e2b7c8e2e3fec9c925e6f212fe9e3941e4f6f9",
+							"body_root": "0x6be1346b5e812847696c6f18d86754b930ebe4421a1d108b3ae14d02e19a7cef"
+						},
+						"signature": "0xb4edd7ffa8cba8e976dfcb5d375f4715fb2993fd27677776805733d454895e76f2d249b81a34a0ae6a37c1072d713bcd0fbc5617b13a51e36807bc17d8de1dd18d670a8bc8e8f9481e888822d08dba067e58844d8796653536cd450ad01acf90"
+					},
+					"root": "0x2922d4d36529c39ae7c463bc0a18f434d616954bdc0a38f7c24e0847a181de15",
+					"canonical": true
+				}
+			}`, options.SlotReturnedFromHeaderEndpoint))
+			if _, err := w.Write(resp); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			return
 		}
 
 		require.Equal(t, http.MethodGet, r.Method)

--- a/beacon/goclient/committee_subscribe.go
+++ b/beacon/goclient/committee_subscribe.go
@@ -2,43 +2,20 @@ package goclient
 
 import (
 	"context"
-	"net/http"
-	"time"
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
-	"go.uber.org/zap"
 )
 
 // SubmitBeaconCommitteeSubscriptions is implementation for subscribing committee to subnet (p2p topic)
 func (gc *GoClient) SubmitBeaconCommitteeSubscriptions(ctx context.Context, subscription []*eth2apiv1.BeaconCommitteeSubscription) error {
-	clientAddress := gc.multiClient.Address()
-	logger := gc.log.With(
-		zap.String("api", "SubmitBeaconCommitteeSubscriptions"),
-		zap.String("client_addr", clientAddress))
-
-	start := time.Now()
-	err := gc.multiClient.SubmitBeaconCommitteeSubscriptions(ctx, subscription)
-	recordRequestDuration(gc.ctx, "SubmitBeaconCommitteeSubscriptions", clientAddress, http.MethodPost, time.Since(start), err)
-	if err != nil {
-		logger.Error(clResponseErrMsg, zap.Error(err))
-		return err
-	}
-
-	logger.Debug("consensus client submitted beacon committee subscriptions")
-	return nil
+	return gc.multiClientSubmit("SubmitBeaconCommitteeSubscriptions", func(ctx context.Context, client Client) error {
+		return client.SubmitBeaconCommitteeSubscriptions(ctx, subscription)
+	})
 }
 
 // SubmitSyncCommitteeSubscriptions is implementation for subscribing sync committee to subnet (p2p topic)
 func (gc *GoClient) SubmitSyncCommitteeSubscriptions(ctx context.Context, subscription []*eth2apiv1.SyncCommitteeSubscription) error {
-	start := time.Now()
-	err := gc.multiClient.SubmitSyncCommitteeSubscriptions(ctx, subscription)
-	recordRequestDuration(gc.ctx, "SubmitSyncCommitteeSubscriptions", gc.multiClient.Address(), http.MethodPost, time.Since(start), err)
-	if err != nil {
-		gc.log.Error(clResponseErrMsg,
-			zap.String("api", "SubmitSyncCommitteeSubscriptions"),
-			zap.Error(err),
-		)
-	}
-
-	return err
+	return gc.multiClientSubmit("SubmitSyncCommitteeSubscriptions", func(ctx context.Context, client Client) error {
+		return client.SubmitSyncCommitteeSubscriptions(ctx, subscription)
+	})
 }

--- a/beacon/goclient/events.go
+++ b/beacon/goclient/events.go
@@ -155,8 +155,8 @@ func (gc *GoClient) eventHandler(e *apiv1.Event) {
 		}
 
 		noTTLOpt := ttlcache.WithTTL[phase0.Root, phase0.Slot](ttlcache.NoTTL)
-		_, isUpdated := gc.blockRootToSlotCache.GetOrSet(eventData.Block, eventData.Slot, noTTLOpt)
-		if isUpdated {
+		_, exists := gc.blockRootToSlotCache.GetOrSet(eventData.Block, eventData.Slot, noTTLOpt)
+		if !exists {
 			logger.
 				With(fields.Slot(eventData.Slot)).
 				With(fields.BlockRoot(eventData.Block)).

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -215,7 +215,7 @@ func New(
 		longTimeout:                        longTimeout,
 		withWeightedAttestationData:        opt.WithWeightedAttestationData,
 		withParallelSubmissions:            opt.WithParallelSubmissions,
-		weightedAttestationDataSoftTimeout: commonTimeout / 2,
+		weightedAttestationDataSoftTimeout: time.Duration(float64(commonTimeout) / 2.5),
 		weightedAttestationDataHardTimeout: commonTimeout,
 		supportedTopics:                    []EventTopic{EventTopicHead, EventTopicBlock},
 		genesisForkVersion:                 phase0.Version(opt.Network.ForkVersion()),

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -149,9 +149,6 @@ type GoClient struct {
 	weightedAttestationDataSoftTimeout time.Duration
 	weightedAttestationDataHardTimeout time.Duration
 
-	// blockRootToSlotReqInflight helps prevent duplicate BeaconBlockHeader requests
-	// from running in parallel.
-	blockRootToSlotReqInflight singleflight.Group[phase0.Root, phase0.Slot]
 	// blockRootToSlotCache is used for attestation data scoring. When multiple Consensus clients are used,
 	// the cache helps reduce the number of Consensus Client calls by `n-1`, where `n` is the number of Consensus clients
 	// that successfully fetched attestation data and proceeded to the scoring phase. Capacity is rather an arbitrary number,
@@ -217,7 +214,7 @@ func New(
 		withWeightedAttestationData:        opt.WithWeightedAttestationData,
 		weightedAttestationDataSoftTimeout: commonTimeout / 2,
 		weightedAttestationDataHardTimeout: commonTimeout,
-		supportedTopics:                    []EventTopic{EventTopicHead},
+		supportedTopics:                    []EventTopic{EventTopicHead, EventTopicBlock},
 		genesisForkVersion:                 phase0.Version(opt.Network.ForkVersion()),
 		// Initialize forks with FAR_FUTURE_EPOCH.
 		ForkEpochAltair:    math.MaxUint64,

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -160,6 +160,8 @@ type GoClient struct {
 
 	withWeightedAttestationData bool
 
+	withParallelSubmissions bool
+
 	subscribersLock      sync.RWMutex
 	headEventSubscribers []subscriber[*apiv1.HeadEvent]
 	supportedTopics      []EventTopic
@@ -212,6 +214,7 @@ func New(
 		commonTimeout:                      commonTimeout,
 		longTimeout:                        longTimeout,
 		withWeightedAttestationData:        opt.WithWeightedAttestationData,
+		withParallelSubmissions:            opt.WithParallelSubmissions,
 		weightedAttestationDataSoftTimeout: commonTimeout / 2,
 		weightedAttestationDataHardTimeout: commonTimeout,
 		supportedTopics:                    []EventTopic{EventTopicHead, EventTopicBlock},

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -117,7 +117,8 @@ type operatorDataStore interface {
 type EventTopic string
 
 const (
-	EventTopicHead EventTopic = "head"
+	EventTopicHead  EventTopic = "head"
+	EventTopicBlock EventTopic = "block"
 )
 
 // GoClient implementing Beacon struct
@@ -166,8 +167,8 @@ type GoClient struct {
 	headEventSubscribers []subscriber[*apiv1.HeadEvent]
 	supportedTopics      []EventTopic
 
-	lastProcessedHeadEventSlotLock sync.Mutex
-	lastProcessedHeadEventSlot     phase0.Slot
+	lastProcessedEventSlotLock sync.Mutex
+	lastProcessedEventSlot     phase0.Slot
 
 	genesisForkVersion phase0.Version
 	ForkLock           sync.RWMutex

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sync/atomic"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/api"
@@ -19,7 +18,6 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/electra"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
-	"github.com/sourcegraph/conc/pool"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"go.uber.org/zap"
 
@@ -230,74 +228,9 @@ func (gc *GoClient) SubmitBlindedBeaconBlock(block *api.VersionedBlindedProposal
 		Proposal: signedBlock,
 	}
 
-	// As gc.multiClient doesn't have a method for blinded block submission
-	// (because it must be submitted to the same node that returned that block),
-	// we need to submit it to client(s) directly.
-	if len(gc.clients) == 1 {
-		clientAddress := gc.clients[0].Address()
-		logger := gc.log.With(
-			zap.String("api", "SubmitBlindedProposal"),
-			zap.String("client_addr", clientAddress))
-
-		start := time.Now()
-		err := gc.clients[0].SubmitBlindedProposal(gc.ctx, opts)
-		recordRequestDuration(gc.ctx, "SubmitBlindedProposal", clientAddress, http.MethodPost, time.Since(start), err)
-		if err != nil {
-			logger.Error(clResponseErrMsg,
-				zap.Error(err),
-			)
-			return err
-		}
-
-		logger.Debug("consensus client submitted blinded beacon block")
-
-		return nil
-	}
-
-	// Although we got a blinded block from one node and that node has to submit it,
-	// other nodes might know this payload too and have a chance to submit it successfully.
-	//
-	// So we do the following:
-	//
-	// Submit the blinded proposal to all clients concurrently.
-	// If any client succeeds, cancel the remaining submissions.
-	// Wait for all submissions to finish or timeout after 1 minute.
-	//
-	// TODO: Make sure this the above is correct. Should we submit only to the node that returned the block?
-
-	logger := gc.log.With(zap.String("api", "SubmitBlindedProposal"))
-
-	submissions := atomic.Int32{}
-	p := pool.New().WithErrors().WithContext(gc.ctx)
-	for _, client := range gc.clients {
-		client := client
-		p.Go(func(ctx context.Context) error {
-			clientAddress := client.Address()
-			logger := logger.With(zap.String("client_addr", clientAddress))
-
-			if err := client.SubmitBlindedProposal(ctx, opts); err == nil {
-				logger.Debug("consensus client returned an error while submitting blinded proposal. As at least one node must submit successfully, it's expected that some nodes may fail to submit.",
-					zap.Error(err))
-				return err
-			}
-
-			logger.Debug("consensus client submitted blinded beacon block")
-
-			submissions.Add(1)
-			return nil
-		})
-	}
-	err := p.Wait()
-	if submissions.Load() > 0 {
-		// At least one client has submitted the proposal successfully,
-		// so we can return without error.
-		return nil
-	}
-	if err != nil {
-		logger.Error("no consensus clients have been able to submit blinded proposal. See adjacent logs for error details.")
-		return fmt.Errorf("no consensus clients have been able to submit blinded proposal")
-	}
-	return nil
+	return gc.multiClientSubmit("SubmitBlindedProposal", func(ctx context.Context, client Client) error {
+		return client.SubmitBlindedProposal(ctx, opts)
+	})
 }
 
 // SubmitBeaconBlock submit the block to the node
@@ -394,21 +327,9 @@ func (gc *GoClient) SubmitProposalPreparation(feeRecipients map[phase0.Validator
 		})
 	}
 
-	clientAddress := gc.multiClient.Address()
-	logger := gc.log.With(
-		zap.String("api", "SubmitProposalPreparations"),
-		zap.String("client_addr", clientAddress))
-
-	start := time.Now()
-	err := gc.multiClient.SubmitProposalPreparations(gc.ctx, preparations)
-	recordRequestDuration(gc.ctx, "SubmitProposalPreparations", clientAddress, http.MethodPost, time.Since(start), err)
-	if err != nil {
-		logger.Error(clResponseErrMsg, zap.Error(err))
-		return err
-	}
-
-	logger.Debug("consensus client submitted proposal preparation")
-	return nil
+	return gc.multiClientSubmit("SubmitProposalPreparations", func(ctx context.Context, client Client) error {
+		return client.SubmitProposalPreparations(ctx, preparations)
+	})
 }
 
 func (gc *GoClient) updateBatchRegistrationCache(registration *api.VersionedSignedValidatorRegistration) error {

--- a/beacon/goclient/proposer.go
+++ b/beacon/goclient/proposer.go
@@ -297,21 +297,9 @@ func (gc *GoClient) SubmitBeaconBlock(block *api.VersionedProposal, sig phase0.B
 		Proposal: signedBlock,
 	}
 
-	clientAddress := gc.multiClient.Address()
-	logger := gc.log.With(
-		zap.String("api", "SubmitProposal"),
-		zap.String("client_addr", clientAddress))
-
-	start := time.Now()
-	err := gc.multiClient.SubmitProposal(gc.ctx, opts)
-	recordRequestDuration(gc.ctx, "SubmitProposal", clientAddress, http.MethodPost, time.Since(start), err)
-	if err != nil {
-		logger.Error(clResponseErrMsg, zap.Error(err))
-		return err
-	}
-
-	logger.Debug("consensus client submitted beacon block")
-	return nil
+	return gc.multiClientSubmit("SubmitProposal", func(ctx context.Context, client Client) error {
+		return client.SubmitProposal(gc.ctx, opts)
+	})
 }
 
 func (gc *GoClient) SubmitValidatorRegistration(registration *api.VersionedSignedValidatorRegistration) error {

--- a/beacon/goclient/sync_committee.go
+++ b/beacon/goclient/sync_committee.go
@@ -73,6 +73,12 @@ func (gc *GoClient) GetSyncMessageBlockRoot(slot phase0.Slot) (phase0.Root, spec
 
 // SubmitSyncMessages submits a signed sync committee msg
 func (gc *GoClient) SubmitSyncMessages(msgs []*altair.SyncCommitteeMessage) error {
+	if gc.withParallelSubmissions {
+		return gc.multiClientSubmit("SubmitSyncCommitteeMessages", func(ctx context.Context, client Client) error {
+			return client.SubmitSyncCommitteeMessages(gc.ctx, msgs)
+		})
+	}
+
 	clientAddress := gc.multiClient.Address()
 	logger := gc.log.With(
 		zap.String("api", "SubmitSyncCommitteeMessages"),

--- a/protocol/v2/blockchain/beacon/client.go
+++ b/protocol/v2/blockchain/beacon/client.go
@@ -65,6 +65,7 @@ type Options struct {
 	BeaconNodeAddr              string `yaml:"BeaconNodeAddr" env:"BEACON_NODE_ADDR" env-required:"true" env-description:"Beacon node address. Supports multiple semicolon separated addresses. ex: http://localhost:5052;http://localhost:5053"`
 	SyncDistanceTolerance       uint64 `yaml:"SyncDistanceTolerance" env:"BEACON_SYNC_DISTANCE_TOLERANCE" env-default:"4" env-description:"The number of out-of-sync slots we can tolerate"`
 	WithWeightedAttestationData bool   `yaml:"WithWeightedAttestationData" env:"WITH_WEIGHTED_ATTESTATION_DATA" env-default:"false" env-description:"Enables Attestation Data fetching & scoring using multiple Beacon nodes simultaneously (as opposed to fetching Attestation Data from just one Beacon node)"`
+	WithParallelSubmissions     bool   `yaml:"WithParallelSubmissions" env:"WITH_PARALLEL_SUBMISSIONS" env-default:"false" env-description:"Enables parallel Attestation and Sync Committee submissions to all Beacon nodes (as oppose to submitting to a single Beacon node via multiclient instance)"`
 
 	CommonTimeout time.Duration // Optional.
 	LongTimeout   time.Duration // Optional.

--- a/protocol/v2/blockchain/beacon/client.go
+++ b/protocol/v2/blockchain/beacon/client.go
@@ -65,7 +65,7 @@ type Options struct {
 	BeaconNodeAddr              string `yaml:"BeaconNodeAddr" env:"BEACON_NODE_ADDR" env-required:"true" env-description:"Beacon node address. Supports multiple semicolon separated addresses. ex: http://localhost:5052;http://localhost:5053"`
 	SyncDistanceTolerance       uint64 `yaml:"SyncDistanceTolerance" env:"BEACON_SYNC_DISTANCE_TOLERANCE" env-default:"4" env-description:"The number of out-of-sync slots we can tolerate"`
 	WithWeightedAttestationData bool   `yaml:"WithWeightedAttestationData" env:"WITH_WEIGHTED_ATTESTATION_DATA" env-default:"false" env-description:"Enables Attestation Data fetching & scoring using multiple Beacon nodes simultaneously (as opposed to fetching Attestation Data from just one Beacon node)"`
-	WithParallelSubmissions     bool   `yaml:"WithParallelSubmissions" env:"WITH_PARALLEL_SUBMISSIONS" env-default:"false" env-description:"Enables parallel Attestation and Sync Committee submissions to all Beacon nodes (as oppose to submitting to a single Beacon node via multiclient instance)"`
+	WithParallelSubmissions     bool   `yaml:"WithParallelSubmissions" env:"WITH_PARALLEL_SUBMISSIONS" env-default:"false" env-description:"Enables parallel Attestation and Sync Committee submissions to all Beacon nodes (as opposed to submitting to a single Beacon node via multiclient instance)"`
 
 	CommonTimeout time.Duration // Optional.
 	LongTimeout   time.Duration // Optional.


### PR DESCRIPTION
This PR addresses several edge cases that may occur during the weighted attestation data flow, particularly those related to scoring.

- The singleflight lock on block root lookups was removed, allowing all clients to retrieve the slot by block root in parallel. This change increases the likelihood of successfully fetching the slot, which is critical for scoring. A vulnerability in the previous implementation was that if one client timed out, other clients might not get a chance to perform the same lookup due to the soft timeout being reached.

- Retry logic was introduced for fetching the slot by block root. This addition is important, as the Block event often arrives just a few milliseconds after the initial scoring attempt, which previously led to slot being not included in the score.

- The timeout for the `BeaconBlockHeader` call was reduced to 1/4 of the soft timeout. The goal is to prevent a single `BlockHeader` call from consuming the entire timeout budget. 

- The system now listens to **Block** events instead of **Head** events when the weighted feature is enabled. This aligns the implementation more closely with Vouch’s behavior.


Other changes:
- Parallel submissions of: Sync Committee Subscriptions, Blinded Proposals, Proposal Preparations (some of them are only when new flag `withParallelSubmissions` is enabled)