### PR TITLE
proposer-delay: log warn for capped value

### DIFF
--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -1213,7 +1213,7 @@ func SetupRunners(
 		case spectypes.RoleProposer:
 			proposedValueCheck := ssv.ProposerValueCheckF(options.Signer, options.NetworkConfig, options.SSVShare.ValidatorPubKey, options.SSVShare.ValidatorIndex, phase0.BLSPubKey(options.SSVShare.SharePubKey))
 			qbftCtrl := buildController(spectypes.RoleProposer, proposedValueCheck)
-			runners[role], err = runner.NewProposerRunner(options.NetworkConfig, shareMap, qbftCtrl, options.Beacon, options.Network, options.Signer, options.OperatorSigner, options.DoppelgangerHandler, proposedValueCheck, 0, options.Graffiti, options.ProposerDelay)
+			runners[role], err = runner.NewProposerRunner(logger, options.NetworkConfig, shareMap, qbftCtrl, options.Beacon, options.Network, options.Signer, options.OperatorSigner, options.DoppelgangerHandler, proposedValueCheck, 0, options.Graffiti, options.ProposerDelay)
 		case spectypes.RoleAggregator:
 			aggregatorValueCheckF := ssv.AggregatorValueCheckF(options.Signer, options.NetworkConfig, options.SSVShare.ValidatorPubKey, options.SSVShare.ValidatorIndex)
 			qbftCtrl := buildController(spectypes.RoleAggregator, aggregatorValueCheckF)

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -53,6 +53,7 @@ type ProposerRunner struct {
 }
 
 func NewProposerRunner(
+	logger *zap.Logger,
 	networkConfig networkconfig.Network,
 	share map[phase0.ValidatorIndex]*spectypes.Share,
 	qbftController *controller.Controller,
@@ -75,6 +76,11 @@ func NewProposerRunner(
 	// https://github.com/ssvlabs/ssv/blob/main/docs/MEV_CONSIDERATIONS.md#getting-started-with-mev-configuration
 	const maxReasonableProposerDelay = 1650 * time.Millisecond
 	if proposerDelay > maxReasonableProposerDelay {
+		logger.Warn(
+			"ProposerDelay value set is too high, capping it at max reasonable proposer delay value",
+			zap.Duration("proposer_delay", proposerDelay),
+			zap.Duration("max_reasonable_proposer_delay", maxReasonableProposerDelay),
+		)
 		proposerDelay = maxReasonableProposerDelay
 	}
 

--- a/protocol/v2/ssv/testing/runner.go
+++ b/protocol/v2/ssv/testing/runner.go
@@ -147,6 +147,7 @@ var ConstructBaseRunner = func(
 		)
 	case spectypes.RoleProposer:
 		r, err = runner.NewProposerRunner(
+			logger,
 			networkconfig.TestNetwork,
 			shareMap,
 			contr,
@@ -398,6 +399,7 @@ var ConstructBaseRunnerWithShareMap = func(
 		)
 	case spectypes.RoleProposer:
 		r, err = runner.NewProposerRunner(
+			logger,
 			networkconfig.TestNetwork,
 			shareMap,
 			contr,


### PR DESCRIPTION
This is useful to have a log line for, just in case we need to debug it (as per https://github.com/ssvlabs/ssv/pull/2262#discussion_r2127047455 suggestion).