### PR TITLE
[SSV-20] ssvsigner: Server-Side Request Forgery via Web3signer_endpoint Configuration

### DIFF
--- a/ssvsigner/cmd/internal/logger/logger.go
+++ b/ssvsigner/cmd/internal/logger/logger.go
@@ -1,0 +1,32 @@
+package logger
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+)
+
+// SetupLogger creates a configured zap logger.
+func SetupLogger(logLevel, logFormat string) (*zap.Logger, error) {
+	cfg := zap.NewProductionConfig()
+
+	if logFormat == "console" {
+		cfg.Encoding = "console"
+		cfg.EncoderConfig = zap.NewDevelopmentEncoderConfig()
+	} else {
+		cfg.Encoding = "json"
+	}
+
+	level := zap.NewAtomicLevel()
+	if err := level.UnmarshalText([]byte(logLevel)); err != nil {
+		return nil, fmt.Errorf("parse log level: %w", err)
+	}
+	cfg.Level = level
+
+	return cfg.Build()
+}
+
+// SetupDevelopmentLogger creates a development logger.
+func SetupDevelopmentLogger() (*zap.Logger, error) {
+	return zap.NewDevelopment()
+}

--- a/ssvsigner/cmd/internal/logger/logger.go
+++ b/ssvsigner/cmd/internal/logger/logger.go
@@ -26,7 +26,7 @@ func SetupLogger(logLevel, logFormat string) (*zap.Logger, error) {
 	return cfg.Build()
 }
 
-// SetupDevelopmentLogger creates a development logger.
-func SetupDevelopmentLogger() (*zap.Logger, error) {
-	return zap.NewDevelopment()
+// SetupProductionLogger creates a production logger.
+func SetupProductionLogger() (*zap.Logger, error) {
+	return zap.NewProduction()
 }

--- a/ssvsigner/cmd/internal/validation/url.go
+++ b/ssvsigner/cmd/internal/validation/url.go
@@ -1,0 +1,50 @@
+package validation
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// ValidateWeb3SignerEndpoint validates that the endpoint is safe from SSRF attacks.
+func ValidateWeb3SignerEndpoint(endpoint string) error {
+	u, err := url.ParseRequestURI(endpoint)
+	if err != nil {
+		return fmt.Errorf("invalid url format: %w", err)
+	}
+
+	// Only allow http/https schemes
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("invalid url scheme %q: only http/https allowed", u.Scheme)
+	}
+
+	hostname := u.Hostname()
+	if hostname == "" {
+		return fmt.Errorf("missing hostname in url")
+	}
+
+	// Check for localhost/loopback
+	if strings.EqualFold(hostname, "localhost") ||
+		strings.HasPrefix(hostname, "127.") ||
+		hostname == "::1" {
+		return fmt.Errorf("localhost/loopback addresses are not allowed")
+	}
+
+	// Parse IP if it's an IP address
+	if ip := net.ParseIP(hostname); ip != nil {
+		if ip.IsUnspecified() {
+			return fmt.Errorf("invalid ip address type: %s", ip)
+		}
+
+		if ip.IsMulticast() {
+			return fmt.Errorf("invalid ip address type: %s", ip)
+		}
+
+		if ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			return fmt.Errorf("private/local ip addresses are not allowed: %s", ip)
+		}
+	}
+
+	return nil
+}

--- a/ssvsigner/cmd/internal/validation/url.go
+++ b/ssvsigner/cmd/internal/validation/url.go
@@ -1,19 +1,91 @@
 package validation
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 )
 
-// ValidateWeb3SignerEndpoint validates that the endpoint is safe from SSRF attacks.
+// blockedCIDRs contains IP ranges that should be blocked for SSRF prevention.
+// Sources: RFC 5735 (IPv4), RFC 6890, and IANA IPv6 Special-Purpose Address Registry.
+var blockedCIDRs = []string{
+	// IPv4 Private Networks - RFC 1918
+	"10.0.0.0/8",     // Private network - RFC 1918
+	"172.16.0.0/12",  // Private network - RFC 1918
+	"192.168.0.0/16", // Private network - RFC 1918
+
+	// IPv4 Special Use - RFC 5735
+	"0.0.0.0/8",          // Current network - RFC 1122
+	"169.254.0.0/16",     // Link-local - RFC 3927
+	"224.0.0.0/4",        // Multicast - RFC 3171
+	"240.0.0.0/4",        // Reserved - RFC 1112
+	"255.255.255.255/32", // Broadcast - RFC 919
+
+	// IPv4 Documentation and Test
+	"192.0.0.0/24",    // IETF Protocol Assignments - RFC 5736
+	"192.0.2.0/24",    // TEST-NET-1 - RFC 5737
+	"198.51.100.0/24", // TEST-NET-2 - RFC 5737
+	"203.0.113.0/24",  // TEST-NET-3 - RFC 5737
+	"192.88.99.0/24",  // IPv6 to IPv4 relay - RFC 3068
+	"198.18.0.0/15",   // Network benchmark - RFC 2544
+	"100.64.0.0/10",   // Shared Address Space - RFC 6598
+
+	// IPv6 Special Use - IANA Registry
+	"::/128",        // Unspecified - RFC 4291
+	"fc00::/7",      // Unique local - RFC 4193
+	"fe80::/10",     // Link-local - RFC 4291
+	"ff00::/8",      // Multicast - RFC 3513
+	"100::/64",      // Discard prefix - RFC 6666
+	"2001::/23",     // IETF Protocol Assignments - RFC 2928
+	"2001:2::/48",   // Benchmarking - RFC 5180
+	"2001:db8::/32", // Documentation - RFC 3849
+	"2001::/32",     // Teredo tunneling - RFC 4380
+	"2002::/16",     // 6to4 - RFC 3056
+	"64:ff9b::/96",  // IPv4/IPv6 translation - RFC 6052
+	"2001:10::/28",  // Deprecated ORCHID - RFC 4843
+	"2001:20::/28",  // ORCHIDv2 - RFC 7343
+}
+
+var blockedNetworks []*net.IPNet
+
+func init() {
+	for _, cidr := range blockedCIDRs {
+		_, network, _ := net.ParseCIDR(cidr)
+		if network != nil {
+			blockedNetworks = append(blockedNetworks, network)
+		}
+	}
+}
+
+// ValidateWeb3SignerEndpoint validates that a Web3Signer endpoint URL is safe from SSRF attacks.
+//
+// The function performs the following validations:
+//  1. URL format and scheme (only http/https allowed)
+//  2. Hostname presence
+//  3. IP address validation (if hostname is an IP)
+//  4. DNS resolution and validation of all resolved IPs (if hostname is a domain)
+//
+// Allowed endpoints:
+//   - Public IP addresses (e.g., https://1.2.3.4:9000)
+//   - Localhost/loopback (e.g., http://localhost:9000, http://127.0.0.1:9000)
+//   - Domain names resolving to allowed IPs (e.g., https://web3signer.example.com)
+//
+// Blocked endpoints:
+//   - Private networks (e.g., http://192.168.1.1, http://10.0.0.1)
+//   - Link-local addresses (e.g., http://169.254.169.254)
+//   - Special-use addresses (e.g., http://0.0.0.0, multicast, broadcast)
+//   - Non-HTTP(S) schemes (e.g., file://, ftp://)
+//
+// Returns an error if the endpoint is invalid or potentially unsafe, nil otherwise.
 func ValidateWeb3SignerEndpoint(endpoint string) error {
 	u, err := url.ParseRequestURI(endpoint)
 	if err != nil {
 		return fmt.Errorf("invalid url format: %w", err)
 	}
 
-	// Only allow http/https schemes
+	// Only allow http/https
 	if u.Scheme != "http" && u.Scheme != "https" {
 		return fmt.Errorf("invalid url scheme %q: only http/https allowed", u.Scheme)
 	}
@@ -23,19 +95,87 @@ func ValidateWeb3SignerEndpoint(endpoint string) error {
 		return fmt.Errorf("missing hostname in url")
 	}
 
-	// Parse IP if it's an IP address
-	if ip := net.ParseIP(hostname); ip != nil {
-		if ip.IsUnspecified() {
-			return fmt.Errorf("invalid ip address type (unspecified): %s", ip)
-		}
+	// Check if it's an IP address
+	ip := net.ParseIP(hostname)
+	if ip != nil {
+		return isBlockedIP(ip)
+	}
 
-		if ip.IsMulticast() {
-			return fmt.Errorf("invalid ip address type (multicast): %s", ip)
-		}
+	// It's a domain name - resolve and validate all IPs
+	ips, err := net.LookupIP(hostname)
+	if err != nil {
+		var dnsErr *net.DNSError
+		if errors.As(err, &dnsErr) {
+			if dnsErr.IsNotFound {
+				return fmt.Errorf("hostname not found: %s", hostname)
+			}
 
-		// Only block non-loopback private IPs
-		if !ip.IsLoopback() && (ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()) {
-			return fmt.Errorf("private network ip addresses (excluding loopback) are not allowed: %s", ip)
+			if dnsErr.IsTimeout {
+				return fmt.Errorf("dns lookup timeout for hostname: %s", hostname)
+			}
+
+			if dnsErr.IsTemporary {
+				return fmt.Errorf("temporary dns failure for hostname: %s", hostname)
+			}
+		}
+		return fmt.Errorf("failed to resolve hostname %s: %w", hostname, err)
+	}
+
+	if len(ips) == 0 {
+		return fmt.Errorf("hostname %s did not resolve to any ip addresses", hostname)
+	}
+
+	var blockedIPs []string
+	for _, resolvedIP := range ips {
+		if err := isBlockedIP(resolvedIP); err != nil {
+			blockedIPs = append(blockedIPs, resolvedIP.String())
+		}
+	}
+
+	if len(blockedIPs) > 0 {
+		return fmt.Errorf("hostname %s resolves to blocked ip addresses: %s",
+			hostname, strings.Join(blockedIPs, ", "))
+	}
+
+	return nil
+}
+
+// isBlockedIP checks if an IP address should be blocked based on SSRF prevention rules.
+// It returns an error if the IP is in a blocked range, nil otherwise.
+//
+// The function blocks:
+//   - Unspecified addresses (0.0.0.0, ::)
+//   - Multicast addresses
+//   - Private networks (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7)
+//   - Link-local addresses (169.254.0.0/16, fe80::/10)
+//   - Special-use addresses (broadcast, documentation, test networks)
+//
+// The function allows:
+//   - Loopback addresses (127.0.0.0/8, ::1) for local Web3Signer support
+//   - All public IPv4 and IPv6 addresses
+func isBlockedIP(ip net.IP) error {
+	// Always block unspecified addresses
+	if ip.IsUnspecified() {
+		return fmt.Errorf("invalid ip address type (unspecified): %s", ip)
+	}
+
+	// Always block multicast
+	if ip.IsMulticast() {
+		return fmt.Errorf("invalid ip address type (multicast): %s", ip)
+	}
+
+	// Allow loopback (localhost)
+	if ip.IsLoopback() {
+		return nil
+	}
+
+	// Check against blocked networks
+	for _, network := range blockedNetworks {
+		if network.Contains(ip) {
+			if ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+				return fmt.Errorf("private/internal ip addresses are not allowed: %s", ip)
+			}
+			return fmt.Errorf("ip address in blocked range: %s", ip)
 		}
 	}
 

--- a/ssvsigner/cmd/internal/validation/url.go
+++ b/ssvsigner/cmd/internal/validation/url.go
@@ -33,9 +33,8 @@ func ValidateWeb3SignerEndpoint(endpoint string) error {
 			return fmt.Errorf("invalid ip address type (multicast): %s", ip)
 		}
 
-		// Only block non-loopback private IPs
-		if !ip.IsLoopback() && (ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()) {
-			return fmt.Errorf("private/local ip addresses are not allowed: %s", ip)
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			return fmt.Errorf("local and private network ip addresses are not allowed: %s", ip)
 		}
 	}
 

--- a/ssvsigner/cmd/internal/validation/url.go
+++ b/ssvsigner/cmd/internal/validation/url.go
@@ -33,8 +33,9 @@ func ValidateWeb3SignerEndpoint(endpoint string) error {
 			return fmt.Errorf("invalid ip address type (multicast): %s", ip)
 		}
 
-		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
-			return fmt.Errorf("local and private network ip addresses are not allowed: %s", ip)
+		// Only block non-loopback private IPs
+		if !ip.IsLoopback() && (ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()) {
+			return fmt.Errorf("private network ip addresses (excluding loopback) are not allowed: %s", ip)
 		}
 	}
 

--- a/ssvsigner/cmd/internal/validation/url_test.go
+++ b/ssvsigner/cmd/internal/validation/url_test.go
@@ -30,24 +30,24 @@ func TestValidateWeb3SignerEndpoint(t *testing.T) {
 			wantErr:  "invalid url format",
 		},
 		{
-			name:     "localhost blocked",
+			name:     "localhost allowed",
 			endpoint: "http://localhost:9000",
-			wantErr:  "localhost/loopback addresses are not allowed",
+			wantErr:  "",
 		},
 		{
-			name:     "127.0.0.1 blocked",
+			name:     "127.0.0.1 allowed",
 			endpoint: "http://127.0.0.1:9000",
-			wantErr:  "localhost/loopback addresses are not allowed",
+			wantErr:  "",
 		},
 		{
-			name:     "127.x.x.x blocked",
+			name:     "127.x.x.x allowed",
 			endpoint: "http://127.1.2.3:9000",
-			wantErr:  "localhost/loopback addresses are not allowed",
+			wantErr:  "",
 		},
 		{
-			name:     "ipv6 loopback blocked",
+			name:     "ipv6 loopback allowed",
 			endpoint: "http://[::1]:9000",
-			wantErr:  "localhost/loopback addresses are not allowed",
+			wantErr:  "",
 		},
 		{
 			name:     "private ip 192.168.x.x blocked",
@@ -87,12 +87,12 @@ func TestValidateWeb3SignerEndpoint(t *testing.T) {
 		{
 			name:     "unspecified ipv4",
 			endpoint: "http://0.0.0.0:9000",
-			wantErr:  "invalid ip address type",
+			wantErr:  "invalid ip address type (unspecified)",
 		},
 		{
 			name:     "multicast ip blocked",
 			endpoint: "http://224.0.0.1:9000",
-			wantErr:  "invalid ip address type",
+			wantErr:  "invalid ip address type (multicast)",
 		},
 	}
 

--- a/ssvsigner/cmd/internal/validation/url_test.go
+++ b/ssvsigner/cmd/internal/validation/url_test.go
@@ -37,17 +37,17 @@ func TestValidateWeb3SignerEndpoint(t *testing.T) {
 		{
 			name:     "127.0.0.1 allowed",
 			endpoint: "http://127.0.0.1:9000",
-			wantErr:  "are not allowed",
+			wantErr:  "",
 		},
 		{
 			name:     "127.x.x.x allowed",
 			endpoint: "http://127.1.2.3:9000",
-			wantErr:  "are not allowed",
+			wantErr:  "",
 		},
 		{
 			name:     "ipv6 loopback allowed",
 			endpoint: "http://[::1]:9000",
-			wantErr:  "are not allowed",
+			wantErr:  "",
 		},
 		{
 			name:     "private ip 192.168.x.x blocked",

--- a/ssvsigner/cmd/internal/validation/url_test.go
+++ b/ssvsigner/cmd/internal/validation/url_test.go
@@ -15,13 +15,13 @@ func TestValidateWeb3SignerEndpoint(t *testing.T) {
 		wantErr  string
 	}{
 		{
-			name:     "valid https endpoint",
-			endpoint: "https://web3signer.example.com",
+			name:     "valid https endpoint with real domain",
+			endpoint: "https://google.com:443",
 			wantErr:  "",
 		},
 		{
-			name:     "valid http endpoint",
-			endpoint: "http://web3signer.example.com:9000",
+			name:     "valid http endpoint with public IP",
+			endpoint: "http://8.8.8.8:9000",
 			wantErr:  "",
 		},
 		{
@@ -52,22 +52,22 @@ func TestValidateWeb3SignerEndpoint(t *testing.T) {
 		{
 			name:     "private ip 192.168.x.x blocked",
 			endpoint: "http://192.168.1.1:9000",
-			wantErr:  "are not allowed",
+			wantErr:  "private/internal ip addresses are not allowed",
 		},
 		{
 			name:     "private ip 10.x.x.x blocked",
 			endpoint: "http://10.0.0.1:9000",
-			wantErr:  "are not allowed",
+			wantErr:  "private/internal ip addresses are not allowed",
 		},
 		{
 			name:     "private ip 172.16.x.x blocked",
 			endpoint: "http://172.16.0.1:9000",
-			wantErr:  "are not allowed",
+			wantErr:  "private/internal ip addresses are not allowed",
 		},
 		{
 			name:     "link local blocked",
 			endpoint: "http://169.254.1.1:9000",
-			wantErr:  "are not allowed",
+			wantErr:  "private/internal ip addresses are not allowed",
 		},
 		{
 			name:     "file scheme blocked",
@@ -93,6 +93,21 @@ func TestValidateWeb3SignerEndpoint(t *testing.T) {
 			name:     "multicast ip blocked",
 			endpoint: "http://224.0.0.1:9000",
 			wantErr:  "invalid ip address type (multicast)",
+		},
+		{
+			name:     "non-existent domain",
+			endpoint: "https://this-domain-definitely-does-not-exist-12345.com",
+			wantErr:  "hostname not found",
+		},
+		{
+			name:     "ipv6 unique local blocked",
+			endpoint: "http://[fd00::1]:9000",
+			wantErr:  "private/internal ip addresses are not allowed",
+		},
+		{
+			name:     "broadcast address blocked",
+			endpoint: "http://255.255.255.255:9000",
+			wantErr:  "ip address in blocked range",
 		},
 	}
 

--- a/ssvsigner/cmd/internal/validation/url_test.go
+++ b/ssvsigner/cmd/internal/validation/url_test.go
@@ -37,37 +37,37 @@ func TestValidateWeb3SignerEndpoint(t *testing.T) {
 		{
 			name:     "127.0.0.1 allowed",
 			endpoint: "http://127.0.0.1:9000",
-			wantErr:  "",
+			wantErr:  "are not allowed",
 		},
 		{
 			name:     "127.x.x.x allowed",
 			endpoint: "http://127.1.2.3:9000",
-			wantErr:  "",
+			wantErr:  "are not allowed",
 		},
 		{
 			name:     "ipv6 loopback allowed",
 			endpoint: "http://[::1]:9000",
-			wantErr:  "",
+			wantErr:  "are not allowed",
 		},
 		{
 			name:     "private ip 192.168.x.x blocked",
 			endpoint: "http://192.168.1.1:9000",
-			wantErr:  "private/local ip addresses are not allowed",
+			wantErr:  "are not allowed",
 		},
 		{
 			name:     "private ip 10.x.x.x blocked",
 			endpoint: "http://10.0.0.1:9000",
-			wantErr:  "private/local ip addresses are not allowed",
+			wantErr:  "are not allowed",
 		},
 		{
 			name:     "private ip 172.16.x.x blocked",
 			endpoint: "http://172.16.0.1:9000",
-			wantErr:  "private/local ip addresses are not allowed",
+			wantErr:  "are not allowed",
 		},
 		{
 			name:     "link local blocked",
 			endpoint: "http://169.254.1.1:9000",
-			wantErr:  "private/local ip addresses are not allowed",
+			wantErr:  "are not allowed",
 		},
 		{
 			name:     "file scheme blocked",

--- a/ssvsigner/cmd/purge-keys/purge-keys.go
+++ b/ssvsigner/cmd/purge-keys/purge-keys.go
@@ -7,8 +7,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
-	"net/url"
+	"os"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -16,6 +15,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/logging/fields"
+	"github.com/ssvlabs/ssv/ssvsigner/cmd/internal/logger"
+
+	"github.com/ssvlabs/ssv/ssvsigner/cmd/internal/validation"
 	ssvsignertls "github.com/ssvlabs/ssv/ssvsigner/tls"
 	"github.com/ssvlabs/ssv/ssvsigner/web3signer"
 )
@@ -31,21 +33,23 @@ type CLI struct {
 }
 
 func main() {
-	cli := CLI{}
-	_ = kong.Parse(&cli)
+	var cli CLI
 
-	logger, err := zap.NewDevelopment()
+	kong.Must(&cli,
+		kong.Name("purge-keys"),
+		kong.UsageOnError(),
+	)
+
+	log, err := logger.SetupDevelopmentLogger()
 	if err != nil {
-		log.Fatal(err)
+		_, _ = fmt.Fprintf(os.Stderr, "setup logger: %v\n", err)
+		os.Exit(1)
 	}
-	defer func() {
-		if err := logger.Sync(); err != nil {
-			log.Println("failed to sync logger: ", err)
-		}
-	}()
 
-	if err := run(logger, cli); err != nil {
-		logger.Fatal("Application failed", zap.Error(err))
+	defer func() { _ = log.Sync() }()
+
+	if err := run(log, cli); err != nil {
+		log.Fatal("application failed", zap.Error(err))
 	}
 }
 
@@ -60,8 +64,8 @@ func run(logger *zap.Logger, cli CLI) error {
 		return fmt.Errorf("init BLS: %w", err)
 	}
 
-	if _, err := url.ParseRequestURI(cli.Web3SignerEndpoint); err != nil {
-		return fmt.Errorf("invalid WEB3SIGNER_ENDPOINT format: %w", err)
+	if err := validation.ValidateWeb3SignerEndpoint(cli.Web3SignerEndpoint); err != nil {
+		return fmt.Errorf("invalid WEB3SIGNER_ENDPOINT: %w", err)
 	}
 
 	ctx := context.Background()

--- a/ssvsigner/cmd/purge-keys/purge-keys.go
+++ b/ssvsigner/cmd/purge-keys/purge-keys.go
@@ -40,7 +40,7 @@ func main() {
 		kong.UsageOnError(),
 	)
 
-	log, err := logger.SetupDevelopmentLogger()
+	log, err := logger.SetupProductionLogger()
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "setup logger: %v\n", err)
 		os.Exit(1)

--- a/ssvsigner/cmd/ssv-signer/ssv-signer_test.go
+++ b/ssvsigner/cmd/ssv-signer/ssv-signer_test.go
@@ -26,7 +26,7 @@ func TestRun_InvalidWeb3SignerEndpoint(t *testing.T) {
 		{
 			name:     "private IP blocked",
 			endpoint: "http://192.168.1.1:9000",
-			wantErr:  "invalid WEB3SIGNER_ENDPOINT: private network ip addresses (excluding loopback) are not allowed",
+			wantErr:  "invalid WEB3SIGNER_ENDPOINT: private/internal ip addresses are not allowed",
 		},
 	}
 

--- a/ssvsigner/cmd/ssv-signer/ssv-signer_test.go
+++ b/ssvsigner/cmd/ssv-signer/ssv-signer_test.go
@@ -26,7 +26,7 @@ func TestRun_InvalidWeb3SignerEndpoint(t *testing.T) {
 		{
 			name:     "private IP blocked",
 			endpoint: "http://192.168.1.1:9000",
-			wantErr:  "invalid WEB3SIGNER_ENDPOINT: private/local ip addresses are not allowed",
+			wantErr:  "invalid WEB3SIGNER_ENDPOINT: local and private network ip addresses are not allowed",
 		},
 	}
 

--- a/ssvsigner/cmd/ssv-signer/ssv-signer_test.go
+++ b/ssvsigner/cmd/ssv-signer/ssv-signer_test.go
@@ -24,11 +24,6 @@ func TestRun_InvalidWeb3SignerEndpoint(t *testing.T) {
 			wantErr:  "invalid WEB3SIGNER_ENDPOINT: invalid url format",
 		},
 		{
-			name:     "localhost blocked",
-			endpoint: "http://localhost:9000",
-			wantErr:  "invalid WEB3SIGNER_ENDPOINT: localhost/loopback addresses are not allowed",
-		},
-		{
 			name:     "private IP blocked",
 			endpoint: "http://192.168.1.1:9000",
 			wantErr:  "invalid WEB3SIGNER_ENDPOINT: private/local ip addresses are not allowed",

--- a/ssvsigner/cmd/ssv-signer/ssv-signer_test.go
+++ b/ssvsigner/cmd/ssv-signer/ssv-signer_test.go
@@ -13,16 +13,44 @@ import (
 )
 
 func TestRun_InvalidWeb3SignerEndpoint(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
-
-	cli := CLI{
-		ListenAddr:         ":8080",
-		Web3SignerEndpoint: "invalid-url",
-		PrivateKey:         base64.StdEncoding.EncodeToString([]byte(rsatesting.PrivKeyPEM)),
+	tests := []struct {
+		name     string
+		endpoint string
+		wantErr  string
+	}{
+		{
+			name:     "invalid URL format",
+			endpoint: "invalid-url",
+			wantErr:  "invalid WEB3SIGNER_ENDPOINT: invalid url format",
+		},
+		{
+			name:     "localhost blocked",
+			endpoint: "http://localhost:9000",
+			wantErr:  "invalid WEB3SIGNER_ENDPOINT: localhost/loopback addresses are not allowed",
+		},
+		{
+			name:     "private IP blocked",
+			endpoint: "http://192.168.1.1:9000",
+			wantErr:  "invalid WEB3SIGNER_ENDPOINT: private/local ip addresses are not allowed",
+		},
 	}
 
-	err := run(logger, cli)
-	require.ErrorContains(t, err, "invalid WEB3SIGNER_ENDPOINT format")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger, _ := zap.NewDevelopment()
+
+			cli := CLI{
+				ListenAddr:         ":8080",
+				Web3SignerEndpoint: tt.endpoint,
+				PrivateKey:         base64.StdEncoding.EncodeToString([]byte(rsatesting.PrivKeyPEM)),
+			}
+
+			err := run(logger, cli)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
 }
 
 func TestRun_MissingPrivateKey(t *testing.T) {

--- a/ssvsigner/cmd/ssv-signer/ssv-signer_test.go
+++ b/ssvsigner/cmd/ssv-signer/ssv-signer_test.go
@@ -26,7 +26,7 @@ func TestRun_InvalidWeb3SignerEndpoint(t *testing.T) {
 		{
 			name:     "private IP blocked",
 			endpoint: "http://192.168.1.1:9000",
-			wantErr:  "invalid WEB3SIGNER_ENDPOINT: local and private network ip addresses are not allowed",
+			wantErr:  "invalid WEB3SIGNER_ENDPOINT: private network ip addresses (excluding loopback) are not allowed",
 		},
 	}
 


### PR DESCRIPTION
**Description**: The `Web3SignerEndpoint` configuration parameter, sourced from CLI arguments or environment variables, is
validated by `validateConfig` using `url.ParseRequestURI `. This validation is insufficient as `url.ParseRequestURI` allows
various URL schemes and does not restrict target hosts (e.g., `localhost` , internal IPs, potentially other schemes if not filtered by
the HTTP client). The validated endpoint is then used by `setupWeb3SignerClient` to instantiate a `web3signer.Web3Signer`
client, which makes HTTPS requests. An attacker who can control the `WEB3SIGNER_ENDPOINT` value could specify an endpoint
pointing to internal network services (e.g., `http://localhost:xxxx , http://internal-service.local/api `). This could
allow the attacker to scan internal networks, access sensitive internal endpoints, or interact with internal services through the ssv-
signer application, as the underlying HTTP client ( `github.com/carlmjohnson/requests` wrapping `net/http` ) may permit such
connections.
Because the system is assumed to be communicating over mTLS with the client, the impact and likelihood is limited.