### PR TITLE
networkconfig: narrow config usage

### DIFF
--- a/cli/bootnode/boot_node.go
+++ b/cli/bootnode/boot_node.go
@@ -58,7 +58,7 @@ var StartBootNodeCmd = &cobra.Command{
 		if err != nil {
 			logger.Fatal("failed to get network config", zap.Error(err))
 		}
-		bootNode, err := bootnode.New(networkConfig, cfg.Options)
+		bootNode, err := bootnode.New(networkConfig.SSVConfig, cfg.Options)
 		if err != nil {
 			logger.Fatal("failed to set up boot node", zap.Error(err))
 		}

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -323,7 +323,7 @@ var StartNodeCmd = &cobra.Command{
 		cfg.P2pNetworkConfig.OperatorPubKeyHash = format.OperatorID(operatorDataStore.GetOperatorData().PublicKey)
 		cfg.P2pNetworkConfig.OperatorDataStore = operatorDataStore
 		cfg.P2pNetworkConfig.FullNode = cfg.SSVOptions.ValidatorOptions.FullNode
-		cfg.P2pNetworkConfig.Network = networkConfig
+		cfg.P2pNetworkConfig.NetworkConfig = networkConfig
 
 		validatorsMap := validators.New(cmd.Context())
 
@@ -369,7 +369,7 @@ var StartNodeCmd = &cobra.Command{
 			ws := exporterapi.NewWsServer(cmd.Context(), nil, http.NewServeMux(), cfg.WithPing)
 			cfg.SSVOptions.WS = ws
 			cfg.SSVOptions.WsAPIPort = cfg.WsAPIPort
-			cfg.SSVOptions.ValidatorOptions.NewDecidedHandler = decided.NewStreamPublisher(networkConfig, logger, ws)
+			cfg.SSVOptions.ValidatorOptions.NewDecidedHandler = decided.NewStreamPublisher(logger, networkConfig.SSVConfig.DomainType, ws)
 		}
 
 		cfg.SSVOptions.ValidatorOptions.DutyRoles = []spectypes.BeaconRole{spectypes.BNRoleAttester} // TODO could be better to set in other place
@@ -426,7 +426,7 @@ var StartNodeCmd = &cobra.Command{
 		var doppelgangerHandler doppelganger.Provider
 		if cfg.EnableDoppelgangerProtection {
 			doppelgangerHandler = doppelganger.NewHandler(&doppelganger.Options{
-				Network:            networkConfig,
+				BeaconConfig:       networkConfig.BeaconConfig,
 				BeaconNode:         consensusClient,
 				ValidatorProvider:  nodeStorage.ValidatorStore().WithOperatorID(operatorDataStore.GetOperatorID),
 				SlotTickerProvider: slotTickerProvider,

--- a/doppelganger/doppelganger.go
+++ b/doppelganger/doppelganger.go
@@ -55,7 +55,7 @@ type BeaconNode interface {
 
 // Options contains the configuration options for the Doppelgänger protection.
 type Options struct {
-	Network            networkconfig.NetworkConfig
+	BeaconConfig       networkconfig.BeaconConfig
 	BeaconNode         BeaconNode
 	ValidatorProvider  ValidatorProvider
 	SlotTickerProvider slotticker.Provider
@@ -68,7 +68,7 @@ type handler struct {
 	mu              sync.RWMutex
 	validatorsState map[phase0.ValidatorIndex]*doppelgangerState
 
-	network            networkconfig.NetworkConfig
+	beaconConfig       networkconfig.BeaconConfig
 	beaconNode         BeaconNode
 	validatorProvider  ValidatorProvider
 	slotTickerProvider slotticker.Provider
@@ -78,7 +78,7 @@ type handler struct {
 // NewHandler initializes a new instance of the Doppelgänger protection.
 func NewHandler(opts *Options) *handler {
 	return &handler{
-		network:            opts.Network,
+		beaconConfig:       opts.BeaconConfig,
 		beaconNode:         opts.BeaconNode,
 		validatorProvider:  opts.ValidatorProvider,
 		slotTickerProvider: opts.SlotTickerProvider,
@@ -176,7 +176,7 @@ func (h *handler) Start(ctx context.Context) error {
 	var startEpoch, previousEpoch phase0.Epoch
 	firstRun := true
 	ticker := h.slotTickerProvider()
-	slotsPerEpoch := h.network.SlotsPerEpoch
+	slotsPerEpoch := h.beaconConfig.SlotsPerEpoch
 
 	for {
 		select {
@@ -184,7 +184,7 @@ func (h *handler) Start(ctx context.Context) error {
 			return ctx.Err()
 		case <-ticker.Next():
 			currentSlot := ticker.Slot()
-			currentEpoch := h.network.EstimatedEpochAtSlot(currentSlot)
+			currentEpoch := h.beaconConfig.EstimatedEpochAtSlot(currentSlot)
 
 			buildStr := fmt.Sprintf("e%v-s%v-#%v", currentEpoch, currentSlot, currentSlot%32+1)
 			h.logger.Debug("🛠 ticker event", zap.String("epoch_slot_pos", buildStr))
@@ -233,7 +233,7 @@ func (h *handler) Start(ctx context.Context) error {
 
 func (h *handler) checkLiveness(ctx context.Context, slot phase0.Slot, epoch phase0.Epoch) {
 	// Set a deadline until the start of the next slot, with a 100ms safety margin
-	ctx, cancel := context.WithDeadline(ctx, h.network.GetSlotStartTime(slot+1).Add(100*time.Millisecond))
+	ctx, cancel := context.WithDeadline(ctx, h.beaconConfig.GetSlotStartTime(slot+1).Add(100*time.Millisecond))
 	defer cancel()
 
 	h.mu.RLock()

--- a/doppelganger/doppelganger_test.go
+++ b/doppelganger/doppelganger_test.go
@@ -20,7 +20,7 @@ func newTestDoppelgangerHandler(t *testing.T) *handler {
 	logger := logging.TestLogger(t)
 
 	return NewHandler(&Options{
-		Network:           networkconfig.TestNetwork,
+		BeaconConfig:      networkconfig.TestNetwork.BeaconConfig,
 		BeaconNode:        mockBeaconNode,
 		ValidatorProvider: mockValidatorProvider,
 		Logger:            logger,

--- a/exporter/api/decided/stream.go
+++ b/exporter/api/decided/stream.go
@@ -5,18 +5,18 @@ import (
 	"time"
 
 	"github.com/patrickmn/go-cache"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/exporter/api"
 	"github.com/ssvlabs/ssv/logging/fields"
-	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/protocol/v2/qbft/controller"
 	qbftstorage "github.com/ssvlabs/ssv/protocol/v2/qbft/storage"
 )
 
 // NewStreamPublisher handles incoming newly decided messages.
 // it forward messages to websocket stream, where messages are cached (1m TTL) to avoid flooding
-func NewStreamPublisher(domainTypeProvider networkconfig.NetworkConfig, logger *zap.Logger, ws api.WebSocketServer) controller.NewDecidedHandler {
+func NewStreamPublisher(logger *zap.Logger, domainType spectypes.DomainType, ws api.WebSocketServer) controller.NewDecidedHandler {
 	c := cache.New(time.Minute, time.Minute*3/2)
 	feed := ws.BroadcastFeed()
 	return func(msg qbftstorage.Participation) {
@@ -28,6 +28,6 @@ func NewStreamPublisher(domainTypeProvider networkconfig.NetworkConfig, logger *
 		c.SetDefault(key, true)
 
 		logger.Debug("broadcast decided stream", fields.PubKey(msg.PubKey[:]), fields.Slot(msg.Slot))
-		feed.Send(api.NewParticipantsAPIMsg(domainTypeProvider.DomainType, msg))
+		feed.Send(api.NewParticipantsAPIMsg(domainType, msg))
 	}
 }

--- a/network/discovery/dv5_bootnode.go
+++ b/network/discovery/dv5_bootnode.go
@@ -28,9 +28,9 @@ type Bootnode struct {
 }
 
 // NewBootnode creates a new bootnode
-func NewBootnode(pctx context.Context, logger *zap.Logger, networkCfg networkconfig.NetworkConfig, opts *BootnodeOptions) (*Bootnode, error) {
+func NewBootnode(pctx context.Context, logger *zap.Logger, ssvConfig networkconfig.SSVConfig, opts *BootnodeOptions) (*Bootnode, error) {
 	ctx, cancel := context.WithCancel(pctx)
-	disc, err := createBootnodeDiscovery(ctx, logger, networkCfg, opts)
+	disc, err := createBootnodeDiscovery(ctx, logger, ssvConfig, opts)
 	if err != nil {
 		cancel()
 		return nil, err
@@ -52,13 +52,13 @@ func (b *Bootnode) Close() error {
 	return nil
 }
 
-func createBootnodeDiscovery(ctx context.Context, logger *zap.Logger, networkCfg networkconfig.NetworkConfig, opts *BootnodeOptions) (Service, error) {
+func createBootnodeDiscovery(ctx context.Context, logger *zap.Logger, ssvConfig networkconfig.SSVConfig, opts *BootnodeOptions) (Service, error) {
 	privKey, err := utils.ECDSAPrivateKey(logger.Named(logging.NameBootNode), opts.PrivateKey)
 	if err != nil {
 		return nil, err
 	}
 	discOpts := &Options{
-		NetworkConfig: networkCfg,
+		SSVConfig: ssvConfig,
 		DiscV5Opts: &DiscV5Options{
 			IP:         opts.ExternalIP,
 			BindIP:     "", // net.IPv4zero.String()

--- a/network/discovery/dv5_service_test.go
+++ b/network/discovery/dv5_service_test.go
@@ -122,7 +122,7 @@ func TestCheckPeer(t *testing.T) {
 		ctx:                 ctx,
 		conns:               &mock.MockConnectionIndex{LimitValue: false},
 		subnetsIdx:          subnetIndex,
-		networkConfig:       TestNetwork,
+		ssvConfig:           TestNetwork.SSVConfig,
 		subnets:             mySubnets,
 		discoveredPeersPool: ttl.New[peer.ID, DiscoveredPeer](time.Hour, time.Hour),
 		trimmedRecently:     ttl.New[peer.ID, struct{}](time.Hour, time.Hour),

--- a/network/discovery/service.go
+++ b/network/discovery/service.go
@@ -42,7 +42,7 @@ type Options struct {
 	SubnetsIdx          peers.SubnetsIndex
 	HostAddress         string
 	HostDNS             string
-	NetworkConfig       networkconfig.NetworkConfig
+	SSVConfig           networkconfig.SSVConfig
 	DiscoveredPeersPool *ttl.Map[peer.ID, DiscoveredPeer]
 	TrimmedRecently     *ttl.Map[peer.ID, struct{}]
 }

--- a/network/discovery/service_test.go
+++ b/network/discovery/service_test.go
@@ -34,7 +34,7 @@ func TestNewDiscV5Service(t *testing.T) {
 	assert.NotNil(t, dvs.dv5Listener)
 	assert.NotNil(t, dvs.conns)
 	assert.NotNil(t, dvs.subnetsIdx)
-	assert.NotNil(t, dvs.networkConfig)
+	assert.NotNil(t, dvs.ssvConfig)
 
 	// Check bootnodes
 	CheckBootnodes(t, dvs, testNetConfig)
@@ -145,7 +145,7 @@ func TestDiscV5Service_PublishENR(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	opts := testingDiscoveryOptions(t, testNetConfig)
+	opts := testingDiscoveryOptions(t, testNetConfig.SSVConfig)
 	dvs, err := newDiscV5Service(ctx, testLogger, opts)
 	require.NoError(t, err)
 
@@ -159,7 +159,7 @@ func TestDiscV5Service_PublishENR(t *testing.T) {
 	checkLocalNodeDomainTypeAlignment(t, localNode, testNetConfig)
 
 	// Change network config
-	dvs.networkConfig = networkconfig.HoleskyStage
+	dvs.ssvConfig = networkconfig.HoleskyStage.SSVConfig
 	// Test PublishENR method
 	dvs.PublishENR(logger)
 
@@ -172,7 +172,7 @@ func TestDiscV5Service_Bootstrap(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	opts := testingDiscoveryOptions(t, testNetConfig)
+	opts := testingDiscoveryOptions(t, testNetConfig.SSVConfig)
 
 	dvs, err := newDiscV5Service(testCtx, testLogger, opts)
 	require.NoError(t, err)
@@ -289,7 +289,7 @@ func TestDiscV5ServiceListenerType(t *testing.T) {
 
 	t.Run("Post-Fork", func(t *testing.T) {
 		netConfig := PostForkNetworkConfig()
-		dvs := testingDiscoveryWithNetworkConfig(t, netConfig)
+		dvs := testingDiscoveryWithNetworkConfig(t, netConfig.SSVConfig)
 
 		// Check listener type
 		_, ok := dvs.dv5Listener.(*forkingDV5Listener)
@@ -309,7 +309,7 @@ func TestDiscV5ServiceListenerType(t *testing.T) {
 	t.Run("Pre-Fork", func(t *testing.T) {
 
 		netConfig := PreForkNetworkConfig()
-		dvs := testingDiscoveryWithNetworkConfig(t, netConfig)
+		dvs := testingDiscoveryWithNetworkConfig(t, netConfig.SSVConfig)
 
 		// Check listener type
 		_, ok := dvs.dv5Listener.(*discover.UDPv5)

--- a/network/discovery/util_test.go
+++ b/network/discovery/util_test.go
@@ -43,7 +43,7 @@ var (
 )
 
 // Options for the discovery service
-func testingDiscoveryOptions(t *testing.T, networkConfig networkconfig.NetworkConfig) *Options {
+func testingDiscoveryOptions(t *testing.T, ssvConfig networkconfig.SSVConfig) *Options {
 	// Generate key
 	privKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -57,7 +57,7 @@ func testingDiscoveryOptions(t *testing.T, networkConfig networkconfig.NetworkCo
 		Port:          testPort,
 		TCPPort:       testTCPPort,
 		NetworkKey:    privKey,
-		Bootnodes:     networkConfig.Bootnodes,
+		Bootnodes:     ssvConfig.Bootnodes,
 		Subnets:       mockSubnets(1),
 		EnableLogging: false,
 	}
@@ -71,15 +71,15 @@ func testingDiscoveryOptions(t *testing.T, networkConfig networkconfig.NetworkCo
 		DiscV5Opts:          discV5Opts,
 		ConnIndex:           connectionIndex,
 		SubnetsIdx:          subnetsIndex,
-		NetworkConfig:       networkConfig,
+		SSVConfig:           ssvConfig,
 		DiscoveredPeersPool: ttl.New[peer.ID, DiscoveredPeer](time.Hour, time.Hour),
 		TrimmedRecently:     ttl.New[peer.ID, struct{}](time.Hour, time.Hour),
 	}
 }
 
 // Testing discovery with a given NetworkConfig
-func testingDiscoveryWithNetworkConfig(t *testing.T, netConfig networkconfig.NetworkConfig) *DiscV5Service {
-	opts := testingDiscoveryOptions(t, netConfig)
+func testingDiscoveryWithNetworkConfig(t *testing.T, ssvConfig networkconfig.SSVConfig) *DiscV5Service {
+	opts := testingDiscoveryOptions(t, ssvConfig)
 	dvs, err := newDiscV5Service(testCtx, testLogger, opts)
 	require.NoError(t, err)
 	require.NotNil(t, dvs)
@@ -88,7 +88,7 @@ func testingDiscoveryWithNetworkConfig(t *testing.T, netConfig networkconfig.Net
 
 // Testing discovery service
 func testingDiscovery(t *testing.T) *DiscV5Service {
-	return testingDiscoveryWithNetworkConfig(t, testNetConfig)
+	return testingDiscoveryWithNetworkConfig(t, testNetConfig.SSVConfig)
 }
 
 // NetworkConfig with fork epoch

--- a/network/p2p/config.go
+++ b/network/p2p/config.go
@@ -74,7 +74,7 @@ type Config struct {
 	// NodeStorage is used to get operator metadata.
 	NodeStorage storage.Storage
 	// Network defines a network configuration.
-	Network networkconfig.NetworkConfig
+	NetworkConfig networkconfig.NetworkConfig
 	// MessageValidator validates incoming messages.
 	MessageValidator validation.MessageValidator
 
@@ -183,12 +183,12 @@ func (c *Config) configureAddrs(logger *zap.Logger, opts []libp2p.Option) ([]lib
 func (c *Config) TransformBootnodes() []string {
 
 	if c.Bootnodes == "" {
-		return c.Network.Bootnodes
+		return c.NetworkConfig.Bootnodes
 	}
 
 	// extend additional bootnodes from config
 	extraBootnodes := strings.Split(c.Bootnodes, ";")
-	return append(extraBootnodes, c.Network.Bootnodes...)
+	return append(extraBootnodes, c.NetworkConfig.Bootnodes...)
 }
 
 func userAgent(fromCfg string) string {

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -589,9 +589,9 @@ func (n *p2pNetwork) UpdateScoreParams(logger *zap.Logger) {
 
 	// function to get the starting time of the next epoch
 	nextEpochStartingTime := func() time.Time {
-		currEpoch := n.cfg.Network.EstimatedCurrentEpoch()
+		currEpoch := n.cfg.NetworkConfig.EstimatedCurrentEpoch()
 		nextEpoch := currEpoch + 1
-		return n.cfg.Network.EpochStartTime(nextEpoch)
+		return n.cfg.NetworkConfig.EpochStartTime(nextEpoch)
 	}
 
 	// Create timer that triggers on the beginning of the next epoch

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -189,7 +189,7 @@ func (n *p2pNetwork) setupPeerServices(logger *zap.Logger) error {
 	if err != nil {
 		return err
 	}
-	d := n.cfg.Network.DomainType
+	d := n.cfg.NetworkConfig.DomainType
 	domain := "0x" + hex.EncodeToString(d[:])
 	self := records.NewNodeInfo(domain)
 	self.Metadata = &records.NodeMetadata{
@@ -218,7 +218,7 @@ func (n *p2pNetwork) setupPeerServices(logger *zap.Logger) error {
 
 	// Handshake filters
 	filters := func() []connections.HandshakeFilter {
-		newDomain := n.cfg.Network.DomainType
+		newDomain := n.cfg.NetworkConfig.DomainType
 		newDomainString := "0x" + hex.EncodeToString(newDomain[:])
 		return []connections.HandshakeFilter{
 			connections.NetworkIDFilter(newDomainString),
@@ -234,7 +234,7 @@ func (n *p2pNetwork) setupPeerServices(logger *zap.Logger) error {
 		SubnetsIdx:      n.idx,
 		IDService:       ids,
 		Network:         n.host.Network(),
-		DomainType:      n.cfg.Network.DomainType,
+		DomainType:      n.cfg.NetworkConfig.DomainType,
 		SubnetsProvider: n.ActiveSubnets,
 	}, filters)
 
@@ -289,7 +289,7 @@ func (n *p2pNetwork) setupDiscovery(logger *zap.Logger) error {
 		SubnetsIdx:          n.idx,
 		HostAddress:         n.cfg.HostAddress,
 		HostDNS:             n.cfg.HostDNS,
-		NetworkConfig:       n.cfg.Network,
+		SSVConfig:           n.cfg.NetworkConfig.SSVConfig,
 		DiscoveredPeersPool: n.discoveredPeersPool,
 		TrimmedRecently:     n.trimmedRecently,
 	}
@@ -306,12 +306,11 @@ func (n *p2pNetwork) setupDiscovery(logger *zap.Logger) error {
 
 func (n *p2pNetwork) setupPubsub(logger *zap.Logger) (topics.Controller, error) {
 	cfg := &topics.PubSubConfig{
-		NetworkConfig: n.cfg.Network,
-		Host:          n.host,
-		TraceLog:      n.cfg.PubSubTrace,
-		MsgValidator:  n.msgValidator,
-		MsgHandler:    n.handlePubsubMessages(logger),
-		ScoreIndex:    n.idx,
+		Host:         n.host,
+		TraceLog:     n.cfg.PubSubTrace,
+		MsgValidator: n.msgValidator,
+		MsgHandler:   n.handlePubsubMessages(logger),
+		ScoreIndex:   n.idx,
 		//Discovery: n.disc,
 		OutboundQueueSize:   n.cfg.PubsubOutQueueSize,
 		ValidationQueueSize: n.cfg.PubsubValidationQueueSize,
@@ -330,7 +329,7 @@ func (n *p2pNetwork) setupPubsub(logger *zap.Logger) (topics.Controller, error) 
 		cfg.ScoreIndex = nil
 	}
 
-	midHandler := topics.NewMsgIDHandler(n.ctx, n.cfg.Network, time.Minute*2)
+	midHandler := topics.NewMsgIDHandler(n.ctx, time.Minute*2)
 	n.msgResolver = midHandler
 	cfg.MsgIDHandler = midHandler
 	go cfg.MsgIDHandler.Start()

--- a/network/p2p/test_utils.go
+++ b/network/p2p/test_utils.go
@@ -55,7 +55,7 @@ func (ln *LocalNet) WithBootnode(ctx context.Context, logger *zap.Logger) error 
 	if err != nil {
 		return err
 	}
-	bn, err := discovery.NewBootnode(ctx, logger, networkconfig.TestNetwork, &discovery.BootnodeOptions{
+	bn, err := discovery.NewBootnode(ctx, logger, networkconfig.TestNetwork.SSVConfig, &discovery.BootnodeOptions{
 		PrivateKey: hex.EncodeToString(b),
 		ExternalIP: "127.0.0.1",
 		Port:       ln.udpRand.Next(13001, 13999),
@@ -187,7 +187,7 @@ func (ln *LocalNet) NewTestP2pNetwork(ctx context.Context, nodeIndex uint64, key
 		signatureVerifier,
 		phase0.Epoch(0),
 	)
-	cfg.Network = networkconfig.TestNetwork
+	cfg.NetworkConfig = networkconfig.TestNetwork
 	if options.TotalValidators > 0 {
 		cfg.GetValidatorStats = func() (uint64, uint64, uint64, error) {
 			return options.TotalValidators, options.ActiveValidators, options.MyValidators, nil

--- a/network/topics/controller_test.go
+++ b/network/topics/controller_test.go
@@ -385,7 +385,7 @@ func newPeer(ctx context.Context, logger *zap.Logger, t *testing.T, msgValidator
 	var p *P
 	var midHandler topics.MsgIDHandler
 	if msgID {
-		midHandler = topics.NewMsgIDHandler(ctx, networkconfig.TestNetwork, 2*time.Minute)
+		midHandler = topics.NewMsgIDHandler(ctx, 2*time.Minute)
 		go midHandler.Start()
 	}
 	cfg := &topics.PubSubConfig{

--- a/network/topics/msg_id.go
+++ b/network/topics/msg_id.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/logging/fields"
-	"github.com/ssvlabs/ssv/networkconfig"
 )
 
 const (
@@ -55,23 +54,21 @@ type msgIDEntry struct {
 
 // msgIDHandler implements MsgIDHandler
 type msgIDHandler struct {
-	networkConfig networkconfig.NetworkConfig
-	ctx           context.Context
-	added         chan addedEvent
-	ids           map[string]*msgIDEntry
-	locker        sync.Locker
-	ttl           time.Duration
+	ctx    context.Context
+	added  chan addedEvent
+	ids    map[string]*msgIDEntry
+	locker sync.Locker
+	ttl    time.Duration
 }
 
 // NewMsgIDHandler creates a new MsgIDHandler
-func NewMsgIDHandler(ctx context.Context, networkConfig networkconfig.NetworkConfig, ttl time.Duration) MsgIDHandler {
+func NewMsgIDHandler(ctx context.Context, ttl time.Duration) MsgIDHandler {
 	handler := &msgIDHandler{
-		networkConfig: networkConfig,
-		ctx:           ctx,
-		added:         make(chan addedEvent, msgIDHandlerBufferSize),
-		ids:           make(map[string]*msgIDEntry),
-		locker:        &sync.Mutex{},
-		ttl:           ttl,
+		ctx:    ctx,
+		added:  make(chan addedEvent, msgIDHandlerBufferSize),
+		ids:    make(map[string]*msgIDEntry),
+		locker: &sync.Mutex{},
+		ttl:    ttl,
 	}
 	return handler
 }

--- a/network/topics/pubsub.go
+++ b/network/topics/pubsub.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/peers"
 	"github.com/ssvlabs/ssv/network/topics/params"
-	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/registry/storage"
 )
 
@@ -46,8 +45,6 @@ const (
 
 // PubSubConfig is the needed config to instantiate pubsub
 type PubSubConfig struct {
-	NetworkConfig networkconfig.NetworkConfig
-
 	Host        host.Host
 	TraceLog    bool
 	StaticPeers []peer.AddrInfo

--- a/utils/boot_node/node.go
+++ b/utils/boot_node/node.go
@@ -49,11 +49,11 @@ type bootNode struct {
 	externalIP  string
 	tcpPort     uint16
 	dbPath      string
-	network     networkconfig.NetworkConfig
+	ssvConfig   networkconfig.SSVConfig
 }
 
 // New is the constructor of ssvNode
-func New(networkConfig networkconfig.NetworkConfig, opts Options) (Node, error) {
+func New(ssvConfig networkconfig.SSVConfig, opts Options) (Node, error) {
 	return &bootNode{
 		privateKey:  opts.PrivateKey,
 		discv5port:  opts.UDPPort,
@@ -61,7 +61,7 @@ func New(networkConfig networkconfig.NetworkConfig, opts Options) (Node, error) 
 		externalIP:  opts.ExternalIP,
 		tcpPort:     opts.TCPPort,
 		dbPath:      opts.DbPath,
-		network:     networkConfig,
+		ssvConfig:   ssvConfig,
 	}, nil
 }
 
@@ -107,8 +107,8 @@ func (n *bootNode) Start(ctx context.Context, logger *zap.Logger) error {
 	node := listener.LocalNode().Node()
 	logger.Info("Running",
 		zap.String("node", node.String()),
-		zap.String("network", n.network.Name),
-		fields.ProtocolID(n.network.DiscoveryProtocolID),
+		zap.Any("domain", n.ssvConfig.DomainType),
+		fields.ProtocolID(n.ssvConfig.DiscoveryProtocolID),
 	)
 
 	handler := &handler{
@@ -166,7 +166,7 @@ func (n *bootNode) createListener(logger *zap.Logger, ipAddr string, port uint16
 
 	listener, err := discover.ListenV5(conn, localNode, discover.Config{
 		PrivateKey:   privateKey,
-		V5ProtocolID: &n.network.DiscoveryProtocolID,
+		V5ProtocolID: &n.ssvConfig.DiscoveryProtocolID,
 	})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Use SSV/Beacon configs instead of NetworkConfig where possible

Part of PRs that will replace https://github.com/ssvlabs/ssv/pull/1308

Depends on https://github.com/ssvlabs/ssv/pull/2145
