### PR TITLE
ssvsigner: flag to allow web3signer to be in insecure networks

### DIFF
--- a/ssvsigner/cmd/internal/validation/url_test.go
+++ b/ssvsigner/cmd/internal/validation/url_test.go
@@ -115,7 +115,7 @@ func TestValidateWeb3SignerEndpoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := ValidateWeb3SignerEndpoint(tt.endpoint)
+			err := ValidateWeb3SignerEndpoint(tt.endpoint, false)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.wantErr)

--- a/ssvsigner/cmd/purge-keys/purge-keys.go
+++ b/ssvsigner/cmd/purge-keys/purge-keys.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/logging/fields"
+
 	"github.com/ssvlabs/ssv/ssvsigner/cmd/internal/logger"
 
 	"github.com/ssvlabs/ssv/ssvsigner/cmd/internal/validation"
@@ -24,7 +25,9 @@ import (
 
 type CLI struct {
 	Web3SignerEndpoint string `env:"WEB3SIGNER_ENDPOINT" required:""`
-	BatchSize          int    `env:"BATCH_SIZE" default:"20"` // reduce if getting context deadline exceeded; increase if it's fast
+	// AllowInsecureNetworks allows ssv-signer to work in insecure networks, which are blocked by default.
+	AllowInsecureNetworks bool `env:"ALLOW_INSECURE_NETWORKS" name:"allow-insecure-networks" default:"false" help:"Allow insecure HTTP networks. Do not use in production"`
+	BatchSize             int  `env:"BATCH_SIZE" default:"20"` // reduce if getting context deadline exceeded; increase if it's fast
 
 	// Client TLS configuration (for connecting to Web3Signer)
 	Web3SignerKeystoreFile         string `env:"WEB3SIGNER_KEYSTORE_FILE" env-description:"Path to PKCS12 keystore file for TLS connection to Web3Signer"`
@@ -155,7 +158,7 @@ func validateConfig(cli CLI) error {
 		return fmt.Errorf("invalid batch size %d, must be > 0", cli.BatchSize)
 	}
 
-	if err := validation.ValidateWeb3SignerEndpoint(cli.Web3SignerEndpoint); err != nil {
+	if err := validation.ValidateWeb3SignerEndpoint(cli.Web3SignerEndpoint, cli.AllowInsecureNetworks); err != nil {
 		return fmt.Errorf("invalid WEB3SIGNER_ENDPOINT: %w", err)
 	}
 

--- a/ssvsigner/cmd/ssv-signer/ssv-signer.go
+++ b/ssvsigner/cmd/ssv-signer/ssv-signer.go
@@ -31,6 +31,8 @@ type CLI struct {
 
 	// AllowInsecureHTTP allows ssv-signer to work without using TLS. Note that it allows "partial" TLS as well such as only server or only client.
 	AllowInsecureHTTP bool `env:"ALLOW_INSECURE_HTTP" name:"allow-insecure-http" default:"false" help:"Allow insecure HTTP requests. Do not use in production"`
+	// AllowInsecureNetworks allows ssv-signer to work in insecure networks, which are blocked by default.
+	AllowInsecureNetworks bool `env:"ALLOW_INSECURE_NETWORKS" name:"allow-insecure-networks" default:"false" help:"Allow insecure HTTP networks. Do not use in production"`
 
 	// Server TLS configuration (for incoming connections to SSV Signer)
 	KeystoreFile         string `env:"KEYSTORE_FILE" env-description:"Path to PKCS12 keystore file for server TLS connections"`
@@ -75,6 +77,7 @@ func run(logger *zap.Logger, cli CLI) error {
 		zap.Bool("server_tls_enabled", cli.KeystoreFile != ""),
 		zap.Bool("client_tls_enabled", cli.Web3SignerKeystoreFile != ""),
 		zap.Bool("allow_insecure_http", cli.AllowInsecureHTTP),
+		zap.Bool("allow_insecure_networks", cli.AllowInsecureNetworks),
 	)
 
 	if cli.AllowInsecureHTTP {
@@ -118,7 +121,7 @@ func validateConfig(cli CLI) error {
 		return fmt.Errorf("neither private key nor keystore provided")
 	}
 
-	if err := validation.ValidateWeb3SignerEndpoint(cli.Web3SignerEndpoint); err != nil {
+	if err := validation.ValidateWeb3SignerEndpoint(cli.Web3SignerEndpoint, cli.AllowInsecureNetworks); err != nil {
 		return fmt.Errorf("invalid WEB3SIGNER_ENDPOINT: %w", err)
 	}
 


### PR DESCRIPTION
`ALLOW_INSECURE_NETWORKS`/`--allow-insecure-networks` allows endpoints that are blocked in `ValidateWeb3SignerEndpoint`