### PR TITLE
fix(go.mod): rebase go-eth2-client fix onto stable branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -268,4 +268,4 @@ replace github.com/google/flatbuffers => github.com/google/flatbuffers v1.11.0
 
 replace github.com/dgraph-io/ristretto => github.com/dgraph-io/ristretto v0.1.1-0.20211108053508-297c39e6640f
 
-replace github.com/attestantio/go-eth2-client => github.com/ssvlabs/go-eth2-client v0.6.31-0.20250603103107-734303473193
+replace github.com/attestantio/go-eth2-client => github.com/ssvlabs/go-eth2-client v0.6.31-0.20250603123001-d1c8c56eb307

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.0.0/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/ssvlabs/eth2-key-manager v1.5.5 h1:AzwNowGvcmVpRCVHq10FVnpkVIUpoDo5YbJWNMnYA8Q=
 github.com/ssvlabs/eth2-key-manager v1.5.5/go.mod h1:yeUzAP+SBJXgeXPiGBrLeLuHIQCpeJZV7Jz3Fwzm/zk=
-github.com/ssvlabs/go-eth2-client v0.6.31-0.20250603103107-734303473193 h1:mwwD8lqgYenR9nuVS/EIA6vKwyER0utEcmWHn6nbO/Y=
-github.com/ssvlabs/go-eth2-client v0.6.31-0.20250603103107-734303473193/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
+github.com/ssvlabs/go-eth2-client v0.6.31-0.20250603123001-d1c8c56eb307 h1:evQvv3FJZty3rMUvLXCAOI+oWYUYXdGARjnyFtRVSa0=
+github.com/ssvlabs/go-eth2-client v0.6.31-0.20250603123001-d1c8c56eb307/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/ssvlabs/ssv-spec v1.1.3 h1:46K31kI4/vA7Vp3DaOuN7t2IABAmzeiMniCqYfzzpo8=
 github.com/ssvlabs/ssv-spec v1.1.3/go.mod h1:pto7dDv99uVfCZidiLrrKgFR6VYy6WY3PGI1TiGCsIU=
 github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250602071339-d1fded00511c h1:Bdxv1Ae7boEkt9ZDwpY5zZKeV6e8CN0zKhR0eLgnrR8=


### PR DESCRIPTION
https://github.com/ssvlabs/ssv/pull/2253 uses unstable `go-eth2-client`'s `fulu` branch. This PR is based on `main` with cherry-picked fixes