### PR TITLE
fix: subnets count parsing empty string

### DIFF
--- a/network/commons/subnets.go
+++ b/network/commons/subnets.go
@@ -88,6 +88,10 @@ type Subnets struct {
 
 // SubnetsFromString parses a given subnet string
 func SubnetsFromString(subnetsStr string) (Subnets, error) {
+	if len(subnetsStr) == 0 {
+		return ZeroSubnets, nil
+	}
+
 	subnetsStr = strings.TrimPrefix(subnetsStr, "0x")
 	data, err := hex.DecodeString(subnetsStr)
 	if err != nil {


### PR DESCRIPTION
### Description

The SubnetsFromString function was returning an error for empty string instead of just returning zero subnets.