### PR TITLE
eth/executionclient: halve batch size on websocket read limit

### DIFF
--- a/eth/executionclient/errors.go
+++ b/eth/executionclient/errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/gorilla/websocket"
 )
 
 var (
@@ -26,11 +27,15 @@ const (
 	errCodeQueryLimit = -32005
 )
 
-// isRPCQueryLimitError checks if the provided error is a query limit error.
-func isRPCQueryLimitError(err error) bool {
+// isQueryLimitError checks if the provided error is a query limit error.
+func isQueryLimitError(err error) bool {
 	var rpcErr rpc.Error
 	if errors.As(err, &rpcErr) {
 		return rpcErr.ErrorCode() == errCodeQueryLimit
+	}
+
+	if errors.Is(err, websocket.ErrReadLimit) {
+		return true
 	}
 
 	return false

--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -241,7 +241,7 @@ func (ec *ExecutionClient) subdivideLogFetch(ctx context.Context, q ethereum.Fil
 		return logs, nil
 	}
 
-	if isRPCQueryLimitError(err) {
+	if isQueryLimitError(err) {
 		if q.FromBlock == nil || q.ToBlock == nil {
 			return nil, err
 		}


### PR DESCRIPTION
Increasing `DefaultHistoricalLogsBatchSize` from 200 to 1000 in https://github.com/ssvlabs/ssv/pull/2204 caused syncing from a new database to fail due to the `websocket: read limit exceeded` error.

The PR adds the mentioned error to the list of errors when subdivision applies 

@kchojn Do you think it's worth reducing the `DefaultHistoricalLogsBatchSize` to something in the middle?