### PR TITLE
[SSV-5] ssvsigner: High CPU Usage and Potential DoS in the Add Validator Flow Due to Unbounded Share Processing

### DIFF
--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -101,7 +101,7 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (err er
 	}()
 
 	if len(shares) > addShareLimit {
-		return fmt.Errorf("too many shares, max %d", addShareLimit)
+		return fmt.Errorf("too many shares, max allowed per request %d", addShareLimit)
 	}
 
 	encodedShares := make([]ShareKeys, 0, len(shares))

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -100,6 +100,10 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (err er
 		c.logger.Debug("requested to add keys to remote signer", fields.Count(len(shares)), zap.Duration("duration", duration), zap.Error(err))
 	}()
 
+	if len(shares) > addShareLimit {
+		return fmt.Errorf("too many shares, max %d", addShareLimit)
+	}
+
 	encodedShares := make([]ShareKeys, 0, len(shares))
 	for _, share := range shares {
 		encodedShares = append(encodedShares, ShareKeys{

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -39,6 +39,10 @@ const (
 	pathOperatorSign     = "/v1/operator/sign"     // TODO: /api/v1/ssv/sign ?
 )
 
+const (
+	addShareLimit = 10
+)
+
 type Server struct {
 	logger          *zap.Logger
 	operatorPrivKey keys.OperatorPrivateKey
@@ -162,6 +166,13 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 	}
 
 	logger = logger.With(zap.Int("req_count", len(req.ShareKeys)))
+
+	if len(req.ShareKeys) > addShareLimit {
+		logger.Warn("requested too many shares to be added")
+		s.writeJSONErr(ctx, logger, fasthttp.StatusBadRequest,
+			fmt.Errorf("requested too many shares to be added: %d", len(req.ShareKeys)))
+		return
+	}
 
 	var importKeystoreReq web3signer.ImportKeystoreRequest
 	for i, share := range req.ShareKeys {

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -40,6 +40,7 @@ const (
 )
 
 const (
+	// Processing one share takes ~0.5-0.8s, so 10 shares seem a reasonable limit.
 	addShareLimit = 10
 )
 

--- a/ssvsigner/server_test.go
+++ b/ssvsigner/server_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 	"unicode"
 
@@ -252,6 +253,27 @@ func (s *ServerTestSuite) TestAddValidator() {
 		assert.Equal(t, fasthttp.StatusInternalServerError, resp.StatusCode())
 
 		s.remoteSigner.ImportError = nil
+	})
+
+	t.Run("too many shares", func(t *testing.T) {
+		tooBigRequest := request
+		for i := 0; i < addShareLimit*2; i++ {
+			sk := new(bls.SecretKey)
+			sk.SetByCSPRNG()
+			pubKey := sk.GetPublicKey().Serialize()
+
+			tooBigRequest.ShareKeys = append(tooBigRequest.ShareKeys, ShareKeys{
+				EncryptedPrivKey: []byte("encrypted_key" + strconv.Itoa(i)),
+				PubKey:           phase0.BLSPubKey(pubKey),
+			})
+		}
+
+		tooBigRequestBody, err := json.Marshal(tooBigRequest)
+		require.NoError(t, err)
+
+		resp, err := s.ServeHTTP("POST", pathValidators, tooBigRequestBody)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusBadRequest, resp.StatusCode())
 	})
 }
 


### PR DESCRIPTION
> Implement a strict limit on the number of shares processed in a single `POST /v1/validators` request (e.g., 5–
10 shares). Clients adding many shares must batch their requests, reducing maximum processing time and CPU load per request.