### PR TITLE
fix(eth/executionclient): flaky TestFetchLogsInBatches when startBlock > endBlockRetry

### DIFF
--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -145,19 +145,22 @@ func (ec *ExecutionClient) FetchHistoricalLogs(ctx context.Context, fromBlock ui
 	return
 }
 
-// Calls FilterLogs multiple times and batches results to avoid fetching enormous amount of events
+// Calls FilterLogs multiple times and batches results to avoid fetching an enormous number of events.
 func (ec *ExecutionClient) fetchLogsInBatches(ctx context.Context, startBlock, endBlock uint64) (<-chan BlockLogs, <-chan error) {
-	logs := make(chan BlockLogs, defaultLogBuf)
-	errors := make(chan error, 1)
+	if startBlock > endBlock {
+		errCh := make(chan error, 1)
+		errCh <- ErrBadInput
+		close(errCh)
+
+		return nil, errCh
+	}
+
+	logCh := make(chan BlockLogs, defaultLogBuf)
+	errCh := make(chan error, 1)
 
 	go func() {
-		defer close(logs)
-		defer close(errors)
-
-		if startBlock > endBlock {
-			errors <- ErrBadInput
-			return
-		}
+		defer close(logCh)
+		defer close(errCh)
 
 		for fromBlock := startBlock; fromBlock <= endBlock; fromBlock += ec.logBatchSize {
 			toBlock := fromBlock + ec.logBatchSize - 1
@@ -175,7 +178,7 @@ func (ec *ExecutionClient) fetchLogsInBatches(ctx context.Context, startBlock, e
 				ec.logger.Error(elResponseErrMsg,
 					zap.String("method", "eth_getLogs"),
 					zap.Error(err))
-				errors <- err
+				errCh <- err
 				return
 			}
 
@@ -190,11 +193,11 @@ func (ec *ExecutionClient) fetchLogsInBatches(ctx context.Context, startBlock, e
 
 			select {
 			case <-ctx.Done():
-				errors <- ctx.Err()
+				errCh <- ctx.Err()
 				return
 
 			case <-ec.closed:
-				errors <- ErrClosed
+				errCh <- ErrClosed
 				return
 
 			default:
@@ -212,20 +215,20 @@ func (ec *ExecutionClient) fetchLogsInBatches(ctx context.Context, startBlock, e
 				}
 				var highestBlock uint64
 				for _, blockLogs := range PackLogs(validLogs) {
-					logs <- blockLogs
+					logCh <- blockLogs
 					if blockLogs.BlockNumber > highestBlock {
 						highestBlock = blockLogs.BlockNumber
 					}
 				}
-				// Emit empty block logs to indicate that we have advanced to this block.
+				// Emit empty block logCh to indicate that we have advanced to this block.
 				if highestBlock < toBlock {
-					logs <- BlockLogs{BlockNumber: toBlock}
+					logCh <- BlockLogs{BlockNumber: toBlock}
 				}
 			}
 		}
 	}()
 
-	return logs, errors
+	return logCh, errCh
 }
 
 // StreamLogs subscribes to events emitted by the contract.

--- a/registry/storage/validatorstore.go
+++ b/registry/storage/validatorstore.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
+
 	"github.com/ssvlabs/ssv/protocol/v2/types"
 )
 


### PR DESCRIPTION
- **Early bad‑input check**: 
    - moved the `startBlock > endBlock` validation *outside* the goroutine
    - this prevents unnecessary goroutine creation for invalid inputs
    - guarantees immediate and consistent error response
    - eliminates race conditions between error reporting and channel closing
- **Channel naming**: 
    - renamed `logs ➔ logCh` and `errors ➔ errCh` to follow Go best practices (short, describes payload, Ch suffix). 
    - eliminates variable name collision with the standard library `errors` package
- **Comment tweak**:
    - updated function docs
