### PR TITLE
ssvsigner: fix panic on remote signer initialization

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -191,7 +191,7 @@ var StartNodeCmd = &cobra.Command{
 				ssvSignerOptions = append(ssvSignerOptions, ssvsigner.WithTLSConfig(clientConfig))
 			}
 
-			ssvSignerClient := ssvsigner.NewClient(
+			ssvSignerClient = ssvsigner.NewClient(
 				cfg.SSVSigner.Endpoint,
 				ssvSignerOptions...,
 			)


### PR DESCRIPTION
https://github.com/ssvlabs/ssv/pull/2151 seems to have broken remote signer initialization, causing a nil pointer dereference panic