### PR TITLE
fix(api/handling.go): restore direct renderer invocation in Handler 

### DIFF
--- a/api/handling.go
+++ b/api/handling.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -19,17 +18,18 @@ type HandlerFunc func(http.ResponseWriter, *http.Request) error
 func Handler(h HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := h(w, r); err != nil {
-			var renderErr error
-			var errRenderer render.Renderer
-
-			if errors.As(err, &errRenderer) {
-				renderErr = errRenderer.Render(w, r)
-			} else {
-				renderErr = render.Render(w, r, Error(err))
-			}
-
-			if renderErr != nil {
-				http.Error(w, renderErr.Error(), http.StatusInternalServerError)
+			//nolint:errorlint
+			// errors.As would be incorrect here since a renderer.Renderer
+			// wrapped inside another error should error, not render.
+			switch e := err.(type) {
+			case render.Renderer:
+				if err := render.Render(w, r, e); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			default:
+				if err := render.Render(w, r, Error(err)); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This reverts the refactoring of `api/handling.go`. Anatoli discovered that rendered errors aren't being properly wrapped (chi renderer does automatically), so I'm restoring the previous implementation to maintain backward compatibility

