### PR TITLE
runners: errors should have all the details

### DIFF
--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -261,7 +261,7 @@ func (b *BaseRunner) basePartialSigMsgProcessing(
 	quorumReached := false
 
 	for _, msg := range signedMsg.Messages {
-		quorumReachedPreviuosly := container.HasQuorum(msg.ValidatorIndex, msg.SigningRoot)
+		quorumReachedPreviously := container.HasQuorum(msg.ValidatorIndex, msg.SigningRoot)
 
 		// Check if it has two signatures for the same signer
 		if container.HasSignature(msg.ValidatorIndex, msg.Signer, msg.SigningRoot) {
@@ -272,7 +272,7 @@ func (b *BaseRunner) basePartialSigMsgProcessing(
 
 		hasQuorum := container.HasQuorum(msg.ValidatorIndex, msg.SigningRoot)
 
-		if hasQuorum && !quorumReachedPreviuosly {
+		if hasQuorum && !quorumReachedPreviously {
 			// Notify about first quorum only
 			roots = append(roots, msg.SigningRoot)
 			quorumReached = true

--- a/protocol/v2/ssv/runner/runner.go
+++ b/protocol/v2/ssv/runner/runner.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -257,10 +258,10 @@ func (b *BaseRunner) basePartialSigMsgProcessing(
 	container *ssv.PartialSigContainer,
 ) (bool, [][32]byte) {
 	roots := make([][32]byte, 0)
-	anyQuorum := false
+	quorumReached := false
 
 	for _, msg := range signedMsg.Messages {
-		prevQuorum := container.HasQuorum(msg.ValidatorIndex, msg.SigningRoot)
+		quorumReachedPreviuosly := container.HasQuorum(msg.ValidatorIndex, msg.SigningRoot)
 
 		// Check if it has two signatures for the same signer
 		if container.HasSignature(msg.ValidatorIndex, msg.Signer, msg.SigningRoot) {
@@ -271,14 +272,14 @@ func (b *BaseRunner) basePartialSigMsgProcessing(
 
 		hasQuorum := container.HasQuorum(msg.ValidatorIndex, msg.SigningRoot)
 
-		if hasQuorum && !prevQuorum {
+		if hasQuorum && !quorumReachedPreviuosly {
 			// Notify about first quorum only
 			roots = append(roots, msg.SigningRoot)
-			anyQuorum = true
+			quorumReached = true
 		}
 	}
 
-	return anyQuorum, roots
+	return quorumReached, roots
 }
 
 // didDecideCorrectly returns true if the expected consensus instance decided correctly
@@ -301,11 +302,11 @@ func (b *BaseRunner) didDecideCorrectly(prevDecided bool, signedMessage *spectyp
 	}
 
 	if b.State.RunningInstance == nil {
-		return false, errors.New("decided wrong instance")
+		return false, fmt.Errorf("decided wrong instance (running instance is nil)")
 	}
 
 	if decidedMessage.Height != b.State.RunningInstance.GetHeight() {
-		return false, errors.New("decided wrong instance")
+		return false, fmt.Errorf("decided wrong instance (msg_height = %d, running_instance_height = %d)", decidedMessage.Height, b.State.RunningInstance.GetHeight())
 	}
 
 	// verify we decided running instance only, if not we do not proceed


### PR DESCRIPTION
This PR aims to add the missing details for various errors that runners/QBFT-related code emits, these are necessary to debug rare cases like the following (when it's not clear whether we have some bug in our QBFT code or if it's something expected - in which case we probably want to rework it such that it doesn't emit a "cryptic error"):
```
{
  "level": "DEBUG",
  "time": "2025-08-12T07:21:32.034520Z",
  "name": "Controller.Validator",
  "msg": "❗ could not handle message",
  "pubkey": "a690fd19afc6f07017c7ea12aea4071c05f9d08646fc525b2e6f5284f2bba72e4d13e1d5cbefab525a5f7f879821c2cc",
  "role": "AGGREGATOR_RUNNER",
  "msg_height": 1064157,
  "msg_round": 1,
  "consensus_msg_type": 2,
  "signers": [
    49,
    50,
    52
  ],
  "msg_type": "consensus",
  "error": "failed processing consensus message: decided wrong instance"
}
```