### PR TITLE
ssvsigner: handle request error after remote signer processed keys [main]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/ssvlabs/eth2-key-manager v1.5.2
 	github.com/ssvlabs/ssv-spec v1.1.3
-	github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250604161645-9802c13c817a
+	github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250623112006-db25cb11109f
 	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.9.0
 	github.com/wealdtech/go-eth2-types/v2 v2.8.1

--- a/go.sum
+++ b/go.sum
@@ -758,6 +758,8 @@ github.com/ssvlabs/ssv-spec v1.1.3 h1:46K31kI4/vA7Vp3DaOuN7t2IABAmzeiMniCqYfzzpo
 github.com/ssvlabs/ssv-spec v1.1.3/go.mod h1:pto7dDv99uVfCZidiLrrKgFR6VYy6WY3PGI1TiGCsIU=
 github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250604161645-9802c13c817a h1:wNloeHz2Rhk97GcxSyQ7aay8xwBUQ51K5HE031+eeZQ=
 github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250604161645-9802c13c817a/go.mod h1:HkcbtVHpGBPnJjdWWd08Z3lv7l0VWejJU80yUUqY5Go=
+github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250623112006-db25cb11109f h1:QeCUBsJw7x6Z9gKvGGBmAk/sW+bVie8MtSlR41KrQ9w=
+github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250623112006-db25cb11109f/go.mod h1:+D+oGPiz6sZXwpzZzDGI2R6rzMRGRROWbrrqVdos7G0=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -92,7 +92,7 @@ func (c *Client) ListValidators(ctx context.Context) (listResp []phase0.BLSPubKe
 	return listResp, err
 }
 
-func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (err error) {
+func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (statuses []web3signer.Status, err error) {
 	start := time.Now()
 	defer func() {
 		duration := time.Since(start)
@@ -101,7 +101,7 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (err er
 	}()
 
 	if len(shares) > addShareLimit {
-		return fmt.Errorf("too many shares, max allowed per request %d", addShareLimit)
+		return nil, fmt.Errorf("too many shares, max allowed per request %d", addShareLimit)
 	}
 
 	encodedShares := make([]ShareKeys, 0, len(shares))
@@ -129,27 +129,26 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (err er
 		Fetch(ctx)
 
 	if requests.HasStatusErr(err, http.StatusUnprocessableEntity) {
-		return ShareDecryptionError(errors.New(errStr))
+		return nil, ShareDecryptionError(errors.New(errStr))
 	}
 
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return nil, fmt.Errorf("request failed: %w", err)
 	}
 
 	if len(resp.Data) != len(shares) {
-		return fmt.Errorf("unexpected statuses length, got %d, expected %d", len(resp.Data), len(shares))
+		return nil, fmt.Errorf("unexpected statuses length, got %d, expected %d", len(resp.Data), len(shares))
 	}
 
+	statuses = make([]web3signer.Status, 0, len(resp.Data))
 	for _, data := range resp.Data {
-		if data.Status != web3signer.StatusImported {
-			return fmt.Errorf("unexpected status %s", data.Status)
-		}
+		statuses = append(statuses, data.Status)
 	}
 
-	return nil
+	return statuses, nil
 }
 
-func (c *Client) RemoveValidators(ctx context.Context, pubKeys ...phase0.BLSPubKey) (err error) {
+func (c *Client) RemoveValidators(ctx context.Context, pubKeys ...phase0.BLSPubKey) (statuses []web3signer.Status, err error) {
 	start := time.Now()
 	defer func() {
 		duration := time.Since(start)
@@ -170,20 +169,19 @@ func (c *Client) RemoveValidators(ctx context.Context, pubKeys ...phase0.BLSPubK
 		ToJSON(&resp).
 		Fetch(ctx)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return nil, fmt.Errorf("request failed: %w", err)
 	}
 
 	if len(resp.Data) != len(pubKeys) {
-		return fmt.Errorf("unexpected statuses length, got %d, expected %d", len(resp.Data), len(pubKeys))
+		return nil, fmt.Errorf("unexpected statuses length, got %d, expected %d", len(resp.Data), len(pubKeys))
 	}
 
+	statuses = make([]web3signer.Status, 0, len(resp.Data))
 	for _, data := range resp.Data {
-		if data.Status != web3signer.StatusDeleted {
-			return fmt.Errorf("received status %s", data.Status)
-		}
+		statuses = append(statuses, data.Status)
 	}
 
-	return nil
+	return statuses, nil
 }
 
 func (c *Client) Sign(ctx context.Context, sharePubKey phase0.BLSPubKey, payload web3signer.SignRequest) (signature phase0.BLSSignature, err error) {

--- a/ssvsigner/ekm/mock.go
+++ b/ssvsigner/ekm/mock.go
@@ -8,31 +8,31 @@ import (
 	"github.com/ssvlabs/eth2-key-manager/core"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/ssvlabs/ssv/storage/basedb"
+
 	ssvclient "github.com/ssvlabs/ssv/ssvsigner"
 	"github.com/ssvlabs/ssv/ssvsigner/web3signer"
-
-	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
 type MockRemoteSigner struct {
 	mock.Mock
 }
 
-func (m *MockRemoteSigner) AddValidators(ctx context.Context, shares ...ssvclient.ShareKeys) error {
+func (m *MockRemoteSigner) AddValidators(ctx context.Context, shares ...ssvclient.ShareKeys) ([]web3signer.Status, error) {
 	args := m.Called(ctx, shares[0])
 	if args.Get(0) == nil {
-		return args.Error(0)
+		return nil, args.Error(1)
 	}
-	return args.Error(0)
+	return args.Get(0).([]web3signer.Status), args.Error(1)
 }
 
-func (m *MockRemoteSigner) RemoveValidators(ctx context.Context, pubKeys ...phase0.BLSPubKey) error {
+func (m *MockRemoteSigner) RemoveValidators(ctx context.Context, pubKeys ...phase0.BLSPubKey) ([]web3signer.Status, error) {
 	args := m.Called(ctx, pubKeys)
 	result := args.Get(0)
 	if result == nil {
-		return args.Error(0)
+		return nil, args.Error(1)
 	}
-	return args.Error(0)
+	return args.Get(0).([]web3signer.Status), args.Error(1)
 }
 
 func (m *MockRemoteSigner) Sign(ctx context.Context, sharePubKey phase0.BLSPubKey, payload web3signer.SignRequest) (phase0.BLSSignature, error) {

--- a/ssvsigner/ekm/remote_key_manager.go
+++ b/ssvsigner/ekm/remote_key_manager.go
@@ -51,8 +51,8 @@ type RemoteKeyManager struct {
 }
 
 type signerClient interface {
-	AddValidators(ctx context.Context, shares ...ssvsigner.ShareKeys) error
-	RemoveValidators(ctx context.Context, sharePubKeys ...phase0.BLSPubKey) error
+	AddValidators(ctx context.Context, shares ...ssvsigner.ShareKeys) ([]web3signer.Status, error)
+	RemoveValidators(ctx context.Context, pubKeys ...phase0.BLSPubKey) (statuses []web3signer.Status, err error)
 	Sign(ctx context.Context, sharePubKey phase0.BLSPubKey, payload web3signer.SignRequest) (phase0.BLSSignature, error)
 	OperatorIdentity(ctx context.Context) (string, error)
 	OperatorSign(ctx context.Context, payload []byte) ([]byte, error)
@@ -116,8 +116,32 @@ func (km *RemoteKeyManager) AddShare(
 		PubKey:           pubKey,
 	}
 
-	if err := km.signerClient.AddValidators(ctx, shareKeys); err != nil {
+	statuses, err := km.signerClient.AddValidators(ctx, shareKeys)
+	if err != nil {
 		return fmt.Errorf("add validator: %w", err)
+	}
+
+	for _, status := range statuses {
+		switch status {
+		case web3signer.StatusImported:
+
+		case web3signer.StatusDuplicated:
+			// A failed request does not guarantee that the keys were not added.
+			// It's possible that the ssv-signer successfully added the keys,
+			// but a network error occurred before a response could be received.
+			// Or, if ssv-signer is behind a load balancer, the load balancer may return an error.
+			// In such cases, the node would crash and, upon restarting, encounter a duplicate key error.
+			// To handle this gracefully, we allow returning a duplicate key error without treating it as a failure.
+			km.logger.Warn("Attempted to add already existing share to the remote signer. " +
+				"This is expected in the first block after failed sync")
+
+		default:
+			return fmt.Errorf("unexpected status %s", status)
+		}
+	}
+
+	if err := km.BumpSlashingProtection(pubKey); err != nil {
+		return fmt.Errorf("could not bump slashing protection: %w", err)
 	}
 
 	return nil
@@ -127,8 +151,28 @@ func (km *RemoteKeyManager) AddShare(
 // its highest attestation/proposal data locally. If the remote or local operations
 // fail, returns an error.
 func (km *RemoteKeyManager) RemoveShare(ctx context.Context, pubKey phase0.BLSPubKey) error {
-	if err := km.signerClient.RemoveValidators(ctx, pubKey); err != nil {
+	statuses, err := km.signerClient.RemoveValidators(ctx, pubKey)
+	if err != nil {
 		return fmt.Errorf("remove validator: %w", err)
+	}
+
+	for _, status := range statuses {
+		switch status {
+		case web3signer.StatusDeleted:
+
+		case web3signer.StatusNotFound:
+			// A failed request does not guarantee that the keys were not deleted.
+			// It's possible that the ssv-signer successfully deleted the keys,
+			// but a network error occurred before a response could be received.
+			// Or, if ssv-signer is behind a load balancer, the load balancer may return an error.
+			// In such cases, the node would crash and, upon restarting, encounter a not found key error.
+			// To handle this gracefully, we allow returning a not found key error without treating it as a failure.
+			km.logger.Warn("Attempted to delete non-existing share from the remote signer. " +
+				"This is expected in the first block after failed sync")
+
+		default:
+			return fmt.Errorf("unexpected status %s", status)
+		}
 	}
 
 	if err := km.RemoveHighestAttestation(pubKey); err != nil {

--- a/ssvsigner/ekm/remote_key_manager.go
+++ b/ssvsigner/ekm/remote_key_manager.go
@@ -140,10 +140,6 @@ func (km *RemoteKeyManager) AddShare(
 		}
 	}
 
-	if err := km.BumpSlashingProtection(pubKey); err != nil {
-		return fmt.Errorf("could not bump slashing protection: %w", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
port of https://github.com/ssvlabs/ssv/pull/2246 to main