### PR TITLE
chore(go.mod): use replace to reference ssvsigner sub module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/ssvlabs/eth2-key-manager v1.5.2
 	github.com/ssvlabs/ssv-spec v1.1.3
-	github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250424103603-719a5867d010
+	github.com/ssvlabs/ssv/ssvsigner v0.0.0-00010101000000-000000000000
 	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.9.0
 	github.com/wealdtech/go-eth2-types/v2 v2.8.1
@@ -269,3 +269,5 @@ replace github.com/google/flatbuffers => github.com/google/flatbuffers v1.11.0
 replace github.com/dgraph-io/ristretto => github.com/dgraph-io/ristretto v0.1.1-0.20211108053508-297c39e6640f
 
 replace github.com/attestantio/go-eth2-client => github.com/ssvlabs/go-eth2-client v0.6.31-0.20250417062221-9cd9b891d4d6
+
+replace github.com/ssvlabs/ssv/ssvsigner => ./ssvsigner

--- a/go.sum
+++ b/go.sum
@@ -756,8 +756,6 @@ github.com/ssvlabs/go-eth2-client v0.6.31-0.20250417062221-9cd9b891d4d6 h1:26sqP
 github.com/ssvlabs/go-eth2-client v0.6.31-0.20250417062221-9cd9b891d4d6/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/ssvlabs/ssv-spec v1.1.3 h1:46K31kI4/vA7Vp3DaOuN7t2IABAmzeiMniCqYfzzpo8=
 github.com/ssvlabs/ssv-spec v1.1.3/go.mod h1:pto7dDv99uVfCZidiLrrKgFR6VYy6WY3PGI1TiGCsIU=
-github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250424103603-719a5867d010 h1:9jnKiOWtFEokR/wCbvUvsIqlGrJGGAZtMBlpuqV2b3Q=
-github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250424103603-719a5867d010/go.mod h1:HkcbtVHpGBPnJjdWWd08Z3lv7l0VWejJU80yUUqY5Go=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/ssvsigner/go.mod
+++ b/ssvsigner/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/microsoft/go-crypto-openssl v0.2.9
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20240618144021-706c95b2dd15
 	github.com/ssvlabs/eth2-key-manager v1.5.2
-	github.com/ssvlabs/ssv v1.2.1-0.20250422001600-57842541ad25
+	github.com/ssvlabs/ssv v0.0.0-00010101000000-000000000000
 	github.com/ssvlabs/ssv-spec v1.1.3
 	github.com/stretchr/testify v1.9.0
 	github.com/valyala/fasthttp v1.58.0
@@ -132,3 +132,5 @@ require (
 	lukechampine.com/blake3 v1.3.0 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+replace github.com/ssvlabs/ssv => ../

--- a/ssvsigner/go.sum
+++ b/ssvsigner/go.sum
@@ -322,8 +322,6 @@ github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0b
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/ssvlabs/eth2-key-manager v1.5.2 h1:gF+8FJkoV1VXpVCPspyVW/Jdky0kt9Pndk88W8ePqx8=
 github.com/ssvlabs/eth2-key-manager v1.5.2/go.mod h1:yeUzAP+SBJXgeXPiGBrLeLuHIQCpeJZV7Jz3Fwzm/zk=
-github.com/ssvlabs/ssv v1.2.1-0.20250422001600-57842541ad25 h1:Jw69olUGu8oIZf5JGDi69wqdrpBz+cbBi9aPV/CiJKk=
-github.com/ssvlabs/ssv v1.2.1-0.20250422001600-57842541ad25/go.mod h1:dWtV013maPZ1QhqbilGPPBuYNm65+QK/mFB3xbY/Scs=
 github.com/ssvlabs/ssv-spec v1.1.3 h1:46K31kI4/vA7Vp3DaOuN7t2IABAmzeiMniCqYfzzpo8=
 github.com/ssvlabs/ssv-spec v1.1.3/go.mod h1:pto7dDv99uVfCZidiLrrKgFR6VYy6WY3PGI1TiGCsIU=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=


### PR DESCRIPTION
Currently there's an ongoing [PR](https://github.com/ssvlabs/ssv/pull/2194) that introduces pebbledb support to the node.
It refactors the `storage` package into two:

```
storage/kv =>
    storage/badger
    storage/pebble
```

basically removing the `kv` package. Now the `ssvsigner` is referencing `storage/kv` via dependency import:

```github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250424103603-719a5867d010```

because of this fixed version import the refactored branch [fails](https://github.com/ssvlabs/ssv/actions/runs/14865369259/job/41740728862) `go mod tidy` with error:

```Ξ Repo/ssv git:(feat/add-pebbledb-support) ▶ go mod tidy
go: finding module for package github.com/ssvlabs/ssv/storage/kv
go: github.com/ssvlabs/ssv/cli/operator imports
        github.com/ssvlabs/ssv/ssvsigner/ekm tested by
        github.com/ssvlabs/ssv/ssvsigner/ekm.test imports
        github.com/ssvlabs/ssv/storage/kv: no matching versions for query "latest"
```

This PR uses `replace` directive to allow importing/referencing packages from the current branch, and not some remote version. 