### PR TITLE
chore(eventhandler): remove unused beacon node attribute

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -963,7 +963,6 @@ func syncContractEvents(
 		operatorDataStore,
 		operatorDecrypter,
 		keyManager,
-		cfg.SSVOptions.ValidatorOptions.Beacon,
 		doppelgangerHandler,
 		eventhandler.WithFullNode(),
 		eventhandler.WithLogger(logger),

--- a/eth/ethtest/utils_test.go
+++ b/eth/ethtest/utils_test.go
@@ -26,7 +26,6 @@ import (
 	operatorstorage "github.com/ssvlabs/ssv/operator/storage"
 	"github.com/ssvlabs/ssv/operator/validator"
 	"github.com/ssvlabs/ssv/operator/validator/mocks"
-	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	registrystorage "github.com/ssvlabs/ssv/registry/storage"
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 	"github.com/ssvlabs/ssv/ssvsigner/keys"
@@ -171,7 +170,6 @@ func setupEventHandler(
 	}
 
 	ctrl := gomock.NewController(t)
-	bc := beacon.NewMockBeaconNode(ctrl)
 
 	contractFilterer, err := contract.NewContractFilterer(ethcommon.Address{}, nil)
 	if err != nil {
@@ -193,7 +191,6 @@ func setupEventHandler(
 			operatorDataStore,
 			operator.privateKey,
 			keyManager,
-			bc,
 			dgHandler,
 			eventhandler.WithFullNode(),
 			eventhandler.WithLogger(logger),
@@ -225,7 +222,6 @@ func setupEventHandler(
 		operatorDataStore,
 		operator.privateKey,
 		keyManager,
-		bc,
 		dgHandler,
 		eventhandler.WithFullNode(),
 		eventhandler.WithLogger(logger),

--- a/eth/eventhandler/event_handler.go
+++ b/eth/eventhandler/event_handler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ssvlabs/ssv/observability"
 	operatordatastore "github.com/ssvlabs/ssv/operator/datastore"
 	nodestorage "github.com/ssvlabs/ssv/operator/storage"
-	beaconprotocol "github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 	"github.com/ssvlabs/ssv/ssvsigner/keys"
@@ -70,7 +69,6 @@ type EventHandler struct {
 	operatorDataStore   operatordatastore.OperatorDataStore
 	operatorDecrypter   keys.OperatorDecrypter
 	keyManager          ekm.KeyManager
-	beacon              beaconprotocol.BeaconNode
 	doppelgangerHandler DoppelgangerProvider
 
 	fullNode bool
@@ -85,7 +83,6 @@ func New(
 	operatorDataStore operatordatastore.OperatorDataStore,
 	operatorDecrypter keys.OperatorDecrypter,
 	keyManager ekm.KeyManager,
-	beacon beaconprotocol.BeaconNode,
 	doppelgangerHandler DoppelgangerProvider,
 	opts ...Option,
 ) (*EventHandler, error) {
@@ -97,7 +94,6 @@ func New(
 		operatorDataStore:   operatorDataStore,
 		operatorDecrypter:   operatorDecrypter,
 		keyManager:          keyManager,
-		beacon:              beacon,
 		doppelgangerHandler: doppelgangerHandler,
 		logger:              zap.NewNop(),
 	}

--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/ssvlabs/ssv/operator/validator"
 	"github.com/ssvlabs/ssv/operator/validator/mocks"
 	"github.com/ssvlabs/ssv/operator/validators"
-	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	registrystorage "github.com/ssvlabs/ssv/registry/storage"
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 	"github.com/ssvlabs/ssv/ssvsigner/keys"
@@ -1378,7 +1377,6 @@ func setupEventHandler(t *testing.T, ctx context.Context, logger *zap.Logger, ne
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		bc := beacon.NewMockBeaconNode(ctrl)
 		validatorCtrl := mocks.NewMockController(ctrl)
 
 		contractFilterer, err := contract.NewContractFilterer(ethcommon.Address{}, nil)
@@ -1394,7 +1392,6 @@ func setupEventHandler(t *testing.T, ctx context.Context, logger *zap.Logger, ne
 			operatorDataStore,
 			operator.privateKey,
 			keyManager,
-			bc,
 			dgHandler,
 			WithFullNode(),
 			WithLogger(logger),
@@ -1405,10 +1402,7 @@ func setupEventHandler(t *testing.T, ctx context.Context, logger *zap.Logger, ne
 
 		return eh, validatorCtrl, nil
 	}
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
-	bc := beacon.NewMockBeaconNode(ctrl)
 	validatorCtrl := validator.NewController(logger, validator.ControllerOptions{
 		Context:           ctx,
 		NetworkConfig:     *network,
@@ -1433,7 +1427,6 @@ func setupEventHandler(t *testing.T, ctx context.Context, logger *zap.Logger, ne
 		operatorDataStore,
 		operator.privateKey,
 		keyManager,
-		bc,
 		dgHandler,
 		WithFullNode(),
 		WithLogger(logger))

--- a/eth/eventsyncer/event_syncer_test.go
+++ b/eth/eventsyncer/event_syncer_test.go
@@ -33,7 +33,6 @@ import (
 	operatorstorage "github.com/ssvlabs/ssv/operator/storage"
 	"github.com/ssvlabs/ssv/operator/validator"
 	"github.com/ssvlabs/ssv/operator/validators"
-	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	registrystorage "github.com/ssvlabs/ssv/registry/storage"
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 	"github.com/ssvlabs/ssv/ssvsigner/keys"
@@ -160,10 +159,6 @@ func setupEventHandler(
 		logger.Fatal("could not create new eth-key-manager signer", zap.Error(err))
 	}
 
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	bc := beacon.NewMockBeaconNode(ctrl)
 	validatorCtrl := validator.NewController(logger, validator.ControllerOptions{
 		Context:           ctx,
 		NetworkConfig:     testNetworkConfig,
@@ -188,7 +183,6 @@ func setupEventHandler(
 		operatorDataStore,
 		privateKey,
 		keyManager,
-		bc,
 		dgHandler,
 		eventhandler.WithFullNode(),
 		eventhandler.WithLogger(logger))


### PR DESCRIPTION
Removing it as it was replaced by `networkconfig.NetworkConfig`