### PR TITLE
fix(network/p2p/p2p_setup.go): scoreParamsFactory not set error in P2P scoring

### DIFF
--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -161,13 +161,16 @@ func (n *p2pNetwork) SetupServices() error {
 	if err := n.setupStreamCtrl(); err != nil {
 		return errors.Wrap(err, "could not setup stream controller")
 	}
+
+	if err := n.setupPeerServices(); err != nil {
+		return errors.Wrap(err, "could not setup peer services")
+	}
+
 	_, err := n.setupPubsub()
 	if err != nil {
 		return errors.Wrap(err, "could not setup topic controller")
 	}
-	if err := n.setupPeerServices(); err != nil {
-		return errors.Wrap(err, "could not setup peer services")
-	}
+
 	if err := n.setupDiscovery(); err != nil {
 		return errors.Wrap(err, "could not setup discovery service")
 	}


### PR DESCRIPTION
The root cause was an incorrect initialization order in `network/p2p/p2p_setup.go` within the `SetupServices` method. The `setupPubsub()` function, which relies on the peer index (n.idx) to correctly initialize topic scoring parameters (including the `scoreParamsFactory`), was being called before `setupPeerServices()`, which is responsible for initializing `n.idx`.

So, `n.idx` was nil at the point `setupPubsub()` was executed. This prevented the `scoreParamsFactory` from being created, leading to the observed error when `UpdateScoreParams()` was subsequently called.

This PR corrects the order by moving the call to `setupPeerServices()` before `setupPubsub()`

after fix:
```go
{"level":"\u001b[35mDEBUG\u001b[0m","time":"2025-05-23T14:30:48.053983Z","name":"P2PNetwork","msg":"updated score parameters successfully"}
```