### PR TITLE
fix(validator slashing protector): epoch '0' check when setting highest source epoch

### DIFF
--- a/ssvsigner/ekm/slashing_protector.go
+++ b/ssvsigner/ekm/slashing_protector.go
@@ -188,8 +188,14 @@ func (sp *SlashingProtector) updateHighestProposal(pubKey phase0.BLSPubKey, slot
 func (sp *SlashingProtector) computeMinimalAttestationSP(epoch phase0.Epoch) *phase0.AttestationData {
 	// Calculate the highest safe target epoch based on the current epoch and a predefined minimum distance.
 	highestTarget := epoch + minSPAttestationEpochGap
+
 	// The highest safe source epoch is one less than the highest target epoch.
-	highestSource := highestTarget - 1
+	var highestSource phase0.Epoch
+	if highestTarget > 0 {
+		highestSource = highestTarget - 1
+	} else {
+		highestSource = 0
+	}
 
 	// Return a new AttestationData object with the calculated source and target epochs.
 	return &phase0.AttestationData{


### PR DESCRIPTION
**Description**

This bug was identified during the local testnet launch when SSV handles epoch `0` duties.

Without this check, the `highestSource` is set to `uint64` max value (`18446744073709551615`), which causes misbehavior in the SSV Node. As a result, all attestations are incorrectly identified as **slashable**, due to this [check in the eth2-key-manager](https://github.com/ssvlabs/eth2-key-manager/blob/main/slashing_protection/normal_protection.go#L39).