### PR TITLE
executionclient: fix log streaming logic

### DIFF
--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -439,7 +439,7 @@ func (ec *ExecutionClient) streamLogsToChan(ctx context.Context, logCh chan<- Bl
 			logStream, fetchErrors := ec.fetchLogsInBatches(ctx, fromBlock, toBlock)
 			for block := range logStream {
 				logCh <- block
-				fromBlock = max(fromBlock, block.BlockNumber+1)
+				fromBlock = block.BlockNumber + 1
 			}
 			if err := <-fetchErrors; err != nil {
 				// If we get an error while fetching, we return the last block we fetched.

--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -229,9 +229,7 @@ func (ec *ExecutionClient) fetchLogsInBatches(ctx context.Context, startBlock, e
 }
 
 // StreamLogs subscribes to events emitted by the contract.
-func (ec *ExecutionClient) StreamLogs(ctx context.Context, fromBlockInputValue uint64) <-chan BlockLogs {
-	fromBlock := fromBlockInputValue
-
+func (ec *ExecutionClient) StreamLogs(ctx context.Context, fromBlock uint64) <-chan BlockLogs {
 	logs := make(chan BlockLogs)
 
 	go func() {

--- a/eth/executionclient/mocks.go
+++ b/eth/executionclient/mocks.go
@@ -378,16 +378,16 @@ func (mr *MockSingleClientProviderMockRecorder) SyncProgress(ctx any) *gomock.Ca
 }
 
 // streamLogsToChan mocks base method.
-func (m *MockSingleClientProvider) streamLogsToChan(ctx context.Context, logs chan<- BlockLogs, fromBlock uint64) (uint64, error) {
+func (m *MockSingleClientProvider) streamLogsToChan(ctx context.Context, logCh chan<- BlockLogs, fromBlock uint64) (uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "streamLogsToChan", ctx, logs, fromBlock)
+	ret := m.ctrl.Call(m, "streamLogsToChan", ctx, logCh, fromBlock)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // streamLogsToChan indicates an expected call of streamLogsToChan.
-func (mr *MockSingleClientProviderMockRecorder) streamLogsToChan(ctx, logs, fromBlock any) *gomock.Call {
+func (mr *MockSingleClientProviderMockRecorder) streamLogsToChan(ctx, logCh, fromBlock any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "streamLogsToChan", reflect.TypeOf((*MockSingleClientProvider)(nil).streamLogsToChan), ctx, logs, fromBlock)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "streamLogsToChan", reflect.TypeOf((*MockSingleClientProvider)(nil).streamLogsToChan), ctx, logCh, fromBlock)
 }

--- a/eth/executionclient/multi_client.go
+++ b/eth/executionclient/multi_client.go
@@ -261,10 +261,6 @@ func (mc *MultiClient) StreamLogs(ctx context.Context, fromBlock uint64) <-chan 
 						return nextBlockToProcess, err
 					}
 
-					if err == nil {
-						return nil, errors.New("streamLogsToChan halted without an error")
-					}
-
 					fromBlock = nextBlockToProcess
 					return nil, err
 				}

--- a/eth/executionclient/multi_client.go
+++ b/eth/executionclient/multi_client.go
@@ -258,7 +258,7 @@ func (mc *MultiClient) StreamLogs(ctx context.Context, fromBlock uint64) <-chan 
 				f := func(client SingleClientProvider) (any, error) {
 					nextBlockToProcess, err := client.streamLogsToChan(ctx, logs, fromBlock)
 					if errors.Is(err, ErrClosed) || errors.Is(err, context.Canceled) {
-						return nextBlockToProcess, err
+						return nil, err
 					}
 
 					fromBlock = nextBlockToProcess

--- a/eth/executionclient/multi_client_test.go
+++ b/eth/executionclient/multi_client_test.go
@@ -307,7 +307,7 @@ func TestMultiClient_StreamLogs(t *testing.T) {
 		DoAndReturn(func(_ context.Context, out chan<- BlockLogs, fromBlock uint64) (uint64, error) {
 			out <- BlockLogs{BlockNumber: 200}
 			out <- BlockLogs{BlockNumber: 201}
-			return 201, nil // Success
+			return 202, nil // Success
 		}).
 		Times(1)
 
@@ -388,7 +388,7 @@ func TestMultiClient_StreamLogs_Success(t *testing.T) {
 		DoAndReturn(func(_ context.Context, out chan<- BlockLogs, fromBlock uint64) (uint64, error) {
 			out <- BlockLogs{BlockNumber: 200}
 			out <- BlockLogs{BlockNumber: 201}
-			return 201, nil
+			return 202, nil
 		}).
 		Times(1)
 
@@ -474,7 +474,7 @@ func TestMultiClient_StreamLogs_Failover(t *testing.T) {
 			DoAndReturn(func(_ context.Context, out chan<- BlockLogs, fromBlock uint64) (uint64, error) {
 				out <- BlockLogs{BlockNumber: 200}
 				out <- BlockLogs{BlockNumber: 201}
-				return 201, errors.New("network error") // Triggers failover
+				return 202, errors.New("network error") // Triggers failover
 			}).
 			Times(1),
 
@@ -484,7 +484,7 @@ func TestMultiClient_StreamLogs_Failover(t *testing.T) {
 			streamLogsToChan(gomock.Any(), gomock.Any(), uint64(202)).
 			DoAndReturn(func(_ context.Context, out chan<- BlockLogs, fromBlock uint64) (uint64, error) {
 				out <- BlockLogs{BlockNumber: 202}
-				return 202, ErrClosed // Reference exported ErrClosed
+				return 203, ErrClosed // Reference exported ErrClosed
 			}).
 			Times(1),
 	)
@@ -622,14 +622,14 @@ func TestMultiClient_StreamLogs_MultipleFailoverAttempts(t *testing.T) {
 		mockClient1.
 			EXPECT().
 			streamLogsToChan(gomock.Any(), gomock.Any(), uint64(200)).
-			Return(uint64(0), errors.New("network error")).
+			Return(uint64(200), errors.New("network error")).
 			Times(1),
 
 		// Setup mockClient2 to fail with fromBlock=200
 		mockClient2.
 			EXPECT().
 			streamLogsToChan(gomock.Any(), gomock.Any(), uint64(200)).
-			Return(uint64(0), errors.New("network error")).
+			Return(uint64(200), errors.New("network error")).
 			Times(1),
 
 		// Setup mockClient3 to handle fromBlock=200
@@ -638,7 +638,7 @@ func TestMultiClient_StreamLogs_MultipleFailoverAttempts(t *testing.T) {
 			streamLogsToChan(gomock.Any(), gomock.Any(), uint64(200)).
 			DoAndReturn(func(_ context.Context, out chan<- BlockLogs, fromBlock uint64) (uint64, error) {
 				out <- BlockLogs{BlockNumber: 200}
-				return 200, nil
+				return 201, nil
 			}).
 			Times(1),
 	)


### PR DESCRIPTION
Fix bug with increasing `fromBlock` when we shouldn't increase it. `streamLogsToChan` currently returns the last block it fetched even if it errored. The new logic returns the next block to process