### PR TITLE
ssvsigner: load possible host names from whole certificate

### DIFF
--- a/ssvsigner/tls/tls.go
+++ b/ssvsigner/tls/tls.go
@@ -327,7 +327,7 @@ func verifyServerCertificate(state tls.ConnectionState, trustedFingerprints map[
 		}
 	}
 	// If we reach here, the server certificate is not trusted
-	return fmt.Errorf("server certificate fingerprint for hosts %q not trusted: %#v", hosts, formatFingerprint(fingerprintHex))
+	return fmt.Errorf("server certificate fingerprint for hosts %s not trusted: %q", hosts, formatFingerprint(fingerprintHex))
 }
 
 // verifyClientCertificate verifies a client certificate using fingerprints.


### PR DESCRIPTION
The previous behavior had unpredictable behavior when sometimes it check Servername sometimes it uses TLS hosts and so on.

But often with TLS the certificate has multiple valid  hosts that can be used in different scenarios and we should check all of them.