### PR TITLE
fix(ssvsigner): linter and tests

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -158,7 +158,7 @@ var StartNodeCmd = &cobra.Command{
 			logger := logger.With(zap.String("ssv_signer_endpoint", cfg.SSVSignerEndpoint))
 			logger.Info("using ssv-signer for signing")
 
-			if _, err := url.Parse(cfg.SSVSignerEndpoint); err != nil {
+			if _, err := url.ParseRequestURI(cfg.SSVSignerEndpoint); err != nil {
 				logger.Fatal("invalid ssv signer endpoint format", zap.Error(err))
 			}
 

--- a/ssvsigner/client_test.go
+++ b/ssvsigner/client_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/assert"
@@ -828,13 +827,13 @@ func TestNew(t *testing.T) {
 			assert.Equal(t, expectedBaseURL, client.baseURL)
 
 			if len(tc.opts) > 0 {
-				assert.NotNil(t, client.logger)
+				assert.NotEqual(t, zap.NewNop(), client.logger)
 			} else {
-				assert.Nil(t, client.logger)
+				assert.Equal(t, zap.NewNop(), client.logger)
 			}
 
 			assert.NotNil(t, client.httpClient)
-			assert.Equal(t, 30*time.Second, client.httpClient.Timeout)
+			assert.EqualValues(t, DefaultRequestTimeout, client.httpClient.Timeout)
 		})
 	}
 }

--- a/ssvsigner/cmd/purge-keys/purge-keys.go
+++ b/ssvsigner/cmd/purge-keys/purge-keys.go
@@ -13,8 +13,9 @@ import (
 
 	"github.com/alecthomas/kong"
 	"github.com/herumi/bls-eth-go-binary/bls"
-	"github.com/ssvlabs/ssv/logging/fields"
 	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/logging/fields"
 
 	"github.com/ssvlabs/ssv/ssvsigner/web3signer"
 )
@@ -52,7 +53,7 @@ func run(logger *zap.Logger, cli CLI) error {
 		return fmt.Errorf("init BLS: %w", err)
 	}
 
-	if _, err := url.Parse(cli.Web3SignerEndpoint); err != nil {
+	if _, err := url.ParseRequestURI(cli.Web3SignerEndpoint); err != nil {
 		return fmt.Errorf("invalid WEB3SIGNER_ENDPOINT format: %w", err)
 	}
 

--- a/ssvsigner/cmd/ssv-signer/ssv-signer.go
+++ b/ssvsigner/cmd/ssv-signer/ssv-signer.go
@@ -84,7 +84,7 @@ func run(logger *zap.Logger, cli CLI) error {
 		return errors.New("neither private key nor keystore provided")
 	}
 
-	if _, err := url.Parse(cli.Web3SignerEndpoint); err != nil {
+	if _, err := url.ParseRequestURI(cli.Web3SignerEndpoint); err != nil {
 		return fmt.Errorf("invalid WEB3SIGNER_ENDPOINT format: %w", err)
 	}
 

--- a/ssvsigner/ekm/local_key_manager_test.go
+++ b/ssvsigner/ekm/local_key_manager_test.go
@@ -360,7 +360,7 @@ func TestEkmListAccounts(t *testing.T) {
 	require.NoError(t, err)
 
 	km, _ := testKeyManager(t, nil, operatorPrivateKey)
-	accounts, err := km.(*LocalKeyManager).slashingProtector.ListAccounts()
+	accounts, err := km.(*LocalKeyManager).ListAccounts()
 	require.NoError(t, err)
 	require.Len(t, accounts, 2)
 }

--- a/ssvsigner/keys/rsaencryption/rsa_encryption_test.go
+++ b/ssvsigner/keys/rsaencryption/rsa_encryption_test.go
@@ -56,6 +56,12 @@ func TestDecryptRSA(t *testing.T) {
 			var data []byte
 
 			if tc.ciphertext == nil {
+				sk, err = PEMToPrivateKey([]byte(rsatesting.PrivKeyPEM))
+				require.NoError(t, err)
+
+				data, err = base64.StdEncoding.DecodeString(rsatesting.PrivKeyBase64)
+				require.NoError(t, err)
+			} else {
 				_, skPem, err := GenerateKeyPairPEM()
 				require.NoError(t, err)
 
@@ -63,12 +69,6 @@ func TestDecryptRSA(t *testing.T) {
 				require.NoError(t, err)
 
 				data = tc.ciphertext
-			} else {
-				sk, err = PEMToPrivateKey([]byte(rsatesting.PrivKeyPEM))
-				require.NoError(t, err)
-
-				data, err = base64.StdEncoding.DecodeString(rsatesting.PrivKeyBase64)
-				require.NoError(t, err)
 			}
 
 			key, err := Decrypt(sk, data)

--- a/ssvsigner/keys/rsaencryption/rsa_encryption_test.go
+++ b/ssvsigner/keys/rsaencryption/rsa_encryption_test.go
@@ -55,13 +55,7 @@ func TestDecryptRSA(t *testing.T) {
 			var err error
 			var data []byte
 
-			if tc.name == "Success" {
-				sk, err = PEMToPrivateKey([]byte(rsatesting.PrivKeyPEM))
-				require.NoError(t, err)
-
-				data, err = base64.StdEncoding.DecodeString(rsatesting.PrivKeyBase64)
-				require.NoError(t, err)
-			} else {
+			if tc.ciphertext == nil {
 				_, skPem, err := GenerateKeyPairPEM()
 				require.NoError(t, err)
 
@@ -69,6 +63,12 @@ func TestDecryptRSA(t *testing.T) {
 				require.NoError(t, err)
 
 				data = tc.ciphertext
+			} else {
+				sk, err = PEMToPrivateKey([]byte(rsatesting.PrivKeyPEM))
+				require.NoError(t, err)
+
+				data, err = base64.StdEncoding.DecodeString(rsatesting.PrivKeyBase64)
+				require.NoError(t, err)
 			}
 
 			key, err := Decrypt(sk, data)

--- a/ssvsigner/keystore/file_test.go
+++ b/ssvsigner/keystore/file_test.go
@@ -112,7 +112,8 @@ func TestLoadOperatorKeystore(t *testing.T) {
 
 		result, err := LoadOperatorKeystore(nonExistentFile, passwordFile)
 		require.Nil(t, result)
-		require.ErrorContains(t, err, "could not read PEM file")
+		require.ErrorContains(t, err, "read keystore file")
+		require.ErrorContains(t, err, "no such file or directory")
 	})
 
 	t.Run("fails when passwordFile does not exist", func(t *testing.T) {
@@ -125,7 +126,8 @@ func TestLoadOperatorKeystore(t *testing.T) {
 
 		result, err := LoadOperatorKeystore(tmpEncryptedFile, passwordFile)
 		require.Nil(t, result)
-		require.ErrorContains(t, err, "could not read password file")
+		require.ErrorContains(t, err, "read password file")
+		require.ErrorContains(t, err, "no such file or directory")
 	})
 
 	t.Run("fails if password file is empty", func(t *testing.T) {
@@ -154,7 +156,7 @@ func TestLoadOperatorKeystore(t *testing.T) {
 		result, err := LoadOperatorKeystore(tmpEncryptedFile, tmpPasswordFile)
 		require.Nil(t, result)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "could not decrypt operator private key keystore")
+		require.Contains(t, err.Error(), "decrypt operator private key keystore")
 	})
 
 	t.Run("fails if PrivateKeyFromBytes returns an error", func(t *testing.T) {
@@ -174,7 +176,7 @@ func TestLoadOperatorKeystore(t *testing.T) {
 		result, err := LoadOperatorKeystore(tmpEncryptedFile, tmpPasswordFile)
 		require.Nil(t, result)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "could not extract operator private key from file")
+		require.Contains(t, err.Error(), "extract operator private key from keystore")
 	})
 
 	t.Run("succeeds with valid files and data", func(t *testing.T) {


### PR DESCRIPTION
https://github.com/ssvlabs/ssv/pull/2028 has been merged with linter and tests broken, it likely happened in one of the latest commits. It happened because the `ssvsigner` subfolder has its own `go.mod`, so it's not covered by the CI checks (similarly to the `e2e` subfolder)