### PR TITLE
ssvsigner: add remote keys summary

### DIFF
--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -269,6 +269,12 @@ func (c *Client) MissingKeys(ctx context.Context, localKeys []phase0.BLSPubKey) 
 		}
 	}
 
+	c.logger.Debug("check for missing keys completed",
+		zap.Int("remote_count", len(remoteKeys)),
+		zap.Int("local_count", len(localKeys)),
+		zap.Int("missing_count", len(missing)),
+	)
+
 	return missing, nil
 }
 


### PR DESCRIPTION
When web3signer has a lot of keys, it works slowlier. However, we don't log the number of keys, although we check it.

The PR adds a debug log with keys summary to help identify web3signer-related issues