### PR TITLE
Bump ssv-signer dependency to the latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/ssvlabs/eth2-key-manager v1.5.5
 	github.com/ssvlabs/ssv-spec v1.1.3
-	github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250527163031-8fc6fde91908
+	github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250602071339-d1fded00511c
 	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.9.0
 	github.com/wealdtech/go-eth2-types/v2 v2.8.1

--- a/go.sum
+++ b/go.sum
@@ -756,8 +756,8 @@ github.com/ssvlabs/go-eth2-client v0.6.31-0.20250417062221-9cd9b891d4d6 h1:26sqP
 github.com/ssvlabs/go-eth2-client v0.6.31-0.20250417062221-9cd9b891d4d6/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/ssvlabs/ssv-spec v1.1.3 h1:46K31kI4/vA7Vp3DaOuN7t2IABAmzeiMniCqYfzzpo8=
 github.com/ssvlabs/ssv-spec v1.1.3/go.mod h1:pto7dDv99uVfCZidiLrrKgFR6VYy6WY3PGI1TiGCsIU=
-github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250527163031-8fc6fde91908 h1:kL742CdbS76LbVCNuzOl+/nT8i8ow4yqfn0rDiw7V4c=
-github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250527163031-8fc6fde91908/go.mod h1:pGWwC0CvKjs7WEGLj83HAmdULrAp32B7QmL1Js+gMUY=
+github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250602071339-d1fded00511c h1:Bdxv1Ae7boEkt9ZDwpY5zZKeV6e8CN0zKhR0eLgnrR8=
+github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250602071339-d1fded00511c/go.mod h1:dd+eut7RJgmUhpAMsgpC30Avtsocu5cWzhsKtEFI67Q=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
[This](https://github.com/ssvlabs/ssv/pull/2245) PR was merged and we want to update the SSV Signer dependency so this change is included