### PR TITLE
beacon/goclient: remove unused operatorDataStore

### DIFF
--- a/beacon/goclient/attest_test.go
+++ b/beacon/goclient/attest_test.go
@@ -19,10 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	operatordatastore "github.com/ssvlabs/ssv/operator/datastore"
 	"github.com/ssvlabs/ssv/operator/slotticker"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
-	registrystorage "github.com/ssvlabs/ssv/registry/storage"
 	"github.com/ssvlabs/ssv/utils/hashmap"
 )
 
@@ -199,7 +197,6 @@ func TestGoClient_GetAttestationData_Simple(t *testing.T) {
 				CommonTimeout:  1 * time.Second,
 				LongTimeout:    1 * time.Second,
 			},
-			operatordatastore.New(&registrystorage.OperatorData{ID: 1}),
 			func() slotticker.SlotTicker {
 				return slotticker.New(zap.NewNop(), slotticker.Config{
 					SlotDuration: 12 * time.Second,
@@ -458,7 +455,6 @@ func createClient(
 			LongTimeout:                 time.Second,
 			WithWeightedAttestationData: withWeightedAttestationData,
 		},
-		operatordatastore.New(&registrystorage.OperatorData{ID: 1}),
 		func() slotticker.SlotTicker {
 			return slotticker.New(zap.NewNop(), slotticker.Config{
 				SlotDuration: 12 * time.Second,

--- a/beacon/goclient/events_test.go
+++ b/beacon/goclient/events_test.go
@@ -78,7 +78,6 @@ func eventsTestClient(t *testing.T, serverURL string) *GoClient {
 		Context:        context.Background(),
 		Network:        beacon.NewNetwork(types.MainNetwork),
 	},
-		tests.MockDataStore{},
 		tests.MockSlotTickerProvider)
 
 	require.NoError(t, err)

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -111,10 +111,6 @@ type MultiClient interface {
 	eth2client.ValidatorLivenessProvider
 }
 
-type operatorDataStore interface {
-	AwaitOperatorID() spectypes.OperatorID
-}
-
 type EventTopic string
 
 const (
@@ -132,8 +128,6 @@ type GoClient struct {
 
 	syncDistanceTolerance phase0.Slot
 	nodeSyncingFn         func(ctx context.Context, opts *api.NodeSyncingOpts) (*api.Response[*apiv1.SyncState], error)
-
-	operatorDataStore operatorDataStore
 
 	// registrationMu synchronises access to registrations
 	registrationMu sync.Mutex
@@ -186,7 +180,6 @@ type GoClient struct {
 func New(
 	logger *zap.Logger,
 	opt beaconprotocol.Options,
-	operatorDataStore operatorDataStore,
 	slotTickerProvider slotticker.Provider,
 ) (*GoClient, error) {
 	logger.Info("consensus client: connecting", fields.Address(opt.BeaconNodeAddr), fields.Network(string(opt.Network.BeaconNetwork)))
@@ -205,7 +198,6 @@ func New(
 		ctx:                   opt.Context,
 		network:               opt.Network,
 		syncDistanceTolerance: phase0.Slot(opt.SyncDistanceTolerance),
-		operatorDataStore:     operatorDataStore,
 		registrations:         map[phase0.BLSPubKey]*validatorRegistration{},
 		attestationDataCache: ttlcache.New(
 			// we only fetch attestation data during the slot of the relevant duty (and never later),

--- a/beacon/goclient/goclient_test.go
+++ b/beacon/goclient/goclient_test.go
@@ -222,7 +222,6 @@ func mockClientWithNetwork(ctx context.Context, serverURL string, commonTimeout,
 			CommonTimeout:  commonTimeout,
 			LongTimeout:    longTimeout,
 		},
-		tests.MockDataStore{},
 		tests.MockSlotTickerProvider,
 	)
 }

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -204,7 +204,7 @@ var StartNodeCmd = &cobra.Command{
 		cfg.ConsensusClient.Context = cmd.Context()
 		cfg.ConsensusClient.Network = networkConfig.Beacon.GetNetwork()
 
-		consensusClient := setupConsensusClient(logger, operatorDataStore, slotTickerProvider)
+		consensusClient := setupConsensusClient(logger, slotTickerProvider)
 
 		executionAddrList := strings.Split(cfg.ExecutionClient.Addr, ";") // TODO: Decide what symbol to use as a separator. Bootnodes are currently separated by ";". Deployment bot currently uses ",".
 		if len(executionAddrList) == 0 {
@@ -721,12 +721,8 @@ func setupP2P(logger *zap.Logger, db basedb.Database) network.P2PNetwork {
 	return n
 }
 
-func setupConsensusClient(
-	logger *zap.Logger,
-	operatorDataStore operatordatastore.OperatorDataStore,
-	slotTickerProvider slotticker.Provider,
-) *goclient.GoClient {
-	cl, err := goclient.New(logger, cfg.ConsensusClient, operatorDataStore, slotTickerProvider)
+func setupConsensusClient(logger *zap.Logger, slotTickerProvider slotticker.Provider) *goclient.GoClient {
+	cl, err := goclient.New(logger, cfg.ConsensusClient, slotTickerProvider)
 	if err != nil {
 		logger.Fatal("failed to create beacon go-client", zap.Error(err),
 			fields.Address(cfg.ConsensusClient.BeaconNodeAddr))


### PR DESCRIPTION
Part of PRs that will replace https://github.com/ssvlabs/ssv/pull/1308
