### PR TITLE
[SSV-18] ssvsigner: Insecure Logger Usage May Lead to Information Disclosure

### DIFF
--- a/ssvsigner/cmd/purge-keys/purge-keys.go
+++ b/ssvsigner/cmd/purge-keys/purge-keys.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/logging/fields"
+
 	ssvsignertls "github.com/ssvlabs/ssv/ssvsigner/tls"
 	"github.com/ssvlabs/ssv/ssvsigner/web3signer"
 )
@@ -34,7 +35,7 @@ func main() {
 	cli := CLI{}
 	_ = kong.Parse(&cli)
 
-	logger, err := zap.NewDevelopment()
+	logger, err := zap.NewProduction()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
> The main() function creates a logger with the zap.NewDevelopment() constructor. The docs at
https://pkg.go.dev/go.uber.org/zap#NewDevelopment state the following:
> 
> ```
> NewDevelopment builds a development Logger that writes DebugLevel and above logs to standard error in a human-friendly format.
> ```
> 
> That said, the logger will be run in debug mode, which will result in verbose message that may leak sensitive information.