### PR TITLE
ssvsigner: log web3signer request duration

### DIFF
--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -149,8 +149,11 @@ func (s *Server) handleListValidators(ctx *fasthttp.RequestCtx) {
 	logger.Debug("received request")
 
 	start := time.Now()
+
 	resp, err := s.remoteSigner.ListKeys(ctx)
+
 	recordRemoteSignerOperation(ctx, opRemoteSignerListKeys, err, time.Since(start))
+	logger = logger.With(fields.Took(time.Since(start)))
 
 	if err != nil {
 		s.handleWeb3SignerErr(ctx, logger, resp, err)
@@ -220,8 +223,12 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 	}
 
 	start := time.Now()
+
 	resp, err := s.remoteSigner.ImportKeystore(ctx, importKeystoreReq)
+
 	recordRemoteSignerOperation(ctx, opRemoteSignerImportKeystore, err, time.Since(start))
+	logger = logger.With(fields.Took(time.Since(start)))
+
 	if err != nil {
 		s.handleWeb3SignerErr(ctx, logger, resp, err)
 		return
@@ -313,8 +320,12 @@ func (s *Server) handleRemoveValidator(ctx *fasthttp.RequestCtx) {
 	logger = logger.With(zap.Int("req_count", len(req.Pubkeys)))
 
 	start := time.Now()
+
 	resp, err := s.remoteSigner.DeleteKeystore(ctx, req)
+
 	recordRemoteSignerOperation(ctx, opRemoteSignerDeleteKeystore, err, time.Since(start))
+	logger = logger.With(fields.Took(time.Since(start)))
+
 	if err != nil {
 		s.handleWeb3SignerErr(ctx, logger, resp, err)
 		return
@@ -363,8 +374,12 @@ func (s *Server) handleSignValidator(ctx *fasthttp.RequestCtx) {
 	logger = logger.With(zap.String("type", string(req.Type)))
 
 	start := time.Now()
+
 	resp, err := s.remoteSigner.Sign(ctx, blsPubKey, req)
+
 	recordRemoteSignerOperation(ctx, opRemoteSignerValidatorSign, err, time.Since(start))
+	logger = logger.With(fields.Took(time.Since(start)))
+
 	if err != nil {
 		s.handleWeb3SignerErr(ctx, logger, resp, err)
 		return


### PR DESCRIPTION
The logs this PR adds could help to identify if slow ssv-signer responses are caused by ssv-signer's or web3signer's issues