### PR TITLE
validator: attempt to fix flaky test TestHandleNonCommitteeMessages

### DIFF
--- a/operator/fee_recipient/controller_test.go
+++ b/operator/fee_recipient/controller_test.go
@@ -160,7 +160,7 @@ func populateStorage(t *testing.T, storage registrystorage.Shares, operatorData 
 		require.NoError(t, storage.Save(nil, createShare(i, operatorData.ID)))
 	}
 
-	// add none committee share
+	// add non-committee share
 	require.NoError(t, storage.Save(nil, createShare(2000, spectypes.OperatorID(1))))
 
 	all := storage.List(nil, registrystorage.ByOperatorID(operatorData.ID), registrystorage.ByNotLiquidated())

--- a/operator/validator/controller_test.go
+++ b/operator/validator/controller_test.go
@@ -181,7 +181,7 @@ func TestSetupValidatorsExporter(t *testing.T) {
 			ctrl, logger, sharesStorage, network, _, recipientStorage, bc := setupCommonTestComponents(t, operatorPrivateKey)
 
 			defer ctrl.Finish()
-			mockValidatorsMap := validators.New(context.TODO())
+			mockValidatorsMap := validators.New(t.Context())
 
 			subnets := commons.Subnets{}
 			for _, share := range sharesWithMetadata {
@@ -234,14 +234,14 @@ func TestSetupValidatorsExporter(t *testing.T) {
 			}
 			ctr := setupController(t, logger, controllerOptions)
 			ctr.validatorStartFunc = validatorStartFunc
-			ctr.StartValidators(context.TODO())
+			ctr.StartValidators(t.Context())
 		})
 	}
 }
 
 func TestHandleNonCommitteeMessages(t *testing.T) {
 	logger := logging.TestLogger(t)
-	mockValidatorsMap := validators.New(context.TODO())
+	mockValidatorsMap := validators.New(t.Context())
 	controllerOptions := MockControllerOptions{
 		validatorsMap: mockValidatorsMap,
 	}
@@ -262,35 +262,35 @@ func TestHandleNonCommitteeMessages(t *testing.T) {
 
 	identifier := spectypes.NewMsgID(networkconfig.TestNetwork.DomainType, []byte("pk"), spectypes.RoleCommittee)
 
-	ctr.messageRouter.Route(context.TODO(), &queue.SSVMessage{
+	ctr.messageRouter.Route(t.Context(), &queue.SSVMessage{
 		SSVMessage: &spectypes.SSVMessage{
 			MsgType: spectypes.SSVConsensusMsgType, // this message will be processed
 			MsgID:   identifier,
 			Data:    generateDecidedMessage(t, identifier),
 		},
 	})
-	ctr.messageRouter.Route(context.TODO(), &queue.SSVMessage{
+	ctr.messageRouter.Route(t.Context(), &queue.SSVMessage{
 		SSVMessage: &spectypes.SSVMessage{
 			MsgType: spectypes.SSVConsensusMsgType, // this message will be processed
 			MsgID:   identifier,
 			Data:    generateChangeRoundMsg(t, identifier),
 		},
 	})
-	ctr.messageRouter.Route(context.TODO(), &queue.SSVMessage{
+	ctr.messageRouter.Route(t.Context(), &queue.SSVMessage{
 		SSVMessage: &spectypes.SSVMessage{
 			MsgType: message.SSVSyncMsgType, // this message will be skipped
 			MsgID:   identifier,
 			Data:    []byte("data"),
 		},
 	})
-	ctr.messageRouter.Route(context.TODO(), &queue.SSVMessage{
+	ctr.messageRouter.Route(t.Context(), &queue.SSVMessage{
 		SSVMessage: &spectypes.SSVMessage{
 			MsgType: 123, // this message will be skipped
 			MsgID:   identifier,
 			Data:    []byte("data"),
 		},
 	})
-	ctr.messageRouter.Route(context.TODO(), &queue.SSVMessage{
+	ctr.messageRouter.Route(t.Context(), &queue.SSVMessage{
 		SSVMessage: &spectypes.SSVMessage{
 			MsgType: spectypes.SSVPartialSignatureMsgType, // this message will be processed
 			MsgID:   identifier,
@@ -531,7 +531,7 @@ func TestSetupValidators(t *testing.T) {
 				createPubKey(byte('0')): testValidator,
 			}
 			committeeMap := make(map[spectypes.CommitteeID]*validator.Committee)
-			mockValidatorsMap := validators.New(context.TODO(), validators.WithInitialState(testValidatorsMap, committeeMap))
+			mockValidatorsMap := validators.New(t.Context(), validators.WithInitialState(testValidatorsMap, committeeMap))
 
 			// Set up the controller with mock data
 			controllerOptions := MockControllerOptions{
@@ -575,7 +575,7 @@ func TestGetValidator(t *testing.T) {
 	testValidatorsMap := map[spectypes.ValidatorPK]*validator.Validator{
 		createPubKey(byte('0')): testValidator,
 	}
-	mockValidatorsMap := validators.New(context.TODO(), validators.WithInitialState(testValidatorsMap, nil))
+	mockValidatorsMap := validators.New(t.Context(), validators.WithInitialState(testValidatorsMap, nil))
 	// Set up the controller with mock data
 	controllerOptions := MockControllerOptions{
 		validatorsMap: mockValidatorsMap,
@@ -625,7 +625,7 @@ func TestGetValidatorStats(t *testing.T) {
 		// Set up the controller with mock data for this subtest
 		controllerOptions := MockControllerOptions{
 			sharesStorage:     mockShares(sharesSlice),
-			validatorsMap:     validators.New(context.TODO()),
+			validatorsMap:     validators.New(t.Context()),
 			operatorDataStore: operatordatastore.New(buildOperatorData(1, "67Ce5c69260bd819B4e0AD13f4b873074D479811")),
 			beacon:            bc,
 		}
@@ -661,7 +661,7 @@ func TestGetValidatorStats(t *testing.T) {
 		// Set up the controller with mock data for this subtest
 		controllerOptions := MockControllerOptions{
 			sharesStorage:     mockShares(sharesSlice),
-			validatorsMap:     validators.New(context.TODO()),
+			validatorsMap:     validators.New(t.Context()),
 			operatorDataStore: operatordatastore.New(buildOperatorData(1, "67Ce5c69260bd819B4e0AD13f4b873074D479811")),
 			beacon:            bc,
 		}
@@ -689,7 +689,7 @@ func TestGetValidatorStats(t *testing.T) {
 		// Set up the controller with mock data for this subtest
 		controllerOptions := MockControllerOptions{
 			sharesStorage:     mockShares(sharesSlice),
-			validatorsMap:     validators.New(context.TODO()),
+			validatorsMap:     validators.New(t.Context()),
 			operatorDataStore: operatordatastore.New(buildOperatorData(1, "67Ce5c69260bd819B4e0AD13f4b873074D479811")),
 			beacon:            bc,
 		}
@@ -730,7 +730,7 @@ func TestGetValidatorStats(t *testing.T) {
 		// Set up the controller with mock data for this subtest
 		controllerOptions := MockControllerOptions{
 			sharesStorage:     mockShares(sharesSlice),
-			validatorsMap:     validators.New(context.TODO()),
+			validatorsMap:     validators.New(t.Context()),
 			operatorDataStore: operatordatastore.New(buildOperatorData(1, "67Ce5c69260bd819B4e0AD13f4b873074D479811")),
 			beacon:            bc,
 		}
@@ -760,7 +760,7 @@ func TestUpdateFeeRecipient(t *testing.T) {
 		testValidatorsMap := map[spectypes.ValidatorPK]*validator.Validator{
 			createPubKey(byte('0')): testValidator,
 		}
-		mockValidatorsMap := validators.New(context.TODO(), validators.WithInitialState(testValidatorsMap, nil))
+		mockValidatorsMap := validators.New(t.Context(), validators.WithInitialState(testValidatorsMap, nil))
 
 		controllerOptions := MockControllerOptions{validatorsMap: mockValidatorsMap}
 		ctr := setupController(t, logger, controllerOptions)
@@ -777,7 +777,7 @@ func TestUpdateFeeRecipient(t *testing.T) {
 		testValidatorsMap := map[spectypes.ValidatorPK]*validator.Validator{
 			createPubKey(byte('0')): testValidator,
 		}
-		mockValidatorsMap := validators.New(context.TODO(), validators.WithInitialState(testValidatorsMap, nil))
+		mockValidatorsMap := validators.New(t.Context(), validators.WithInitialState(testValidatorsMap, nil))
 		controllerOptions := MockControllerOptions{validatorsMap: mockValidatorsMap}
 		ctr := setupController(t, logger, controllerOptions)
 

--- a/operator/validator/controller_test.go
+++ b/operator/validator/controller_test.go
@@ -258,6 +258,8 @@ func TestHandleNonCommitteeMessages(t *testing.T) {
 		return nil
 	})
 
+	logger.Debug("starting to send messages")
+
 	identifier := spectypes.NewMsgID(networkconfig.TestNetwork.DomainType, []byte("pk"), spectypes.RoleCommittee)
 
 	ctr.messageRouter.Route(context.TODO(), &queue.SSVMessage{
@@ -297,7 +299,7 @@ func TestHandleNonCommitteeMessages(t *testing.T) {
 	})
 
 	receivedMsgsCnt := 0
-	timeout := time.After(5 * time.Second)
+	timeout := time.After(30 * time.Second)
 	for {
 		select {
 		case msg := <-receivedMsgs:


### PR DESCRIPTION
This PR aims to address the `TestHandleNonCommitteeMessages` flaky failure (see failing Github pipeline https://github.com/ssvlabs/ssv/actions/runs/15730946442/job/44331699107):
```
2025-06-18T11:03:47.556136Z	DEBUG	TestHandleNonCommitteeMessages	router message handler stopped
panic: time out!

goroutine 142 [running]:
github.com/ssvlabs/ssv/operator/validator.TestHandleNonCommitteeMessages.func2()
	/home/runner/work/ssv/ssv/operator/validator/controller_test.go:307 +0x38
created by github.com/ssvlabs/ssv/operator/validator.TestHandleNonCommitteeMessages in goroutine 139
	/home/runner/work/ssv/ssv/operator/validator/controller_test.go:305 +0xec7
FAIL	github.com/ssvlabs/ssv/operator/validator	6.608s
# github.com/ssvlabs/ssv/operator/validator/metadata.test
/usr/bin/ld: warning: bint64.o: missing .note.GNU-stack section implies executable stack
/usr/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
```

I'm not entirely sure what the root-cause of this failure is, there isn't enough info in the logs to tell 
- if message just didn't manage to arrive in under 4s time (which seems strange anyway, but maybe possible due to some infra-related slow-downs)
- or whether the message was lost entirely
- or yet **another unlikely possibility** would be that `t.Context()` is somehow canceled somewhere at the start of this test (although we don't do it ourselves, so that would me a bug in Golang testing library itself)

hence I'm updating the way we check for arrived messages such that we'll log what messages have actually arrived (and how long it took)
