### PR TITLE
fix(eth/executionclient/defaults.go): revert DefaultHistoricalLogsBatchSize to 200 to prevent websocket read limit errors

### DIFF
--- a/eth/executionclient/defaults.go
+++ b/eth/executionclient/defaults.go
@@ -11,7 +11,7 @@ const (
 	DefaultHealthInvalidationInterval  = 24 * time.Second // TODO: decide on this value, for now choosing the node prober interval but it should probably be a bit less than block interval
 	DefaultFollowDistance              = 8
 	// TODO ALAN: revert
-	DefaultHistoricalLogsBatchSize = 1000
+	DefaultHistoricalLogsBatchSize = 200
 	defaultLogBuf                  = 8 * 1024
 	maxReconnectionAttempts        = 5000
 	reconnectionBackoffFactor      = 2


### PR DESCRIPTION
More context here: https://github.com/ssvlabs/ssv/pull/2247