### PR TITLE
chore: remove ANSI color codes from default log format

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -15,7 +15,7 @@ type Args struct {
 type GlobalConfig struct {
 	LogLevel       string `yaml:"LogLevel" env:"LOG_LEVEL" env-default:"info" env-description:"Log level (debug, info, warn, error)"`
 	LogFormat      string `yaml:"LogFormat" env:"LOG_FORMAT" env-default:"console" env-description:"Log encoding format (json, console)"`
-	LogLevelFormat string `yaml:"LogLevelFormat" env:"LOG_LEVEL_FORMAT" env-default:"capitalColor" env-description:"Log level format (capitalColor, capital, lowercase)"`
+	LogLevelFormat string `yaml:"LogLevelFormat" env:"LOG_LEVEL_FORMAT" env-default:"capital" env-description:"Log level format (capitalColor, capital, lowercase)"`
 	LogFilePath    string `yaml:"LogFilePath" env:"LOG_FILE_PATH" env-default:"./data/debug.log" env-description:"File path to write logs to"`
 	LogFileSize    int    `yaml:"LogFileSize" env:"LOG_FILE_SIZE" env-default:"500" env-description:"Maximum log file size in megabytes before rotation"`
 	LogFileBackups int    `yaml:"LogFileBackups" env:"LOG_FILE_BACKUPS" env-default:"3" env-description:"Number of rotated log files to keep"`


### PR DESCRIPTION
  ## Summary
  Changed default `LogLevelFormat` from `capitalColor` to `capital` to remove ANSI escape codes from logs.

  ## Problem
  Logs were showing ANSI color codes like `\u001b[35mDEBUG\u001b[0m` instead of clean `DEBUG` text. This causes noise in log aggregation systems (Loki, Elasticsearch) and makes parsing/querying more difficult.

  ## Solution
  Changed the default log level encoder from `capitalColor` to `capital`. This produces clean log output without terminal color codes while maintaining the same log level formatting.

