### PR TITLE
eth/executionclient: multi client metrics

### DIFF
--- a/eth/executionclient/multi_client.go
+++ b/eth/executionclient/multi_client.go
@@ -160,6 +160,7 @@ func (mc *MultiClient) connect(ctx context.Context, clientIndex int) error {
 		WithSyncDistanceTolerance(mc.syncDistanceTolerance),
 	)
 	if err != nil {
+		recordClientInit(ctx, mc.nodeAddrs[clientIndex], false, err)
 		return fmt.Errorf("create single client: %w", err)
 	}
 
@@ -168,6 +169,7 @@ func (mc *MultiClient) connect(ctx context.Context, clientIndex int) error {
 		logger.Error("failed to get chain ID",
 			zap.String("address", mc.nodeAddrs[clientIndex]),
 			zap.Error(err))
+		recordClientInit(ctx, mc.nodeAddrs[clientIndex], false, err)
 		return fmt.Errorf("get chain ID: %w", err)
 	}
 
@@ -178,9 +180,12 @@ func (mc *MultiClient) connect(ctx context.Context, clientIndex int) error {
 			zap.String("address", mc.nodeAddrs[clientIndex]),
 			zap.Error(err),
 		)
+		recordClientInit(ctx, mc.nodeAddrs[clientIndex], false, err)
+		return err
 	}
 
 	mc.clients[clientIndex] = singleClient
+	recordClientInit(ctx, mc.nodeAddrs[clientIndex], true, nil)
 	return nil
 }
 
@@ -284,6 +289,7 @@ func (mc *MultiClient) Healthy(ctx context.Context) error {
 	}
 
 	healthyClients := atomic.Bool{}
+	healthyCount := atomic.Int64{}
 	p := pool.New().WithErrors().WithContext(ctx)
 
 	for i := range mc.clients {
@@ -306,11 +312,16 @@ func (mc *MultiClient) Healthy(ctx context.Context) error {
 				return err
 			}
 			healthyClients.Store(true)
+			healthyCount.Add(1)
 
 			return nil
 		})
 	}
 	err := p.Wait()
+
+	// Record the current count of healthy clients
+	recordHealthyClientsCount(ctx, healthyCount.Load())
+
 	if healthyClients.Load() {
 		mc.lastHealthy.Store(time.Now().Unix())
 		return nil
@@ -407,8 +418,14 @@ func (mc *MultiClient) Close() error {
 // and it's possible that clients go up and down several times, therefore there should be no limit.
 // It must be called with maxTries != 0 from other methods to return an error if all nodes are down.
 func (mc *MultiClient) call(ctx context.Context, f func(client SingleClientProvider) (any, error), maxTries int) (any, error) {
+	method := methodFromContext(ctx)
+	startTime := time.Now()
+
 	if len(mc.clients) == 1 {
-		return f(mc.clients[0]) // no need for mutex because one client is always non-nil
+		client := mc.clients[0] // no need for mutex because one client is always non-nil
+		result, err := f(client)
+		recordMultiClientMethodCall(ctx, method, mc.nodeAddrs[0], time.Since(startTime), err)
+		return result, err
 	}
 
 	// Iterate over the clients in round-robin fashion,
@@ -428,12 +445,13 @@ func (mc *MultiClient) call(ctx context.Context, f func(client SingleClientProvi
 
 			allErrs = errors.Join(allErrs, err)
 			mc.currentClientIndex.Store(int64(nextClientIndex)) // Advance.
+			recordClientSwitch(ctx, mc.nodeAddrs[clientIndex], mc.nodeAddrs[nextClientIndex])
 			continue
 		}
 
 		logger := mc.logger.With(
 			zap.String("addr", mc.nodeAddrs[clientIndex]),
-			zap.String("method", methodFromContext(ctx)))
+			zap.String("method", method))
 
 		// Make sure this client is healthy. This shouldn't cause too many requests because the result is cached.
 		// TODO: Make sure the allowed tolerance doesn't cause issues in log streaming.
@@ -444,12 +462,14 @@ func (mc *MultiClient) call(ctx context.Context, f func(client SingleClientProvi
 
 			allErrs = errors.Join(allErrs, err)
 			mc.currentClientIndex.Store(int64(nextClientIndex)) // Advance.
+			recordClientSwitch(ctx, mc.nodeAddrs[clientIndex], mc.nodeAddrs[nextClientIndex])
 			continue
 		}
 
 		v, err := f(client)
 		if errors.Is(err, ErrClosed) || errors.Is(err, context.Canceled) {
 			logger.Debug("received graceful closure from client", zap.Error(err))
+			recordMultiClientMethodCall(ctx, method, mc.nodeAddrs[clientIndex], time.Since(startTime), err)
 			return v, err
 		}
 
@@ -460,14 +480,19 @@ func (mc *MultiClient) call(ctx context.Context, f func(client SingleClientProvi
 
 			allErrs = errors.Join(allErrs, err)
 			mc.currentClientIndex.Store(int64(nextClientIndex)) // Advance.
+			recordClientSwitch(ctx, mc.nodeAddrs[clientIndex], mc.nodeAddrs[nextClientIndex])
 			continue
 		}
 
 		// Update currentClientIndex to the successful client.
 		mc.currentClientIndex.Store(int64(clientIndex))
+		recordMultiClientMethodCall(ctx, method, mc.nodeAddrs[clientIndex], time.Since(startTime), nil)
 		return v, nil
 	}
 
+	// Record the failure with the last attempted client
+	lastClientIndex := (startingIndex + maxTries - 1) % len(mc.clients)
+	recordMultiClientMethodCall(ctx, method, mc.nodeAddrs[lastClientIndex], time.Since(startTime), allErrs)
 	return nil, fmt.Errorf("all clients failed: %w", allErrs)
 }
 

--- a/eth/executionclient/observability.go
+++ b/eth/executionclient/observability.go
@@ -52,6 +52,45 @@ var (
 			metricName("sync.last_processed_block"),
 			metric.WithUnit("{block_number}"),
 			metric.WithDescription("last processed block by execution client")))
+
+	// MultiClient metrics
+	clientSwitchCounter = observability.NewMetric(
+		meter.Int64Counter(
+			metricName("client.switch"),
+			metric.WithDescription("number of times the execution client has been switched")))
+
+	multiClientMethodCallsCounter = observability.NewMetric(
+		meter.Int64Counter(
+			metricName("multi_client.method_calls"),
+			metric.WithDescription("number of method calls to the multi client")))
+
+	multiClientMethodErrorsCounter = observability.NewMetric(
+		meter.Int64Counter(
+			metricName("multi_client.method_errors"),
+			metric.WithDescription("number of method call errors in the multi client")))
+
+	multiClientMethodDurationHistogram = observability.NewMetric(
+		meter.Float64Histogram(
+			metricName("multi_client.method_duration"),
+			metric.WithUnit("s"),
+			metric.WithDescription("multi client method call duration in seconds"),
+			metric.WithExplicitBucketBoundaries(observability.SecondsHistogramBuckets...)))
+
+	healthyClientsGauge = observability.NewMetric(
+		meter.Int64Gauge(
+			metricName("multi_client.healthy_clients"),
+			metric.WithUnit("{clients}"),
+			metric.WithDescription("number of healthy clients in the multi client")))
+
+	clientInitCounter = observability.NewMetric(
+		meter.Int64Counter(
+			metricName("client.init"),
+			metric.WithDescription("number of times a client was initialized")))
+
+	clientInitErrorCounter = observability.NewMetric(
+		meter.Int64Counter(
+			metricName("client.init_error"),
+			metric.WithDescription("number of times a client initialization failed")))
 )
 
 func metricName(name string) string {
@@ -85,5 +124,50 @@ func resetExecutionClientStatusGauge(ctx context.Context, nodeAddr string) {
 			metric.WithAttributes(semconv.ServerAddress(nodeAddr)),
 			metric.WithAttributes(executionClientStatusAttribute(status)),
 		)
+	}
+}
+
+// recordClientSwitch records a client switch event
+func recordClientSwitch(ctx context.Context, fromAddr, toAddr string) {
+	clientSwitchCounter.Add(ctx, 1,
+		metric.WithAttributes(
+			attribute.String("from_addr", fromAddr),
+			attribute.String("to_addr", toAddr),
+		),
+	)
+}
+
+// recordMultiClientMethodCall records metrics for multi client method calls
+func recordMultiClientMethodCall(ctx context.Context, method string, nodeAddr string, duration time.Duration, err error) {
+	attrs := []attribute.KeyValue{
+		attribute.String("method", method),
+		semconv.ServerAddress(nodeAddr),
+	}
+
+	multiClientMethodCallsCounter.Add(ctx, 1, metric.WithAttributes(attrs...))
+	multiClientMethodDurationHistogram.Record(ctx, duration.Seconds(), metric.WithAttributes(attrs...))
+
+	if err != nil {
+		errorAttrs := append(attrs, attribute.String("error", err.Error()))
+		multiClientMethodErrorsCounter.Add(ctx, 1, metric.WithAttributes(errorAttrs...))
+	}
+}
+
+// recordHealthyClientsCount records the number of healthy clients
+func recordHealthyClientsCount(ctx context.Context, count int64) {
+	healthyClientsGauge.Record(ctx, count)
+}
+
+// recordClientInit records metrics for client initialization
+func recordClientInit(ctx context.Context, nodeAddr string, success bool, err error) {
+	attrs := []attribute.KeyValue{
+		semconv.ServerAddress(nodeAddr),
+	}
+
+	clientInitCounter.Add(ctx, 1, metric.WithAttributes(attrs...))
+
+	if !success {
+		errorAttrs := append(attrs, attribute.String("error", err.Error()))
+		clientInitErrorCounter.Add(ctx, 1, metric.WithAttributes(errorAttrs...))
 	}
 }


### PR DESCRIPTION
Add metrics to track execution client switching and healthiness in the EL multi-client implementation

- Client switch counter
- Method call metrics (count/errors/duration)
- Gauge for healthy client count
- Init success/failure tracking