### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @ssvlabs/ssv-team-lead @ssvlabs/approvers
+


### PR DESCRIPTION
Adding a `CODEOWNER`s file will result in a requirement to have at least one person from the teams to approve PR to be able to merge it