### PR TITLE
UPDATE [SSV-20] ssvsigner: Server-Side Request Forgery via Web3signer_endpoint Configuration 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/ssvlabs/eth2-key-manager v1.5.2
 	github.com/ssvlabs/ssv-spec v1.1.3
-	github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250626110133-f6f994903796
+	github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250626113238-124bb1a0584d
 	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.9.0
 	github.com/wealdtech/go-eth2-types/v2 v2.8.1

--- a/go.sum
+++ b/go.sum
@@ -756,8 +756,8 @@ github.com/ssvlabs/go-eth2-client v0.6.31-0.20250610091445-4c697a8c1568 h1:aOL0g
 github.com/ssvlabs/go-eth2-client v0.6.31-0.20250610091445-4c697a8c1568/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/ssvlabs/ssv-spec v1.1.3 h1:46K31kI4/vA7Vp3DaOuN7t2IABAmzeiMniCqYfzzpo8=
 github.com/ssvlabs/ssv-spec v1.1.3/go.mod h1:pto7dDv99uVfCZidiLrrKgFR6VYy6WY3PGI1TiGCsIU=
-github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250626110133-f6f994903796 h1:OQOtLYqHXHy9V8E9SrKf7YY6OaRE7LY61SY65Sz1Fa4=
-github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250626110133-f6f994903796/go.mod h1:C+KLGl4CcVkwmH50iocomM8lFZHHPvs7WSNL7QRZJ1E=
+github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250626113238-124bb1a0584d h1:RPXCnmmvMQ29MuyfylpoQx8eqGsE3Gc0AIP+00QN3Ns=
+github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250626113238-124bb1a0584d/go.mod h1:twWz30d2dyagPBp/epzNPnSulE6gbbj5lIWKnXssDLI=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/ssvsigner/cmd/internal/validation/url.go
+++ b/ssvsigner/cmd/internal/validation/url.go
@@ -1,182 +1,36 @@
 package validation
 
 import (
-	"errors"
 	"fmt"
-	"net"
 	"net/url"
-	"strings"
 )
 
-// blockedCIDRs contains IP ranges that should be blocked for SSRF prevention.
-// Sources: RFC 5735 (IPv4), RFC 6890, and IANA IPv6 Special-Purpose Address Registry.
-var blockedCIDRs = []string{
-	// IPv4 Private Networks - RFC 1918
-	"10.0.0.0/8",     // Private network - RFC 1918
-	"172.16.0.0/12",  // Private network - RFC 1918
-	"192.168.0.0/16", // Private network - RFC 1918
-
-	// IPv4 Special Use - RFC 5735
-	"0.0.0.0/8",          // Current network - RFC 1122
-	"169.254.0.0/16",     // Link-local - RFC 3927
-	"224.0.0.0/4",        // Multicast - RFC 3171
-	"240.0.0.0/4",        // Reserved - RFC 1112
-	"255.255.255.255/32", // Broadcast - RFC 919
-
-	// IPv4 Documentation and Test
-	"192.0.0.0/24",    // IETF Protocol Assignments - RFC 5736
-	"192.0.2.0/24",    // TEST-NET-1 - RFC 5737
-	"198.51.100.0/24", // TEST-NET-2 - RFC 5737
-	"203.0.113.0/24",  // TEST-NET-3 - RFC 5737
-	"192.88.99.0/24",  // IPv6 to IPv4 relay - RFC 3068
-	"198.18.0.0/15",   // Network benchmark - RFC 2544
-	"100.64.0.0/10",   // Shared Address Space - RFC 6598
-
-	// IPv6 Special Use - IANA Registry
-	"::/128",        // Unspecified - RFC 4291
-	"fc00::/7",      // Unique local - RFC 4193
-	"fe80::/10",     // Link-local - RFC 4291
-	"ff00::/8",      // Multicast - RFC 3513
-	"100::/64",      // Discard prefix - RFC 6666
-	"2001::/23",     // IETF Protocol Assignments - RFC 2928
-	"2001:2::/48",   // Benchmarking - RFC 5180
-	"2001:db8::/32", // Documentation - RFC 3849
-	"2001::/32",     // Teredo tunneling - RFC 4380
-	"2002::/16",     // 6to4 - RFC 3056
-	"64:ff9b::/96",  // IPv4/IPv6 translation - RFC 6052
-	"2001:10::/28",  // Deprecated ORCHID - RFC 4843
-	"2001:20::/28",  // ORCHIDv2 - RFC 7343
-}
-
-var blockedNetworks []*net.IPNet
-
-func init() {
-	for _, cidr := range blockedCIDRs {
-		_, network, _ := net.ParseCIDR(cidr)
-		if network != nil {
-			blockedNetworks = append(blockedNetworks, network)
-		}
-	}
-}
-
-// ValidateWeb3SignerEndpoint validates that a Web3Signer endpoint URL is safe from SSRF attacks.
+// ValidateWeb3SignerEndpoint validates the Web3Signer endpoint URL format.
 //
-// The function performs the following validations:
-//  1. URL format and scheme (only http/https allowed)
-//  2. Hostname presence
-//  3. IP address validation (if hostname is an IP)
-//  4. DNS resolution and validation of all resolved IPs (if hostname is a domain)
+// The function performs minimal validation:
+//   - Valid URL format
+//   - HTTP/HTTPS scheme (Web3Signer only supports these)
+//   - Hostname presence
 //
-// Allowed endpoints:
-//   - Public IP addresses (e.g., https://1.2.3.4:9000)
-//   - Localhost/loopback (e.g., http://localhost:9000, http://127.0.0.1:9000)
-//   - Domain names resolving to allowed IPs (e.g., https://web3signer.example.com)
+// Everything else is allowed, including:
+//   - Private networks (10.x.x.x, 192.168.x.x, etc.) - standard deployment pattern
+//   - Localhost/loopback - common for local deployments
+//   - Any public IP or domain
+//   - Unusual addresses (0.0.0.0, multicast) - will fail naturally at connection time
 //
-// Blocked endpoints:
-//   - Private networks (e.g., http://192.168.1.1, http://10.0.0.1)
-//   - Link-local addresses (e.g., http://169.254.169.254)
-//   - Special-use addresses (e.g., http://0.0.0.0, multicast, broadcast)
-//   - Non-HTTP(S) schemes (e.g., file://, ftp://)
-//
-// Returns an error if the endpoint is invalid or potentially unsafe, nil otherwise.
+// Returns an error if the URL format is invalid, nil otherwise.
 func ValidateWeb3SignerEndpoint(endpoint string) error {
 	u, err := url.ParseRequestURI(endpoint)
 	if err != nil {
 		return fmt.Errorf("invalid url format: %w", err)
 	}
 
-	// Only allow http/https
 	if u.Scheme != "http" && u.Scheme != "https" {
 		return fmt.Errorf("invalid url scheme %q: only http/https allowed", u.Scheme)
 	}
 
-	hostname := u.Hostname()
-	if hostname == "" {
+	if u.Hostname() == "" {
 		return fmt.Errorf("missing hostname in url")
-	}
-
-	// Check if it's an IP address
-	ip := net.ParseIP(hostname)
-	if ip != nil {
-		return isBlockedIP(ip)
-	}
-
-	// It's a domain name - resolve and validate all IPs
-	ips, err := net.LookupIP(hostname)
-	if err != nil {
-		var dnsErr *net.DNSError
-		if errors.As(err, &dnsErr) {
-			if dnsErr.IsNotFound {
-				return fmt.Errorf("hostname not found: %s", hostname)
-			}
-
-			if dnsErr.IsTimeout {
-				return fmt.Errorf("dns lookup timeout for hostname: %s", hostname)
-			}
-
-			if dnsErr.IsTemporary {
-				return fmt.Errorf("temporary dns failure for hostname: %s", hostname)
-			}
-		}
-		return fmt.Errorf("failed to resolve hostname %s: %w", hostname, err)
-	}
-
-	if len(ips) == 0 {
-		return fmt.Errorf("hostname %s did not resolve to any ip addresses", hostname)
-	}
-
-	var blockedIPs []string
-	for _, resolvedIP := range ips {
-		if err := isBlockedIP(resolvedIP); err != nil {
-			blockedIPs = append(blockedIPs, resolvedIP.String())
-		}
-	}
-
-	if len(blockedIPs) > 0 {
-		return fmt.Errorf("hostname %s resolves to blocked ip addresses: %s",
-			hostname, strings.Join(blockedIPs, ", "))
-	}
-
-	return nil
-}
-
-// isBlockedIP checks if an IP address should be blocked based on SSRF prevention rules.
-// It returns an error if the IP is in a blocked range, nil otherwise.
-//
-// The function blocks:
-//   - Unspecified addresses (0.0.0.0, ::)
-//   - Multicast addresses
-//   - Private networks (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7)
-//   - Link-local addresses (169.254.0.0/16, fe80::/10)
-//   - Special-use addresses (broadcast, documentation, test networks)
-//
-// The function allows:
-//   - Loopback addresses (127.0.0.0/8, ::1) for local Web3Signer support
-//   - All public IPv4 and IPv6 addresses
-func isBlockedIP(ip net.IP) error {
-	// Always block unspecified addresses
-	if ip.IsUnspecified() {
-		return fmt.Errorf("invalid ip address type (unspecified): %s", ip)
-	}
-
-	// Always block multicast
-	if ip.IsMulticast() {
-		return fmt.Errorf("invalid ip address type (multicast): %s", ip)
-	}
-
-	// Allow loopback (localhost)
-	if ip.IsLoopback() {
-		return nil
-	}
-
-	// Check against blocked networks
-	for _, network := range blockedNetworks {
-		if network.Contains(ip) {
-			if ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
-				return fmt.Errorf("private/internal ip addresses are not allowed: %s", ip)
-			}
-			return fmt.Errorf("ip address in blocked range: %s", ip)
-		}
 	}
 
 	return nil

--- a/ssvsigner/cmd/internal/validation/url_test.go
+++ b/ssvsigner/cmd/internal/validation/url_test.go
@@ -25,11 +25,6 @@ func TestValidateWeb3SignerEndpoint(t *testing.T) {
 			wantErr:  "",
 		},
 		{
-			name:     "invalid url format",
-			endpoint: "invalid-url",
-			wantErr:  "invalid url format",
-		},
-		{
 			name:     "localhost allowed",
 			endpoint: "http://localhost:9000",
 			wantErr:  "",
@@ -50,24 +45,64 @@ func TestValidateWeb3SignerEndpoint(t *testing.T) {
 			wantErr:  "",
 		},
 		{
-			name:     "private ip 192.168.x.x blocked",
+			name:     "private ip 192.168.x.x allowed",
 			endpoint: "http://192.168.1.1:9000",
-			wantErr:  "private/internal ip addresses are not allowed",
+			wantErr:  "",
 		},
 		{
-			name:     "private ip 10.x.x.x blocked",
+			name:     "private ip 10.x.x.x allowed",
 			endpoint: "http://10.0.0.1:9000",
-			wantErr:  "private/internal ip addresses are not allowed",
+			wantErr:  "",
 		},
 		{
-			name:     "private ip 172.16.x.x blocked",
+			name:     "private ip 172.16.x.x allowed",
 			endpoint: "http://172.16.0.1:9000",
-			wantErr:  "private/internal ip addresses are not allowed",
+			wantErr:  "",
 		},
 		{
-			name:     "link local blocked",
+			name:     "link local allowed",
 			endpoint: "http://169.254.1.1:9000",
-			wantErr:  "private/internal ip addresses are not allowed",
+			wantErr:  "",
+		},
+		{
+			name:     "metadata endpoint allowed (will fail at connection)",
+			endpoint: "http://169.254.169.254:9000",
+			wantErr:  "",
+		},
+		{
+			name:     "unspecified ipv4 allowed (will fail at connection)",
+			endpoint: "http://0.0.0.0:9000",
+			wantErr:  "",
+		},
+		{
+			name:     "unspecified ipv6 allowed (will fail at connection)",
+			endpoint: "http://[::]:9000",
+			wantErr:  "",
+		},
+		{
+			name:     "multicast ip allowed",
+			endpoint: "http://224.0.0.1:9000",
+			wantErr:  "",
+		},
+		{
+			name:     "ipv6 unique local allowed",
+			endpoint: "http://[fd00::1]:9000",
+			wantErr:  "",
+		},
+		{
+			name:     "broadcast address allowed",
+			endpoint: "http://255.255.255.255:9000",
+			wantErr:  "",
+		},
+		{
+			name:     "domain that may not exist (validation doesn't check DNS)",
+			endpoint: "https://web3signer.internal.company.com:9000",
+			wantErr:  "",
+		},
+		{
+			name:     "invalid url format",
+			endpoint: "invalid-url",
+			wantErr:  "invalid url format",
 		},
 		{
 			name:     "file scheme blocked",
@@ -85,29 +120,24 @@ func TestValidateWeb3SignerEndpoint(t *testing.T) {
 			wantErr:  "missing hostname in url",
 		},
 		{
-			name:     "unspecified ipv4",
-			endpoint: "http://0.0.0.0:9000",
-			wantErr:  "invalid ip address type (unspecified)",
+			name:     "empty string",
+			endpoint: "",
+			wantErr:  "invalid url format",
 		},
 		{
-			name:     "multicast ip blocked",
-			endpoint: "http://224.0.0.1:9000",
-			wantErr:  "invalid ip address type (multicast)",
+			name:     "just scheme",
+			endpoint: "http:",
+			wantErr:  "missing hostname in url",
 		},
 		{
-			name:     "non-existent domain",
-			endpoint: "https://this-domain-definitely-does-not-exist-12345.com",
-			wantErr:  "hostname not found",
+			name:     "javascript scheme blocked",
+			endpoint: "javascript:alert(1)",
+			wantErr:  "only http/https allowed",
 		},
 		{
-			name:     "ipv6 unique local blocked",
-			endpoint: "http://[fd00::1]:9000",
-			wantErr:  "private/internal ip addresses are not allowed",
-		},
-		{
-			name:     "broadcast address blocked",
-			endpoint: "http://255.255.255.255:9000",
-			wantErr:  "ip address in blocked range",
+			name:     "data scheme blocked",
+			endpoint: "data:text/html,<script>alert(1)</script>",
+			wantErr:  "only http/https allowed",
 		},
 	}
 

--- a/ssvsigner/cmd/ssv-signer/ssv-signer_test.go
+++ b/ssvsigner/cmd/ssv-signer/ssv-signer_test.go
@@ -24,9 +24,19 @@ func TestRun_InvalidWeb3SignerEndpoint(t *testing.T) {
 			wantErr:  "invalid WEB3SIGNER_ENDPOINT: invalid url format",
 		},
 		{
-			name:     "private IP blocked",
-			endpoint: "http://192.168.1.1:9000",
-			wantErr:  "invalid WEB3SIGNER_ENDPOINT: private/internal ip addresses are not allowed",
+			name:     "missing scheme",
+			endpoint: "192.168.1.1:9000",
+			wantErr:  "invalid WEB3SIGNER_ENDPOINT: invalid url format",
+		},
+		{
+			name:     "invalid scheme",
+			endpoint: "ftp://example.com",
+			wantErr:  "invalid WEB3SIGNER_ENDPOINT: invalid url scheme \"ftp\": only http/https allowed",
+		},
+		{
+			name:     "missing hostname",
+			endpoint: "http://",
+			wantErr:  "invalid WEB3SIGNER_ENDPOINT: missing hostname in url",
 		},
 	}
 

--- a/ssvsigner/go.mod
+++ b/ssvsigner/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/microsoft/go-crypto-openssl v0.2.9
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20240618144021-706c95b2dd15
 	github.com/ssvlabs/eth2-key-manager v1.5.2
-	github.com/ssvlabs/ssv v1.2.1-0.20250626110133-f6f994903796
+	github.com/ssvlabs/ssv v1.2.1-0.20250626113238-124bb1a0584d
 	github.com/ssvlabs/ssv-spec v1.1.3
 	github.com/stretchr/testify v1.9.0
 	github.com/valyala/fasthttp v1.58.0

--- a/ssvsigner/go.sum
+++ b/ssvsigner/go.sum
@@ -322,8 +322,8 @@ github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0b
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/ssvlabs/eth2-key-manager v1.5.2 h1:gF+8FJkoV1VXpVCPspyVW/Jdky0kt9Pndk88W8ePqx8=
 github.com/ssvlabs/eth2-key-manager v1.5.2/go.mod h1:yeUzAP+SBJXgeXPiGBrLeLuHIQCpeJZV7Jz3Fwzm/zk=
-github.com/ssvlabs/ssv v1.2.1-0.20250626110133-f6f994903796 h1:556QDkknYRK0SGy1SstNNmMsRXkCvir8LvZ13iyBCCM=
-github.com/ssvlabs/ssv v1.2.1-0.20250626110133-f6f994903796/go.mod h1:T8nGTyuqYK278r1qeQDYlHfij5ZXR9K9yfhNj+fFcXc=
+github.com/ssvlabs/ssv v1.2.1-0.20250626113238-124bb1a0584d h1:NfCX3FdO+Yfu0FEVT76cIa2T1PVy8QkTuA6pjlX/dmk=
+github.com/ssvlabs/ssv v1.2.1-0.20250626113238-124bb1a0584d/go.mod h1:fR4Vm5CaQfN967wxgkJLI9AxIQ9Jv+yagI/26iBszOU=
 github.com/ssvlabs/ssv-spec v1.1.3 h1:46K31kI4/vA7Vp3DaOuN7t2IABAmzeiMniCqYfzzpo8=
 github.com/ssvlabs/ssv-spec v1.1.3/go.mod h1:pto7dDv99uVfCZidiLrrKgFR6VYy6WY3PGI1TiGCsIU=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=


### PR DESCRIPTION
## Audit Finding — Private-IP Validation on `WEB3SIGNER_ENDPOINT`

### Audit description (summary)  
> `WEB3SIGNER_ENDPOINT` is validated only with `url.ParseRequestURI`, which allows schemes such as `http://localhost` or `http://10.x.x.x`.  
> An attacker who controls this value could make the SSV node call internal services (network scanning / sensitive endpoints).  
> Impact is limited because the node ↔ signer channel already uses mTLS.

---

## Why the private-IP block is **removed**

| Argument | Details |
| -------- | ------- |
| **1. Input isn’t untrusted** | Only the node **operator** sets `WEB3SIGNER_ENDPOINT`. SSRF defences target *untrusted user* input (see OWASP SSRF: <https://owasp.org/www-community/attacks/Server_Side_Request_Forgery>). |
| **2. Private subnet = safer** | Signing services are best kept on RFC 1918 ranges (<https://www.rfc-editor.org/rfc/rfc1918>). Forcing a **public** IP increases exposure. |
| **3. No industry precedent** | Teku, Lighthouse, Prysm all allow `http://localhost:9000` (example in Teku docs: <https://docs.teku.consensys.io/how-to/use-external-signer/>). |
| **4. Defence-in-depth already present** | mTLS, VPC/firewall rules, host egress policies protect the channel. Web3Signer’s own best practices emphasise network isolation (<https://docs.web3signer.consensys.io/>). |
| **5. Filter gives false confidence** | An attacker with env-var access could just point to a malicious **public** server; the old CIDR block wouldn’t help. |

---

## What we validate now

1. Well-formed URL.  
2. Scheme is **`http` or `https`**.  
3. Hostname is present.  

No CIDR filtering; `localhost` / private IPs are allowed.

---

We rely on mTLS + network controls. Blocking private ranges would break standard, safer deployments without meaningfully reducing risk.