### PR TITLE
fix(Dockerfile.multiarch): Cross-compilation wasn't producing correct architecture binaries

### DIFF
--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -3,8 +3,8 @@
 #
 # Global build arguments
 #
-# Note BUILDPLATFORM and TARGETARCH are crucial variables:
-#   see https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
+## Note BUILDPLATFORM and TARGETARCH are crucial variables:
+##   see https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETARCH

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -2,9 +2,8 @@
 # Supports cross-compilation for amd64/arm64/arm targets with proper CGO settings
 #
 # Global build arguments
-#
-## Note BUILDPLATFORM and TARGETARCH are crucial variables:
-##   see https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
+# Note BUILDPLATFORM and TARGETARCH are crucial variables:
+#   see https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETARCH
@@ -17,66 +16,94 @@ FROM --platform=$BUILDPLATFORM golang:1.24 AS base
 # Install essential build tools
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-      curl git ca-certificates make gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
-      gcc-arm-linux-gnueabihf libc6-dev-armhf-cross gcc-x86-64-linux-gnu libc6-dev-amd64-cross \
-      zip unzip bzip2 && \
+      curl \
+      git \
+      ca-certificates \
+      make \
+      gcc-aarch64-linux-gnu \
+      g++-aarch64-linux-gnu \
+      libc6-dev-arm64-cross \
+      gcc-arm-linux-gnueabihf \
+      g++-arm-linux-gnueabihf \
+      libc6-dev-armhf-cross \
+      gcc-x86-64-linux-gnu \
+      g++-x86-64-linux-gnu \
+      libc6-dev-amd64-cross \
+      zip \
+      unzip \
+      bzip2 && \
     rm -rf /var/lib/apt/lists/*
 
-# Set working directory for the build
+# Set working directory and cache Go modules
 WORKDIR /go/src/github.com/ssvlabs/ssv/
-
-# Cache dependencies
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,mode=0755,target=/go/pkg \
     go mod download && go mod verify
 
 #
-# STEP 2: Build executable binary with cross-compilation
+# STEP 2: Builder image
 #
 FROM base AS builder
+ARG TARGETARCH
+ENV GOPATH=/go
+WORKDIR /go/src/github.com/ssvlabs/ssv/
 
 # Copy source code
 COPY . .
 
-# Set up compiler based on target architecture
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-      export CC=x86_64-linux-gnu-gcc; \
-    elif [ "$TARGETARCH" = "arm64" ]; then \
-      export CC=aarch64-linux-gnu-gcc; \
-    elif [ "$TARGETARCH" = "arm" ]; then \
-      export CC=arm-linux-gnueabihf-gcc; \
-    fi && \
+# Pull in target glibc static libs for -static to find libm.a and libmvec.a
+RUN set -eux; \
+    TARGET_DEB_ARCH=$(case "$TARGETARCH" in \
+      amd64) echo amd64 ;; \
+      arm64) echo arm64 ;; \
+      *)    echo armhf ;; \
+    esac); \
+    dpkg --add-architecture "$TARGET_DEB_ARCH"; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends libc6-dev:"$TARGET_DEB_ARCH"; \
+    rm -rf /var/lib/apt/lists/*
+
+# Build the static binary
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,mode=0755,target=/go/pkg \
     COMMIT=$(git rev-parse HEAD) && \
-    VERSION=$(git describe --tags $(git rev-list --tags --max-count=1) --always) && \
-    echo "Building version: $VERSION (commit: $COMMIT)" && \
-    CGO_ENABLED=1 GOOS=linux GOARCH=$TARGETARCH \
-    go install \
-      -tags="blst_enabled" \
-      -ldflags "-X main.Commit=$COMMIT -X main.Version=$VERSION -linkmode external -extldflags '-static -lm'" \
-      ./cmd/ssvnode
+    VERSION=$(git describe --tags --always) && \
+    CC=$(case "$TARGETARCH" in \
+      amd64) echo x86_64-linux-gnu-gcc ;; \
+      arm64) echo aarch64-linux-gnu-gcc ;; \
+      *)    echo arm-linux-gnueabihf-gcc ;; \
+    esac) && \
+    echo "Building version $VERSION (commit $COMMIT) for $TARGETARCH" && \
+    CGO_ENABLED=1 GOOS=linux GOARCH=$TARGETARCH CC=$CC \
+      go build -tags="blst_enabled" \
+        -ldflags "\
+          -X main.Commit=$COMMIT \
+          -X main.Version=$VERSION \
+          -s -w \
+          -linkmode external \
+          -extldflags '-static -lm'" \
+        -o /go/bin/ssvnode ./cmd/ssvnode
 
 #
-# STEP 3: Prepare image to run the binary
+# STEP 3: Runner image
 #
-FROM golang:1.24 AS runner
+FROM --platform=$TARGETPLATFORM golang:1.24 AS runner
 
 # Install minimal runtime dependencies
 RUN apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-  dnsutils && \
-  rm -rf /var/lib/apt/lists/*
+    DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+      dnsutils && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy binary and configuration
 WORKDIR /
 COPY --from=builder /go/bin/ssvnode /go/bin/ssvnode
-COPY ./Makefile .env* ./
+COPY Makefile .env* ./
 COPY config/* ./config/
 
-# Expose port for load balancing
+# Expose ports and set DNS resolver
 EXPOSE 5678 5000 4000/udp
-
-# Force using Go's DNS resolver because Alpine's DNS resolver (when netdns=cgo) may cause issues.
 ENV GODEBUG="netdns=go"
 
 #ENTRYPOINT ["/go/bin/ssvnode"]

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -2,6 +2,7 @@
 # Supports cross-compilation for amd64/arm64/arm targets with proper CGO settings
 #
 # Global build arguments
+#
 # Note BUILDPLATFORM and TARGETARCH are crucial variables:
 #   see https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
 ARG BUILDPLATFORM
@@ -34,19 +35,21 @@ RUN apt-get update && \
       bzip2 && \
     rm -rf /var/lib/apt/lists/*
 
-# Set working directory and cache Go modules
+# Set working directory for the build
 WORKDIR /go/src/github.com/ssvlabs/ssv/
+
+# Cache dependencies
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,mode=0755,target=/go/pkg \
     go mod download && go mod verify
 
 #
-# STEP 2: Builder image
+# STEP 2: Build executable binary with cross-compilation
 #
 FROM base AS builder
+
 ARG TARGETARCH
-ENV GOPATH=/go
 WORKDIR /go/src/github.com/ssvlabs/ssv/
 
 # Copy source code
@@ -68,7 +71,7 @@ RUN set -eux; \
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,mode=0755,target=/go/pkg \
     COMMIT=$(git rev-parse HEAD) && \
-    VERSION=$(git describe --tags --always) && \
+    VERSION=$(git describe --tags $(git rev-list --tags --max-count=1) --always) && \
     CC=$(case "$TARGETARCH" in \
       amd64) echo x86_64-linux-gnu-gcc ;; \
       arm64) echo aarch64-linux-gnu-gcc ;; \


### PR DESCRIPTION
> [!IMPORTANT]  
> This PR should be merged before the next release.
> It solves: https://github.com/ssvlabs/ssv/issues/2182

```md
# Cross-Platform Build Fix

## What We Fixed

### Issue: Cross-compilation wasn't producing correct architecture binaries
When building for ARM64 on an AMD64 host (or vice versa), the resulting binary had the host architecture rather than the target architecture.

## Changes Made

1. **Added Target Architecture Development Libraries**
   - Used `dpkg --add-architecture` to enable multi-arch support
   - Installed `libc6-dev:<target-arch>` packages to provide proper static libraries
   - Ensured availability of architecture-specific `libm.a` and `libmvec.a`
   
2. **Ensured Proper Cross-Compiler Selection**
   - Maintained explicit compiler selection based on `TARGETARCH`
   - Mapped each architecture to its specific cross-compiler:
     - AMD64: `x86_64-linux-gnu-gcc`
     - ARM64: `aarch64-linux-gnu-gcc`
     - ARM: `arm-linux-gnueabihf-gcc`

3. **Fixed Build Environment Variables**
   - Passed correct `CC` variable to Go build process

## Results

- Binary verification confirms correct ELF machine type:
  - ARM64 binaries show machine type `0xB7` (AArch64)
  - AMD64 binaries show machine type `0x3E` (x86-64)
- Docker containers now run on their target platforms without "Exec format error"
- Multi-architecture builds produce compatible binaries for each platform
```


Tests (macOs)
```bash
# ================================================
# VERIFICATION SCRIPT FOR ARM64 BUILD
# ================================================

# Create temporary container to extract binary
docker create --name temp_arm64_container ssvlabs/ssv-node:arm64-test
docker cp temp_arm64_container:/go/bin/ssvnode ./ssvnode_arm64
docker rm temp_arm64_container

# Basic file examination
echo "=== ARM64 Binary Basic Info ==="
file ./ssvnode_arm64

# Check ELF header with hexdump
echo "=== ARM64 Binary Hexdump ==="
hexdump -n 64 -C ./ssvnode_arm64

# Detailed ELF metadata check
echo "=== ARM64 Binary ELF Header ==="
docker run --rm -v $(pwd):/work alpine sh -c "apk add --no-cache binutils && readelf -h /work/ssvnode_arm64"

# Check Docker image metadata
echo "=== ARM64 Docker Image Metadata ==="
docker inspect ssvlabs/ssv-node:arm64-test --format 'Architecture: {{.Architecture}}'
docker inspect ssvlabs/ssv-node:arm64-test --format 'OS/Arch: {{.Os}}/{{.Architecture}}'

# ================================================
# VERIFICATION SCRIPT FOR AMD64 BUILD
# ================================================

# Create temporary container to extract binary
docker create --name temp_amd64_container ssvlabs/ssv-node:amd64-test
docker cp temp_amd64_container:/go/bin/ssvnode ./ssvnode_amd64
docker rm temp_amd64_container

# Basic file examination
echo "=== AMD64 Binary Basic Info ==="
file ./ssvnode_amd64

# Check ELF header with hexdump
echo "=== AMD64 Binary Hexdump ==="
hexdump -n 64 -C ./ssvnode_amd64

# Detailed ELF metadata check
echo "=== AMD64 Binary ELF Header ==="
docker run --rm -v $(pwd):/work alpine sh -c "apk add --no-cache binutils && readelf -h /work/ssvnode_amd64"

# Check Docker image metadata
echo "=== AMD64 Docker Image Metadata ==="
docker inspect ssvlabs/ssv-node:amd64-test --format 'Architecture: {{.Architecture}}'
docker inspect ssvlabs/ssv-node:amd64-test --format 'OS/Arch: {{.Os}}/{{.Architecture}}'
```


## Results:

### ARM64
> === ARM64 Binary Basic Info ===
./ssvnode_arm64: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, BuildID[sha1]=40f6937b6df3717831761c183dc38c08f4fad25d, for GNU/Linux 3.7.0, stripped
> === ARM64 Binary Hexdump ===
00000000  7f 45 4c 46 02 01 01 00  00 00 00 00 00 00 00 00  |.ELF............|
00000010  02 00 **b7 00** 01 00 00 00  00 0b 40 00 00 00 00 00  |..........@.....|
00000020  40 00 00 00 00 00 00 00  78 2d eb 02 00 00 00 00  |@.......x-......|
00000030  00 00 00 00 40 00 38 00  06 00 40 00 23 00 22 00  |....@.8...@.#.".|
00000040

### AMD64
> === AMD64 Binary Basic Info ===
./ssvnode_amd64: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, BuildID[sha1]=557405c9c8779abc2a5f43f8d329e604944a382a, for GNU/Linux 3.2.0, stripped
=== AMD64 Binary Hexdump ===
00000000  7f 45 4c 46 02 01 01 00  00 00 00 00 00 00 00 00  |.ELF............|
00000010  02 00 **3e 00** 01 00 00 00  70 1f 40 00 00 00 00 00  |..>.....p.@.....|
00000020  40 00 00 00 00 00 00 00  88 4e 14 03 00 00 00 00  |@........N......|
00000030  00 00 00 00 40 00 38 00  0a 00 40 00 24 00 23 00  |....@.8...@.$.#.|
00000040