### PR TITLE
Removing redundant variable copies in for loop

### DIFF
--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -467,7 +467,6 @@ func (gc *GoClient) multiClientSubmit(
 	submissions := atomic.Int32{}
 	p := pool.New().WithErrors().WithContext(gc.ctx).WithMaxGoroutines(len(gc.clients))
 	for _, client := range gc.clients {
-		client := client
 		p.Go(func(ctx context.Context) error {
 			clientAddress := client.Address()
 			logger := logger.With(zap.String("client_addr", clientAddress))

--- a/beacon/goclient/dataversion_test.go
+++ b/beacon/goclient/dataversion_test.go
@@ -171,7 +171,6 @@ func TestCheckForkValues(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a client with initial fork values.
 			client := &GoClient{

--- a/eth/eventhandler/validation_test.go
+++ b/eth/eventhandler/validation_test.go
@@ -117,7 +117,6 @@ func Test_validateValidatorAddedEvent(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.saved {
 				for _, operator := range tc.operators {

--- a/eth/executionclient/multi_client.go
+++ b/eth/executionclient/multi_client.go
@@ -296,7 +296,6 @@ func (mc *MultiClient) Healthy(ctx context.Context) error {
 	p := pool.New().WithErrors().WithContext(ctx)
 
 	for i := range mc.clients {
-		i := i
 		p.Go(func(ctx context.Context) error {
 			client, err := mc.getClient(ctx, i)
 			if err != nil {

--- a/exporter/api/query_handlers_test.go
+++ b/exporter/api/query_handlers_test.go
@@ -62,7 +62,6 @@ func TestHandleErrorQuery(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			nm := NetworkMessage{
 				Msg: Message{

--- a/identity/store_test.go
+++ b/identity/store_test.go
@@ -49,7 +49,6 @@ func TestSetupPrivateKey(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			db, err := kv.NewInMemory(logging.TestLogger(t), basedb.Options{})
 			require.NoError(t, err)

--- a/message/validation/consensus_validation_test.go
+++ b/message/validation/consensus_validation_test.go
@@ -94,7 +94,6 @@ func TestMessageValidator_currentEstimatedRound(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			mv := &messageValidator{}
 			got, err := mv.currentEstimatedRound(tc.sinceSlotStart)

--- a/message/validation/utils_test.go
+++ b/message/validation/utils_test.go
@@ -49,7 +49,6 @@ func TestMessageValidator_maxRound(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			mv := &messageValidator{}
 			got, err := mv.maxRound(tc.role)

--- a/message/validation/validation_test.go
+++ b/message/validation/validation_test.go
@@ -825,7 +825,6 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 			for role, msgTypes := range tests {
 				for _, msgType := range msgTypes {
-					role, msgType := role, msgType
 					subtestName := fmt.Sprintf("%v/%v", message.RunnerRoleToString(role), message.PartialMsgTypeToString(msgType))
 					t.Run(subtestName, func(t *testing.T) {
 						ds := dutystore.New()
@@ -905,7 +904,6 @@ func Test_ValidateSSVMessage(t *testing.T) {
 
 			for role, msgTypes := range tests {
 				for _, msgType := range msgTypes {
-					role, msgType := role, msgType
 					subtestName := fmt.Sprintf("%v/%v", message.RunnerRoleToString(role), message.PartialMsgTypeToString(msgType))
 					t.Run(subtestName, func(t *testing.T) {
 						ds := dutystore.New()
@@ -1217,7 +1215,6 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		}
 
 		for role, receivedAt := range tests {
-			role, receivedAt := role, receivedAt
 			t.Run(message.RunnerRoleToString(role), func(t *testing.T) {
 				dutyExecutorID := shares.active.ValidatorPubKey[:]
 				if validator.committeeRole(role) {
@@ -1542,7 +1539,6 @@ func Test_ValidateSSVMessage(t *testing.T) {
 		}
 
 		for role, round := range tests {
-			role, round := role, round
 			t.Run(message.RunnerRoleToString(role), func(t *testing.T) {
 				dutyExecutorID := shares.active.ValidatorPubKey[:]
 				if validator.committeeRole(role) {

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -73,8 +73,6 @@ func (o Options) signerStorage(logger *zap.Logger) ekm.Storage {
 func (m Migrations) Run(ctx context.Context, logger *zap.Logger, opt Options) (applied int, err error) {
 	logger.Info("applying migrations", fields.Count(len(m)))
 	for _, migration := range m {
-		migration := migration
-
 		// Skip the migration if it's already completed.
 		obj, _, err := opt.Db.Get(migrationsPrefix, []byte(migration.Name))
 		if err != nil {

--- a/network/commons/subnets_test.go
+++ b/network/commons/subnets_test.go
@@ -60,7 +60,6 @@ func TestSubnetsParsing(t *testing.T) {
 	}
 
 	for _, subtest := range subtests {
-		subtest := subtest
 		t.Run(subtest.name, func(t *testing.T) {
 			s, err := FromString(subtest.str)
 			if subtest.shouldError {

--- a/network/discovery/dv5_service_test.go
+++ b/network/discovery/dv5_service_test.go
@@ -93,7 +93,6 @@ func TestCheckPeer(t *testing.T) {
 
 	// Create the LocalNode instances for the tests.
 	for _, test := range tests {
-		test := test
 		t.Run(test.name+":setup", func(t *testing.T) {
 			// Create a random network key.
 			priv, err := utils.ECDSAPrivateKey(logger, "")
@@ -132,7 +131,6 @@ func TestCheckPeer(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name+":run", func(t *testing.T) {
 			err := dvs.checkPeer(context.TODO(), logger, PeerEvent{
 				Node: test.localNode.Node(),

--- a/network/discovery/subnets_test.go
+++ b/network/discovery/subnets_test.go
@@ -59,7 +59,6 @@ func TestNsToSubnet(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.isSubnet, isSubnet(test.ns))
 

--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -59,7 +59,6 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 	messageValidators := make([]*MockMessageValidator, nodeCount)
 	var mtx sync.Mutex
 	for i := 0; i < nodeCount; i++ {
-		i := i
 		messageValidators[i] = &MockMessageValidator{
 			Accepted: make([]int, nodeCount),
 			Ignored:  make([]int, nodeCount),
@@ -220,8 +219,6 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 	// - node 0, (node 1 OR 3), (node 1 OR 3), node 2
 	// (after excluding itself from this list)
 	for _, node := range vNet.Nodes {
-		node := node
-
 		// Prepare the valid orders, excluding the node itself.
 		validOrders := [][]NodeIndex{
 			{0, 1, 3, 2},

--- a/network/p2p/test_utils.go
+++ b/network/p2p/test_utils.go
@@ -79,8 +79,6 @@ func CreateAndStartLocalNet(pCtx context.Context, logger *zap.Logger, options Lo
 
 		eg, ctx := errgroup.WithContext(pCtx)
 		for i, node := range ln.Nodes {
-			i, node := i, node //hack to avoid closures. price of using error groups
-
 			eg.Go(func() error { //if replace EG to regular goroutines round don't change to second in test
 				if err := node.Start(logger); err != nil {
 					return fmt.Errorf("could not start node %d: %w", i, err)

--- a/network/topics/params/message_rate_test.go
+++ b/network/topics/params/message_rate_test.go
@@ -77,7 +77,6 @@ func TestCalculateMessageRateForTopic(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			msgRate := calculateMessageRateForTopic(tt.args.committees)
 			require.InDelta(t, tt.want, msgRate, tt.want*0.001)

--- a/network/topics/params/scores_test.go
+++ b/network/topics/params/scores_test.go
@@ -57,7 +57,6 @@ func TestTopicScoreParams(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			opts := test.opts()
 			// raw, err := json.MarshalIndent(&opts, "", "\t")

--- a/operator/duties/scheduler.go
+++ b/operator/duties/scheduler.go
@@ -191,8 +191,6 @@ func (s *Scheduler) Start(ctx context.Context, logger *zap.Logger) error {
 
 		// This call is blocking.
 		handler.HandleInitialDuties(ctx)
-
-		handler := handler
 		s.pool.Go(func(ctx context.Context) error {
 			// Wait for the head event subscription to complete before starting the handler.
 			handler.HandleDuties(ctx)
@@ -387,7 +385,6 @@ func (s *Scheduler) HandleHeadEvent(logger *zap.Logger) func(event *eth2apiv1.He
 // ExecuteDuties tries to execute the given duties
 func (s *Scheduler) ExecuteDuties(ctx context.Context, logger *zap.Logger, duties []*spectypes.ValidatorDuty) {
 	for _, duty := range duties {
-		duty := duty
 		logger := s.loggerWithDutyContext(logger, duty)
 		slotDelay := time.Since(s.network.Beacon.GetSlotStartTime(duty.Slot))
 		if slotDelay >= 100*time.Millisecond {

--- a/protocol/v2/qbft/spectest/qbft_mapping_test.go
+++ b/protocol/v2/qbft/spectest/qbft_mapping_test.go
@@ -29,7 +29,6 @@ func TestQBFTMapping(t *testing.T) {
 	}
 
 	for name, test := range untypedTests {
-		name, test := name, test
 		testName := strings.Split(name, "_")[1]
 		testType := strings.Split(name, "_")[0]
 

--- a/protocol/v2/ssv/spectest/ssv_mapping_test.go
+++ b/protocol/v2/ssv/spectest/ssv_mapping_test.go
@@ -55,7 +55,6 @@ func TestSSVMapping(t *testing.T) {
 	}
 
 	for name, test := range untypedTests {
-		name, test := name, test
 		r := prepareTest(t, logger, name, test)
 		if r != nil {
 			t.Run(r.name, func(t *testing.T) {

--- a/protocol/v2/types/ssvshare_test.go
+++ b/protocol/v2/types/ssvshare_test.go
@@ -67,7 +67,6 @@ func TestSSVShare_HasBeaconMetadata(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			require.Equal(t, tc.Result, tc.ShareMetadata.HasBeaconMetadata())
 		})
@@ -93,7 +92,6 @@ func TestValidCommitteeSize(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			for _, size := range tc.sizes {
 				require.Equal(t, tc.valid, ValidCommitteeSize(size))
@@ -154,7 +152,6 @@ func TestSSVShare_IsAttesting(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			result := tc.Share.IsAttesting(tc.Epoch)
 			require.Equal(t, tc.Expected, result)
@@ -211,9 +208,7 @@ func TestSSVShare_IsParticipating(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
-
 			result := tc.Share.IsParticipating(networkconfig.Mainnet, tc.Epoch)
 			require.Equal(t, tc.Expected, result)
 		})
@@ -307,7 +302,6 @@ func TestIsSyncCommitteeEligible(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			result := tc.Share.IsSyncCommitteeEligible(networkconfig.TestNetwork, tc.Epoch)
 			require.Equal(t, tc.Expected, result)

--- a/registry/storage/shares_test.go
+++ b/registry/storage/shares_test.go
@@ -476,7 +476,6 @@ func TestSharesStorage_HighContentionConcurrency(t *testing.T) {
 // Runs the given function as a test with and without storage reopen.
 func testWithStorageReopen(t *testing.T, f func(t *testing.T, storage *testStorage, reopen func(t *testing.T))) {
 	for _, withReopen := range []bool{false, true} {
-		withReopen := withReopen
 		t.Run(fmt.Sprintf("withReopen=%t", withReopen), func(t *testing.T) {
 			logger := logging.TestLogger(t)
 			storage, err := newTestStorage(logger)

--- a/utils/format/format_test.go
+++ b/utils/format/format_test.go
@@ -40,7 +40,6 @@ func TestDomainTypeFromString(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := DomainTypeFromString(tt.input)
 			if tt.wantErr {

--- a/utils/hashmap/hashmap_test.go
+++ b/utils/hashmap/hashmap_test.go
@@ -491,7 +491,6 @@ func TestIssue1682(t *testing.T) {
 			m := New[string, validatorStatus]()
 			var wg sync.WaitGroup
 			for _, cmtID := range cmtIDs {
-				cmtID := cmtID
 				n := 50 + randSeed().Intn(200)
 				for j := 0; j < n; j++ {
 					wg.Add(1)

--- a/utils/ttl/map_test.go
+++ b/utils/ttl/map_test.go
@@ -491,7 +491,6 @@ func TestIssue1682(t *testing.T) {
 			m := New[string, validatorStatus](1*time.Hour, 1*time.Hour)
 			var wg sync.WaitGroup
 			for _, cmtID := range cmtIDs {
-				cmtID := cmtID
 				n := 50 + randSeed().Intn(200)
 				for j := 0; j < n; j++ {
 					wg.Add(1)


### PR DESCRIPTION
# Go version 1.22 and above

- With Go version 1.22 and above, the for loop variables are created newly instead of using their references.
- Go closures now take in the value of the for loop variable instead of the reference in each iteration, thereby removing temporary workarounds like `i := i`.

# Using `copyloopvar`

- Utilised `copyloopvar` as a linter to detect variables in for loop that are copied.

```
go install github.com/karamaru-alpha/copyloopvar/cmd/copyloopvar@latest
go vet -vettool=`which copyloopvar` ./...
```

- Ran ```go vet -vettool=`which copyloopvar` ./...``` after removing the lines with variable copies to ensure complete cleanup.

# List of files and respective lines with redundant variable copies

- This table contains a list of files and respective lines where redundant variable copies were removed.

| File Path                                            |   Line Number | Issue                                                        |
|------------------------------------------------------|---------------|--------------------------------------------------------------|
| beacon/goclient/attest.go                            |           470 | The copy of the 'for' variable "client" can be deleted (Go 1.22+) |
| beacon/goclient/dataversion_test.go                  |           174 | The copy of the 'for' variable "tc" can be deleted (Go 1.22+) |
| identity/store_test.go                               |            52 | The copy of the 'for' variable "test" can be deleted (Go 1.22+) |
| network/commons/subnets_test.go                      |            63 | The copy of the 'for' variable "subtest" can be deleted (Go 1.22+) |
| message/validation/consensus_validation_test.go      |            97 | The copy of the 'for' variable "tc" can be deleted (Go 1.22+) |
| message/validation/utils_test.go                     |            52 | The copy of the 'for' variable "tc" can be deleted (Go 1.22+) |
| message/validation/validation_test.go                |           828 | The copy of the 'for' variable "msgType" can be deleted (Go 1.22+) |
| message/validation/validation_test.go                |           908 | The copy of the 'for' variable "msgType" can be deleted (Go 1.22+) |
| message/validation/validation_test.go                |          1220 | The copy of the 'for' variable "role" can be deleted (Go 1.22+) |
| message/validation/validation_test.go                |          1220 | The copy of the 'for' variable "receivedAt" can be deleted (Go 1.22+) |
| message/validation/validation_test.go                |          1545 | The copy of the 'for' variable "role" can be deleted (Go 1.22+) |
| message/validation/validation_test.go                |          1545 | The copy of the 'for' variable "round" can be deleted (Go 1.22+) |
| network/p2p/test_utils.go                            |            82 | The copy of the 'for' variable "i" can be deleted (Go 1.22+) |
| network/p2p/test_utils.go                            |            82 | The copy of the 'for' variable "node" can be deleted (Go 1.22+) |
| network/p2p/p2p_validation_test.go                   |           222 | The copy of the 'for' variable "node" can be deleted (Go 1.22+) |
| exporter/api/query_handlers_test.go                  |            65 | The copy of the 'for' variable "test" can be deleted (Go 1.22+) |
| network/discovery/dv5_service_test.go                |            96 | The copy of the 'for' variable "test" can be deleted (Go 1.22+) |
| network/discovery/dv5_service_test.go                |           135 | The copy of the 'for' variable "test" can be deleted (Go 1.22+) |
| network/discovery/subnets_test.go                    |            62 | The copy of the 'for' variable "test" can be deleted (Go 1.22+) |
| network/topics/params/message_rate_test.go           |            80 | The copy of the 'for' variable "tt" can be deleted (Go 1.22+) |
| network/topics/params/scores_test.go                 |            60 | The copy of the 'for' variable "test" can be deleted (Go 1.22+) |
| protocol/v2/qbft/spectest/qbft_mapping_test.go       |            32 | The copy of the 'for' variable "name" can be deleted (Go 1.22+) |
| protocol/v2/qbft/spectest/qbft_mapping_test.go       |            32 | The copy of the 'for' variable "test" can be deleted (Go 1.22+) |
| protocol/v2/types/ssvshare_test.go                   |            70 | The copy of the 'for' variable "tc" can be deleted (Go 1.22+) |
| protocol/v2/types/ssvshare_test.go                   |            96 | The copy of the 'for' variable "tc" can be deleted (Go 1.22+) |
| protocol/v2/types/ssvshare_test.go                   |           157 | The copy of the 'for' variable "tc" can be deleted (Go 1.22+) |
| protocol/v2/types/ssvshare_test.go                   |           214 | The copy of the 'for' variable "tc" can be deleted (Go 1.22+) |
| protocol/v2/types/ssvshare_test.go                   |           310 | The copy of the 'for' variable "tc" can be deleted (Go 1.22+) |
| utils/format/format_test.go                          |            43 | The copy of the 'for' variable "tt" can be deleted (Go 1.22+) |
| utils/hashmap/hashmap_test.go                        |           494 | The copy of the 'for' variable "cmtID" can be deleted (Go 1.22+) |
| utils/ttl/map_test.go                                |           494 | The copy of the 'for' variable "cmtID" can be deleted (Go 1.22+) |
| migrations/migrations.go                             |            76 | The copy of the 'for' variable "migration" can be deleted (Go 1.22+) |
| registry/storage/shares_test.go                      |           479 | The copy of the 'for' variable "withReopen" can be deleted (Go 1.22+) |
| protocol/v2/ssv/spectest/ssv_mapping_test.go         |            58 | The copy of the 'for' variable "name" can be deleted (Go 1.22+) |
| protocol/v2/ssv/spectest/ssv_mapping_test.go         |            58 | The copy of the 'for' variable "test" can be deleted (Go 1.22+) |
| operator/duties/scheduler.go                         |           195 | The copy of the 'for' variable "handler" can be deleted (Go 1.22+) |
| operator/duties/scheduler.go                         |           390 | The copy of the 'for' variable "duty" can be deleted (Go 1.22+) |
| eth/eventhandler/validation_test.go                  |           120 | The copy of the 'for' variable "tc" can be deleted (Go 1.22+) |
| eth/executionclient/multi_client.go                  |           299 | The copy of the 'for' variable "i" can be deleted (Go 1.22+) |
| network/p2p/p2p_validation_test.go                   |            62 | The copy of the 'for' variable "i" can be deleted (Go 1.22+) |

# References

- https://github.com/karamaru-alpha/copyloopvar
- https://go.dev/blog/loopvar-preview