### PR TITLE
[SSV-10] ssvsigner: The Order of Operations in RemoteKeyManager.AddShare() May Lead to Ineffective Local Slashing Protection

### DIFF
--- a/ssvsigner/ekm/remote_key_manager.go
+++ b/ssvsigner/ekm/remote_key_manager.go
@@ -108,6 +108,10 @@ func (km *RemoteKeyManager) AddShare(
 	encryptedPrivKey []byte,
 	pubKey phase0.BLSPubKey,
 ) error {
+	if err := km.BumpSlashingProtection(pubKey); err != nil {
+		return fmt.Errorf("could not bump slashing protection: %w", err)
+	}
+
 	shareKeys := ssvsigner.ShareKeys{
 		EncryptedPrivKey: hexutil.Bytes(encryptedPrivKey),
 		PubKey:           pubKey,
@@ -115,10 +119,6 @@ func (km *RemoteKeyManager) AddShare(
 
 	if err := km.signerClient.AddValidators(ctx, shareKeys); err != nil {
 		return fmt.Errorf("add validator: %w", err)
-	}
-
-	if err := km.BumpSlashingProtection(pubKey); err != nil {
-		return fmt.Errorf("could not bump slashing protection: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
> Reverse the order of operations in `AddShare()` so that local protection is initialized before the key is activated
remotely:
> 1. Call `km.BumpSlashingProtection(pubKey)` first.
> 2. Then call `km.signerClient.AddValidators(ctx, shareKeys)`.
> 
> This ensures that if `BumpSlashingProtection()` fails, the key is never added to the remote signer. If the remote call then fails, local protection is still correctly initialized, preventing any window where a slashable signing could occur.