### PR TITLE
benchmarks: go vs openssl rsa implementations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ UNFORMATTED=$(shell gofmt -l .)
 GET_TOOL=go get -modfile=tool.mod -tool
 RUN_TOOL=go tool -modfile=tool.mod
 
-#Lint
 .PHONY: lint
 lint:
 	$(RUN_TOOL) golangci-lint run -v ./...
@@ -70,14 +69,17 @@ spec-test-raceless:
 	@echo "Running spec tests without race flag"
 	@go test -tags blst_enabled -timeout 20m -count=1 -p 1 -v `go list ./... | grep spectest`
 
-#Test
+.PHONY: benchmark
+benchmark:
+	@echo "Running benchmark for specified directory"
+	@go test -run=^# -bench . -benchmem -v TARGET_DIR_PATH -count 3
+
 .PHONY: docker-spec-test
 docker-spec-test:
 	@echo "Running spec tests in docker"
 	@docker build -t ssv_tests -f tests.Dockerfile .
 	@docker run --rm ssv_tests make spec-test
 
-#Test
 .PHONY: docker-unit-test
 docker-unit-test:
 	@echo "Running unit tests in docker"
@@ -90,7 +92,12 @@ docker-integration-test:
 	@docker build -t ssv_tests -f tests.Dockerfile .
 	@docker run --rm ssv_tests make integration-test
 
-#Build
+.PHONY: docker-benchmark
+docker-benchmark:
+	@echo "Running benchmark in docker"
+	@docker build -t ssv_tests -f tests.Dockerfile .
+	@docker run --rm ssv_tests make benchmark
+
 .PHONY: build
 build:
 	CGO_ENABLED=1 go build -o ./bin/ssvnode -ldflags "-X main.Commit=`git rev-parse HEAD` -X main.Version=`git describe --tags $(git rev-list --tags --max-count=1)`" ./cmd/ssvnode/

--- a/operator/keys/rsa_benchmark_test.go
+++ b/operator/keys/rsa_benchmark_test.go
@@ -1,0 +1,246 @@
+package keys
+
+import (
+	"crypto"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/herumi/bls-eth-go-binary/bls"
+)
+
+const (
+	keySize = 2048
+)
+
+var (
+	// msg we'll use for benchmarking.
+	msg = []byte("Some message example to be hashed for benchmarking, let's make it at " +
+		"least 100 bytes long so we can benchmark against somewhat real-world message size. " +
+		"Although it still might be way too small. Lajfklflfaslfjsalfalsfjsla fjlajlfaslkfjaslkf" +
+		"lasjflkasljfLFSJLfjsalfjaslfLKFsalfjalsfjalsfjaslfjaslfjlasflfslafasklfjsalfj;eqwfgh442")
+	// msgHash is a typical sha256 hash, we use it for benchmarking because it's the most
+	// common type of data we work with.
+	msgHash = func() []byte {
+		hash := sha256.Sum256(msg)
+		return hash[:]
+	}()
+)
+
+var (
+	privKey   *rsa.PrivateKey
+	pubKey    *rsa.PublicKey
+	signature []byte
+	data      = []byte("This is some test data for verification.")
+	hashed    = sha256.Sum256(data)
+)
+
+var (
+	privKeyPSS   *rsa.PrivateKey
+	pubKeyPSS    *rsa.PublicKey
+	pssSignature []byte
+	dataPSS      = []byte("This is some test data for PSS verification.")
+	hashedPSS    = sha256.Sum256(dataPSS)
+)
+
+var (
+	privKeyFast   *rsa.PrivateKey
+	pubKeyFast    *rsa.PublicKey
+	signatureFast []byte
+	dataFast      = []byte("This is test data for fast verification.")
+	hashedFast    = md5.Sum(dataFast)
+)
+
+func init() {
+	var err error
+	privKey, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+	pubKey = &privKey.PublicKey
+
+	signature, err = rsa.SignPKCS1v15(rand.Reader, privKey, crypto.SHA256, hashed[:])
+	if err != nil {
+		panic(err)
+	}
+
+	if err := bls.Init(bls.BLS12_381); err != nil {
+		panic(err)
+	}
+
+	if err := bls.SetETHmode(bls.EthModeLatest); err != nil {
+		panic(err)
+	}
+
+	privKeyPSS, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+	pubKeyPSS = &privKeyPSS.PublicKey
+
+	pssOptions := &rsa.PSSOptions{
+		SaltLength: rsa.PSSSaltLengthAuto,
+		Hash:       crypto.SHA256,
+	}
+
+	pssSignature, err = rsa.SignPSS(rand.Reader, privKeyPSS, crypto.SHA256, hashedPSS[:], pssOptions)
+	if err != nil {
+		panic(err)
+	}
+
+	privKeyFast, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+	pubKeyFast = &privKeyFast.PublicKey
+
+	signatureFast, err = rsa.SignPKCS1v15(rand.Reader, privKeyFast, crypto.MD5, hashedFast[:])
+	if err != nil {
+		panic(err)
+	}
+}
+
+func BenchmarkSignRSA(b *testing.B) {
+	privKey, _ := genKeypair(b)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := SignRSA(privKey, msgHash)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncryptRSA(b *testing.B) {
+	_, pubKey := genKeypair(b)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := EncryptRSA(pubKey, msgHash)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerifyRSA(b *testing.B) {
+	privKey, pubKey := genKeypair(b)
+	sig, err := SignRSA(privKey, msgHash)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := VerifyRSA(pubKey, msg, sig)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerifyBLS(b *testing.B) {
+	secKey := new(bls.SecretKey)
+	secKey.SetByCSPRNG()
+	pubKey := secKey.GetPublicKey()
+	msg := []byte("This is some test data for verification.")
+	sig := secKey.SignByte(msg)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !sig.VerifyByte(pubKey, msg) {
+			b.Fatal("Verification failed")
+		}
+	}
+}
+
+func BenchmarkVerifyPKCS1v15(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hashed[:], signature)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerifyPKCS1v15FastHash(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := rsa.VerifyPKCS1v15(pubKeyFast, crypto.MD5, hashedFast[:], signatureFast)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkVerifyPSS(b *testing.B) {
+	pssOptions := &rsa.PSSOptions{
+		SaltLength: rsa.PSSSaltLengthAuto,
+		Hash:       crypto.SHA256,
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := rsa.VerifyPSS(pubKeyPSS, crypto.SHA256, hashedPSS[:], pssSignature, pssOptions)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSignBLS(b *testing.B) {
+	secKey := new(bls.SecretKey)
+	secKey.SetByCSPRNG()
+	msg := []byte("This is some test data for verification.")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = secKey.SignByte(msg)
+	}
+}
+
+func BenchmarkSignPKCS1v15(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := rsa.SignPKCS1v15(rand.Reader, privKey, crypto.SHA256, hashed[:])
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSignPKCS1v15FastHash(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := rsa.SignPKCS1v15(rand.Reader, privKeyFast, crypto.MD5, hashedFast[:])
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSignPSS(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pssOptions := &rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthAuto,
+			Hash:       crypto.SHA256,
+		}
+
+		_, err := rsa.SignPSS(rand.Reader, privKeyPSS, crypto.SHA256, hashedPSS[:], pssOptions)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func genKeypair(b *testing.B) (*privateKey, *publicKey) {
+	pKey, err := rsa.GenerateKey(rand.Reader, keySize)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return &privateKey{privKey: pKey}, &publicKey{pubKey: &pKey.PublicKey}
+}

--- a/operator/keys/rsa_benchmark_test.go
+++ b/operator/keys/rsa_benchmark_test.go
@@ -17,10 +17,10 @@ const (
 
 var (
 	// msg we'll use for benchmarking.
-	msg = []byte("Some message example to be hashed for benchmarking, let's make it at " +
-		"least 100 bytes long so we can benchmark against somewhat real-world message size. " +
-		"Although it still might be way too small. Lajfklflfaslfjsalfalsfjsla fjlajlfaslkfjaslkf" +
-		"lasjflkasljfLFSJLfjsalfjaslfLKFsalfjalsfjalsfjaslfjaslfjlasflfslafasklfjsalfj;eqwfgh442")
+	msg = []byte(`Some message example to be hashed for benchmarking, let's make it at 
+		least 100 bytes long so we can benchmark against somewhat real-world message size. 
+		Although it still might be way too small. Lajfklflfaslfjsalfalsfjsla fjlajlfaslkfjaslkf
+		lasjflkasljfLFSJLfjsalfjaslfLKFsalfjalsfjalsfjaslfjaslfjlasflfslafasklfjsalfj;eqwfgh442`)
 	// msgHash is a typical sha256 hash, we use it for benchmarking because it's the most
 	// common type of data we work with.
 	msgHash = func() []byte {
@@ -105,8 +105,7 @@ func init() {
 func BenchmarkSignRSA(b *testing.B) {
 	privKey, _ := genKeypair(b)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := SignRSA(privKey, msgHash)
 		if err != nil {
 			b.Fatal(err)
@@ -117,8 +116,7 @@ func BenchmarkSignRSA(b *testing.B) {
 func BenchmarkEncryptRSA(b *testing.B) {
 	_, pubKey := genKeypair(b)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := EncryptRSA(pubKey, msgHash)
 		if err != nil {
 			b.Fatal(err)
@@ -133,8 +131,7 @@ func BenchmarkVerifyRSA(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		err := VerifyRSA(pubKey, msg, sig)
 		if err != nil {
 			b.Fatal(err)
@@ -149,8 +146,7 @@ func BenchmarkVerifyBLS(b *testing.B) {
 	msg := []byte("This is some test data for verification.")
 	sig := secKey.SignByte(msg)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if !sig.VerifyByte(pubKey, msg) {
 			b.Fatal("Verification failed")
 		}
@@ -158,8 +154,7 @@ func BenchmarkVerifyBLS(b *testing.B) {
 }
 
 func BenchmarkVerifyPKCS1v15(b *testing.B) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		err := rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hashed[:], signature)
 		if err != nil {
 			b.Fatal(err)
@@ -168,8 +163,7 @@ func BenchmarkVerifyPKCS1v15(b *testing.B) {
 }
 
 func BenchmarkVerifyPKCS1v15FastHash(b *testing.B) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		err := rsa.VerifyPKCS1v15(pubKeyFast, crypto.MD5, hashedFast[:], signatureFast)
 		if err != nil {
 			b.Fatal(err)
@@ -182,8 +176,7 @@ func BenchmarkVerifyPSS(b *testing.B) {
 		SaltLength: rsa.PSSSaltLengthAuto,
 		Hash:       crypto.SHA256,
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		err := rsa.VerifyPSS(pubKeyPSS, crypto.SHA256, hashedPSS[:], pssSignature, pssOptions)
 		if err != nil {
 			b.Fatal(err)
@@ -196,15 +189,13 @@ func BenchmarkSignBLS(b *testing.B) {
 	secKey.SetByCSPRNG()
 	msg := []byte("This is some test data for verification.")
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = secKey.SignByte(msg)
 	}
 }
 
 func BenchmarkSignPKCS1v15(b *testing.B) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := rsa.SignPKCS1v15(rand.Reader, privKey, crypto.SHA256, hashed[:])
 		if err != nil {
 			b.Fatal(err)
@@ -213,8 +204,7 @@ func BenchmarkSignPKCS1v15(b *testing.B) {
 }
 
 func BenchmarkSignPKCS1v15FastHash(b *testing.B) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := rsa.SignPKCS1v15(rand.Reader, privKeyFast, crypto.MD5, hashedFast[:])
 		if err != nil {
 			b.Fatal(err)
@@ -223,8 +213,7 @@ func BenchmarkSignPKCS1v15FastHash(b *testing.B) {
 }
 
 func BenchmarkSignPSS(b *testing.B) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		pssOptions := &rsa.PSSOptions{
 			SaltLength: rsa.PSSSaltLengthAuto,
 			Hash:       crypto.SHA256,

--- a/operator/keys/rsa_linux.go
+++ b/operator/keys/rsa_linux.go
@@ -69,14 +69,6 @@ func SignRSA(priv *privateKey, data []byte) ([]byte, error) {
 	return openssl.SignRSAPKCS1v15(opriv, crypto.SHA256, data)
 }
 
-func checkCachePubkey(pub *publicKey) (*openssl.PublicKeyRSA, error) {
-	var err error
-	pub.once.Do(func() {
-		pub.cachedPubkey, err = rsaPublicKeyToOpenSSL(pub.pubKey)
-	})
-	return pub.cachedPubkey, err
-}
-
 func EncryptRSA(pub *publicKey, data []byte) ([]byte, error) {
 	opub, err := checkCachePubkey(pub)
 	if err != nil {
@@ -92,4 +84,12 @@ func VerifyRSA(pub *publicKey, data, signature []byte) error {
 	}
 	hashed := sha256.Sum256(data)
 	return openssl.VerifyRSAPKCS1v15(opub, crypto.SHA256, hashed[:], signature)
+}
+
+func checkCachePubkey(pub *publicKey) (*openssl.PublicKeyRSA, error) {
+	var err error
+	pub.once.Do(func() {
+		pub.cachedPubkey, err = rsaPublicKeyToOpenSSL(pub.pubKey)
+	})
+	return pub.cachedPubkey, err
 }


### PR DESCRIPTION
Revamp of https://github.com/ssvlabs/ssv/pull/1799 to add **go** vs **openssl** benchmarks