### PR TITLE
refactor(beacon/goclient): move beacon options from protocol/v2/blockchain/beacon

### DIFF
--- a/beacon/goclient/attest_test.go
+++ b/beacon/goclient/attest_test.go
@@ -192,7 +192,7 @@ func TestGoClient_GetAttestationData_Simple(t *testing.T) {
 
 		client, err := New(
 			zap.NewNop(),
-			beacon.Options{
+			Options{
 				Context:        ctx,
 				Network:        beacon.NewNetwork(types.MainNetwork),
 				BeaconNodeAddr: server.URL,
@@ -450,7 +450,7 @@ func createClient(
 	beaconServerURL string,
 	withWeightedAttestationData bool) (*GoClient, error) {
 	client, err := New(zap.NewNop(),
-		beacon.Options{
+		Options{
 			Context:                     ctx,
 			Network:                     beacon.NewNetwork(types.MainNetwork),
 			BeaconNodeAddr:              beaconServerURL,

--- a/beacon/goclient/events_test.go
+++ b/beacon/goclient/events_test.go
@@ -73,7 +73,7 @@ func TestSubscribeToHeadEvents(t *testing.T) {
 }
 
 func eventsTestClient(t *testing.T, serverURL string) *GoClient {
-	server, err := New(zap.NewNop(), beacon.Options{
+	server, err := New(zap.NewNop(), Options{
 		BeaconNodeAddr: serverURL,
 		Context:        context.Background(),
 		Network:        beacon.NewNetwork(types.MainNetwork),

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -185,7 +185,7 @@ type GoClient struct {
 // New init new client and go-client instance
 func New(
 	logger *zap.Logger,
-	opt beaconprotocol.Options,
+	opt Options,
 	operatorDataStore operatorDataStore,
 	slotTickerProvider slotticker.Provider,
 ) (*GoClient, error) {

--- a/beacon/goclient/goclient_test.go
+++ b/beacon/goclient/goclient_test.go
@@ -215,7 +215,7 @@ func mockClient(ctx context.Context, serverURL string, commonTimeout, longTimeou
 func mockClientWithNetwork(ctx context.Context, serverURL string, commonTimeout, longTimeout time.Duration, network types.BeaconNetwork) (beacon.BeaconNode, error) {
 	return New(
 		zap.NewNop(),
-		beacon.Options{
+		Options{
 			Context:        ctx,
 			Network:        beacon.NewNetwork(network),
 			BeaconNodeAddr: serverURL,

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 )
 
-// Options for controller struct creation
+// Options defines beacon client options
 type Options struct {
 	Context                     context.Context
 	Network                     beacon.Network

--- a/beacon/goclient/options.go
+++ b/beacon/goclient/options.go
@@ -1,0 +1,20 @@
+package goclient
+
+import (
+	"context"
+	"time"
+
+	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
+)
+
+// Options for controller struct creation
+type Options struct {
+	Context                     context.Context
+	Network                     beacon.Network
+	BeaconNodeAddr              string `yaml:"BeaconNodeAddr" env:"BEACON_NODE_ADDR" env-required:"true" env-description:"Beacon node URL(s). Multiple nodes are supported via semicolon-separated URLs (e.g. 'http://localhost:5052;http://localhost:5053')"`
+	SyncDistanceTolerance       uint64 `yaml:"SyncDistanceTolerance" env:"BEACON_SYNC_DISTANCE_TOLERANCE" env-default:"4" env-description:"Maximum number of slots behind head considered in-sync"`
+	WithWeightedAttestationData bool   `yaml:"WithWeightedAttestationData" env:"WITH_WEIGHTED_ATTESTATION_DATA" env-default:"false" env-description:"Enable attestation data scoring across multiple beacon nodes"`
+
+	CommonTimeout time.Duration // Optional.
+	LongTimeout   time.Duration // Optional.
+}

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -80,7 +80,7 @@ type config struct {
 	DBOptions                    basedb.Options          `yaml:"db"`
 	SSVOptions                   operator.Options        `yaml:"ssv"`
 	ExecutionClient              executionclient.Options `yaml:"eth1"` // TODO: execution_client in yaml
-	ConsensusClient              beaconprotocol.Options  `yaml:"eth2"` // TODO: consensus_client in yaml
+	ConsensusClient              goclient.Options        `yaml:"eth2"` // TODO: consensus_client in yaml
 	P2pNetworkConfig             p2pv1.Config            `yaml:"p2p"`
 	KeyStore                     KeyStore                `yaml:"KeyStore"`
 	Graffiti                     string                  `yaml:"Graffiti" env:"GRAFFITI" env-description:"Custom graffiti for block proposals" env-default:"ssv.network" `

--- a/protocol/v2/blockchain/beacon/client.go
+++ b/protocol/v2/blockchain/beacon/client.go
@@ -2,7 +2,6 @@ package beacon
 
 import (
 	"context"
-	"time"
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
@@ -55,16 +54,4 @@ type BeaconNode interface {
 	beaconValidator
 	signer // TODO need to handle differently
 	proposer
-}
-
-// Options for controller struct creation
-type Options struct {
-	Context                     context.Context
-	Network                     Network
-	BeaconNodeAddr              string `yaml:"BeaconNodeAddr" env:"BEACON_NODE_ADDR" env-required:"true" env-description:"Beacon node URL(s). Multiple nodes are supported via semicolon-separated URLs (e.g. 'http://localhost:5052;http://localhost:5053')"`
-	SyncDistanceTolerance       uint64 `yaml:"SyncDistanceTolerance" env:"BEACON_SYNC_DISTANCE_TOLERANCE" env-default:"4" env-description:"Maximum number of slots behind head considered in-sync"`
-	WithWeightedAttestationData bool   `yaml:"WithWeightedAttestationData" env:"WITH_WEIGHTED_ATTESTATION_DATA" env-default:"false" env-description:"Enable attestation data scoring across multiple beacon nodes"`
-
-	CommonTimeout time.Duration // Optional.
-	LongTimeout   time.Duration // Optional.
 }


### PR DESCRIPTION
Part of PRs that will replace https://github.com/ssvlabs/ssv/pull/1308