### PR TITLE
hotfix: prevent false `indicesChange` trigger on metadata update

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -185,9 +185,8 @@ type controller struct {
 	syncCommRoots            *ttlcache.Cache[phase0.Root, struct{}]
 	domainCache              *validator.DomainCache
 
-	recentlyStartedValidators uint64
-	indicesChange             chan struct{}
-	validatorExitCh           chan duties.ExitDescriptor
+	indicesChange   chan struct{}
+	validatorExitCh chan duties.ExitDescriptor
 }
 
 // NewController creates a new validator controller instance
@@ -915,11 +914,8 @@ func (c *controller) startValidator(v *validator.Validator) (bool, error) {
 		validatorErrorsCounter.Add(c.ctx, 1)
 		return false, errors.Wrap(err, "could not start validator")
 	}
-	if started {
-		c.recentlyStartedValidators++
-	}
 
-	return true, nil // TODO: what should be returned if c.validatorStart(v) returns false?
+	return started, nil
 }
 
 func (c *controller) HandleMetadataUpdates(ctx context.Context) {

--- a/protocol/v2/ssv/validator/startup.go
+++ b/protocol/v2/ssv/validator/startup.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ssvlabs/ssv-spec/p2p"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
+
 	"github.com/ssvlabs/ssv/logging"
 	"github.com/ssvlabs/ssv/logging/fields"
 )
@@ -47,7 +48,7 @@ func (v *Validator) Start(logger *zap.Logger) (started bool, err error) {
 		copy(valpk[:], share.ValidatorPubKey[:])
 
 		if err := n.Subscribe(valpk); err != nil {
-			return true, err
+			return false, err
 		}
 		go v.StartQueueConsumer(logger, identifier, v.ProcessMessage)
 	}

--- a/protocol/v2/ssv/validator/startup.go
+++ b/protocol/v2/ssv/validator/startup.go
@@ -48,6 +48,7 @@ func (v *Validator) Start(logger *zap.Logger) (started bool, err error) {
 		copy(valpk[:], share.ValidatorPubKey[:])
 
 		if err := n.Subscribe(valpk); err != nil {
+			atomic.StoreUint32(&v.state, uint32(NotStarted))
 			return false, err
 		}
 		go v.StartQueueConsumer(logger, identifier, v.ProcessMessage)


### PR DESCRIPTION
This hotfix ensures `startValidatorsForMetadata` returns the correct number of newly started validators.
- Previously, the return value from `startValidator` was not respected, leading to an inaccurate count.
- As a result, `indicesChange` could be incorrectly triggered after metadata updates.
- The count is now accurate, preventing unnecessary duty refreshes.

The full solution will be provided in [#2060](https://github.com/ssvlabs/ssv/pull/2060).
This hotfix is a minimal step toward resolving [#2037](https://github.com/ssvlabs/ssv/issues/2037) until the full fix is merged.
