### PR TITLE
Configures Renovate to use the stage branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    target-branch: stage
-    schedule:
-      interval: weekly

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "github>ssvlabs/github-settings//shared-configs/renovate.json"
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "github>ssvlabs/github-settings//shared-configs/renovate.json"
+  ],
+  "baseBranches": [
+    "stage"
   ]
 }


### PR DESCRIPTION
Configures Renovate to use the `stage` branch as the base branch for updates. This ensures that dependency updates are first applied and tested against `stage` before being merged into the main branch.