### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/operator/fee_recipient/controller.go
+++ b/operator/fee_recipient/controller.go
@@ -96,10 +96,7 @@ func (rc *recipientController) prepareAndSubmit(logger *zap.Logger, slot phase0.
 	const batchSize = 500
 	var submitted int
 	for start := 0; start < len(shares); start += batchSize {
-		end := start + batchSize
-		if end > len(shares) {
-			end = len(shares)
-		}
+		end := min(start+batchSize, len(shares))
 		batch := shares[start:end]
 
 		count, err := rc.submit(logger, batch)

--- a/operator/validator/metadata/syncer.go
+++ b/operator/validator/metadata/syncer.go
@@ -304,10 +304,7 @@ func (s *Syncer) nextBatch(_ context.Context, subnetsBuf *big.Int) []*ssvtypes.S
 	// Combine validators up to batchSize, prioritizing the new ones.
 	shares := newShares
 	if remainder := batchSize - len(shares); remainder > 0 {
-		end := remainder
-		if end > len(staleShares) {
-			end = len(staleShares)
-		}
+		end := min(remainder, len(staleShares))
 		shares = append(shares, staleShares[:end]...)
 	}
 


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.