### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -156,10 +156,7 @@ func (ec *ExecutionClient) fetchLogsInBatches(ctx context.Context, startBlock, e
 		defer close(errCh)
 
 		for fromBlock := startBlock; fromBlock <= endBlock; fromBlock += ec.logBatchSize {
-			toBlock := fromBlock + ec.logBatchSize - 1
-			if toBlock > endBlock {
-				toBlock = endBlock
-			}
+			toBlock := min(fromBlock+ec.logBatchSize-1, endBlock)
 
 			start := time.Now()
 			query := ethereum.FilterQuery{

--- a/network/discovery/shared_conn.go
+++ b/network/discovery/shared_conn.go
@@ -22,10 +22,7 @@ func (s *SharedUDPConn) ReadFromUDPAddrPort(b []byte) (n int, addr netip.AddrPor
 	if !ok {
 		return 0, netip.AddrPort{}, errors.New("connection was closed")
 	}
-	l := len(packet.Data)
-	if l > len(b) {
-		l = len(b)
-	}
+	l := min(len(packet.Data), len(b))
 	copy(b[:l], packet.Data[:l])
 	return l, packet.Addr, nil
 }

--- a/operator/fee_recipient/controller.go
+++ b/operator/fee_recipient/controller.go
@@ -97,10 +97,7 @@ func (rc *recipientController) prepareAndSubmit(ctx context.Context) error {
 	const batchSize = 500
 	var submitted int
 	for start := 0; start < len(shares); start += batchSize {
-		end := start + batchSize
-		if end > len(shares) {
-			end = len(shares)
-		}
+		end := min(start+batchSize, len(shares))
 		batch := shares[start:end]
 
 		count, err := rc.submit(ctx, batch)

--- a/protocol/v2/qbft/controller/types_test.go
+++ b/protocol/v2/qbft/controller/types_test.go
@@ -132,10 +132,7 @@ func TestInstances_AddNewInstance(t *testing.T) {
 				})
 
 				// Compare with mirror only the first (capacity) elements.
-				addedSoFarCap := capacity
-				if len(mirror) < capacity {
-					addedSoFarCap = len(mirror)
-				}
+				addedSoFarCap := min(len(mirror), capacity)
 				requireHeights(t, i, mirror[:addedSoFarCap]...)
 			}
 


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

The new pr for https://github.com/ssvlabs/ssv/pull/2455