### PR TITLE
eth/executionclient: log on connection attempt

### DIFF
--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -98,6 +98,9 @@ func New(ctx context.Context, nodeAddr string, contractAddr ethcommon.Address, o
 	for _, opt := range opts {
 		opt(client)
 	}
+
+	client.logger.Info("execution client: connecting", fields.Address(nodeAddr))
+
 	err := client.connect(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to execution client: %w", err)

--- a/eth/executionclient/multi_client.go
+++ b/eth/executionclient/multi_client.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/ssvlabs/ssv/eth/contract"
+	"github.com/ssvlabs/ssv/logging/fields"
 )
 
 var _ Provider = &MultiClient{}
@@ -101,6 +102,8 @@ func NewMulti(
 	for _, opt := range opts {
 		opt(multiClient)
 	}
+
+	multiClient.logger.Info("execution client: connecting (multi client)", fields.Addresses(nodeAddrs))
 
 	var connected bool
 

--- a/logging/fields/fields.go
+++ b/logging/fields/fields.go
@@ -32,6 +32,7 @@ const (
 	FieldABI                 = "abi"
 	FieldABIVersion          = "abi_version"
 	FieldAddress             = "address"
+	FieldAddresses           = "addresses"
 	FieldBeaconRole          = "beacon_role"
 	FieldBindIP              = "bind_ip"
 	FieldBlock               = "block"
@@ -144,6 +145,10 @@ func AddressURL(val url.URL) zapcore.Field {
 
 func Address(val string) zapcore.Field {
 	return zap.String(FieldAddress, val)
+}
+
+func Addresses(vals []string) zapcore.Field {
+	return zap.Strings(FieldAddresses, vals)
 }
 
 func ENR(val *enode.Node) zapcore.Field {


### PR DESCRIPTION
In the execution client, unlike the consensus client, we have logs on connection/failure, but not on a connection attempt, which might be helpful for debugging issues