### PR TITLE
fix: establish single source of truth for fee recipients

### DIFF
--- a/api/handlers/validators_test.go
+++ b/api/handlers/validators_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	v1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
@@ -498,6 +499,10 @@ func (m *mockShares) Drop() error {
 
 func (m *mockShares) UpdateValidatorsMetadata(_ beacon.ValidatorMetadataMap) (beacon.ValidatorMetadataMap, error) {
 	return nil, nil
+}
+
+func (m *mockShares) UpdateFeeRecipientForOwner(owner common.Address, feeRecipient bellatrix.ExecutionAddress) {
+	// no-op
 }
 
 // TestValidatorsList tests the List method of the Validators handler.

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -449,7 +449,6 @@ var StartNodeCmd = &cobra.Command{
 		cfg.SSVOptions.ValidatorOptions.OperatorDataStore = operatorDataStore
 		cfg.SSVOptions.ValidatorOptions.RegistryStorage = nodeStorage
 		cfg.SSVOptions.ValidatorOptions.ValidatorRegistrationSubmitter = validatorRegistrationSubmitter
-		cfg.SSVOptions.ValidatorOptions.RecipientsStorage = nodeStorage
 
 		var decidedStreamPublisherFn func(dutytracer.DecidedInfo)
 		if cfg.WsAPIPort != 0 {

--- a/migrations/migration_6_share_exit_epoch.go
+++ b/migrations/migration_6_share_exit_epoch.go
@@ -100,13 +100,12 @@ func mapShare(share *migration_6_OldStorageShare) *storage.Share {
 
 	domainShare := &types.SSVShare{
 		Share: spectypes.Share{
-			ValidatorPubKey:     validatorPubKey,
-			SharePubKey:         share.SharePubKey,
-			Committee:           committee,
-			DomainType:          share.DomainType,
-			FeeRecipientAddress: share.FeeRecipientAddress,
-			Graffiti:            share.Graffiti,
-			ValidatorIndex:      phase0.ValidatorIndex(share.ValidatorIndex),
+			ValidatorPubKey: validatorPubKey,
+			SharePubKey:     share.SharePubKey,
+			Committee:       committee,
+			DomainType:      share.DomainType,
+			Graffiti:        share.Graffiti,
+			ValidatorIndex:  phase0.ValidatorIndex(share.ValidatorIndex),
 		},
 		OwnerAddress:    share.OwnerAddress,
 		Liquidated:      share.Liquidated,

--- a/migrations/migration_6_share_exit_epoch_test.go
+++ b/migrations/migration_6_share_exit_epoch_test.go
@@ -172,7 +172,6 @@ func sharesEqual(left *migration_6_OldStorageShare, right *storage.Share) bool {
 		!bytes.Equal(left.SharePubKey, right.SharePubKey) ||
 		!bytes.Equal(left.Graffiti, right.Graffiti) ||
 		!bytes.Equal(left.DomainType[:], right.DomainType[:]) ||
-		!bytes.Equal(left.FeeRecipientAddress[:], right.FeeRecipientAddress[:]) ||
 		!bytes.Equal(left.OwnerAddress[:], right.OwnerAddress[:]) {
 		return false
 	}

--- a/operator/dutytracer/collector_test.go
+++ b/operator/dutytracer/collector_test.go
@@ -914,7 +914,7 @@ func TestCollector_getOrCreateCommitteeTrace(t *testing.T) {
 	require.NoError(t, err)
 
 	dutyStore := store.New(db)
-	_, vstore, _ := storage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, nil)
+	_, vstore, _ := storage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, &noOpRecipientReader{}, nil)
 
 	var committeeID = spectypes.CommitteeID{1}
 
@@ -1019,7 +1019,7 @@ func TestCollector_getOrCreateValidatorTrace(t *testing.T) {
 	require.NoError(t, err)
 
 	dutyStore := store.New(db)
-	_, vstore, _ := storage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, nil)
+	_, vstore, _ := storage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, &noOpRecipientReader{}, nil)
 
 	var vPubKey = spectypes.ValidatorPK{1}
 	var role = spectypes.BNRoleAggregator

--- a/operator/dutytracer/eviction_test.go
+++ b/operator/dutytracer/eviction_test.go
@@ -39,7 +39,7 @@ func TestEviction(t *testing.T) {
 	}
 
 	dutyStore := store.New(db)
-	_, vstore, _ := storage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, nil)
+	_, vstore, _ := storage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, &noOpRecipientReader{}, nil)
 
 	collector := New(t.Context(), zap.NewNop(), vstore, mockDomainDataProvider{}, dutyStore, networkconfig.TestNetwork.Beacon)
 

--- a/operator/dutytracer/store_test.go
+++ b/operator/dutytracer/store_test.go
@@ -30,7 +30,7 @@ func TestValidatorCommitteeMapping(t *testing.T) {
 	}
 
 	dutyStore := store.New(db)
-	_, vstore, _ := registrystorage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, nil)
+	_, vstore, _ := registrystorage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, &noOpRecipientReader{}, nil)
 
 	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.Beacon, nil)
 
@@ -137,7 +137,7 @@ func TestCommitteeDutyStore(t *testing.T) {
 	err = db.Set([]byte("val_pki"), validatorPK[:], value)
 	require.NoError(t, err)
 
-	_, vstore, _ := registrystorage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, nil)
+	_, vstore, _ := registrystorage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, &noOpRecipientReader{}, nil)
 
 	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.Beacon, nil)
 
@@ -315,7 +315,7 @@ func TestCommitteeDutyStore_GetAllCommitteeDecideds(t *testing.T) {
 	dutyStore := store.New(db)
 	err = db.Set([]byte("val_pki"), validatorPK7[:], encodeLittleEndian(index1))
 	require.NoError(t, err)
-	shares, vstore, _ := registrystorage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, nil)
+	shares, vstore, _ := registrystorage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, &noOpRecipientReader{}, nil)
 	shares.Save(db, &types.SSVShare{
 		Status: eth2apiv1.ValidatorStateActiveOngoing,
 		Share: spectypes.Share{
@@ -384,7 +384,7 @@ func TestValidatorDutyStore(t *testing.T) {
 	err = db.Set([]byte("val_pki"), validatorPK1[:], value)
 	require.NoError(t, err)
 
-	_, vstore, _ := registrystorage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, nil)
+	_, vstore, _ := registrystorage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, &noOpRecipientReader{}, nil)
 
 	collector := New(zap.NewNop(), vstore, nil, dutyStore, networkconfig.TestNetwork.Beacon, nil)
 

--- a/operator/fee_recipient/controller_test.go
+++ b/operator/fee_recipient/controller_test.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"testing"
-	"time"
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
@@ -20,8 +18,6 @@ import (
 	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability/log"
 	operatordatastore "github.com/ssvlabs/ssv/operator/datastore"
-	"github.com/ssvlabs/ssv/operator/slotticker"
-	"github.com/ssvlabs/ssv/operator/slotticker/mocks"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
 	"github.com/ssvlabs/ssv/protocol/v2/types"
 	registrystorage "github.com/ssvlabs/ssv/registry/storage"
@@ -40,109 +36,220 @@ func TestSubmitProposal(t *testing.T) {
 
 	operatorDataStore := operatordatastore.New(operatorData)
 
-	db, shareStorage, recipientStorage := createStorage(t)
-	defer db.Close()
+	db, shareStorage, recipientStorage := createStorageWithRecipients(t)
+	defer func() { require.NoError(t, db.Close()) }()
 
 	beaconConfig := networkconfig.TestNetwork.Beacon
 	populateStorage(t, shareStorage, operatorData)
 
 	frCtrl := NewController(logger, &ControllerOptions{
-		Ctx:               context.TODO(),
+		Ctx:               t.Context(),
 		BeaconConfig:      beaconConfig,
 		ShareStorage:      shareStorage,
-		RecipientStorage:  recipientStorage,
 		OperatorDataStore: operatorDataStore,
 	})
 
-	t.Run("submit first time or halfway through epoch", func(t *testing.T) {
-		numberOfRequests := 4
-		var wg sync.WaitGroup
-		wg.Add(numberOfRequests) // Set up the wait group before starting goroutines
+	t.Run("custom fee recipients from storage", func(t *testing.T) {
+		// Set custom fee recipients for some validators
+		customRecipient1 := bellatrix.ExecutionAddress{0x11, 0x22, 0x33, 0x44, 0x55}
+		customRecipient2 := bellatrix.ExecutionAddress{0xaa, 0xbb, 0xcc, 0xdd, 0xee}
+
+		owner1 := common.HexToAddress("0x0000000000000000000000000000000000000000")
+		owner2 := common.HexToAddress("0x0000000000000000000000000000000000000001")
+
+		_, err := recipientStorage.SaveRecipientData(nil, &registrystorage.RecipientData{
+			Owner:        owner1,
+			FeeRecipient: customRecipient1,
+		})
+		require.NoError(t, err)
+
+		_, err = recipientStorage.SaveRecipientData(nil, &registrystorage.RecipientData{
+			Owner:        owner2,
+			FeeRecipient: customRecipient2,
+		})
+		require.NoError(t, err)
+
+		var capturedRecipients map[phase0.ValidatorIndex]bellatrix.ExecutionAddress
 
 		client := beacon.NewMockBeaconNode(ctrl)
-		client.EXPECT().SubmitProposalPreparation(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, feeRecipients map[phase0.ValidatorIndex]bellatrix.ExecutionAddress) error {
-			wg.Done()
-			return nil
-		}).Times(numberOfRequests)
-
-		ticker := mocks.NewMockSlotTicker(ctrl)
-		mockTimeChan := make(chan time.Time)
-		mockSlotChan := make(chan phase0.Slot)
-		ticker.EXPECT().Next().Return(mockTimeChan).AnyTimes()
-		ticker.EXPECT().Slot().DoAndReturn(func() phase0.Slot {
-			return <-mockSlotChan
-		}).AnyTimes()
+		client.EXPECT().SubmitProposalPreparation(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, feeRecipients map[phase0.ValidatorIndex]bellatrix.ExecutionAddress) error {
+				capturedRecipients = feeRecipients
+				return nil
+			}).Times(1)
 
 		frCtrl.beaconClient = client
-		frCtrl.slotTickerProvider = func() slotticker.SlotTicker {
-			return ticker
+
+		err = frCtrl.prepareAndSubmit(t.Context())
+		require.NoError(t, err)
+
+		// Verify custom recipients are used for validators with index 0 and 1
+		require.Equal(t, customRecipient1, capturedRecipients[0])
+		require.Equal(t, customRecipient2, capturedRecipients[1])
+
+		// Verify owner address is used as default for others (e.g., index 2)
+		owner2Addr := common.HexToAddress("0x0000000000000000000000000000000000000002")
+		var expectedDefault bellatrix.ExecutionAddress
+		copy(expectedDefault[:], owner2Addr.Bytes())
+		require.Equal(t, expectedDefault, capturedRecipients[2])
+	})
+
+	t.Run("owner address as default fee recipient", func(t *testing.T) {
+		// Create fresh storage without custom recipients
+		db2, shareStorage2, _ := createStorageWithRecipients(t)
+		defer func() { require.NoError(t, db2.Close()) }()
+		populateStorage(t, shareStorage2, operatorData)
+
+		frCtrl2 := NewController(logger, &ControllerOptions{
+			Ctx:               t.Context(),
+			BeaconConfig:      beaconConfig,
+			ShareStorage:      shareStorage2,
+			OperatorDataStore: operatorDataStore,
+		})
+
+		var capturedRecipients map[phase0.ValidatorIndex]bellatrix.ExecutionAddress
+
+		client := beacon.NewMockBeaconNode(ctrl)
+		client.EXPECT().SubmitProposalPreparation(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, feeRecipients map[phase0.ValidatorIndex]bellatrix.ExecutionAddress) error {
+				capturedRecipients = feeRecipients
+				return nil
+			}).Times(1)
+
+		frCtrl2.beaconClient = client
+
+		err := frCtrl2.prepareAndSubmit(t.Context())
+		require.NoError(t, err)
+
+		// Verify all validators use their owner address as fee recipient
+		for i := 0; i < 10; i++ { // Check first 10 validators
+			ownerAddr := common.HexToAddress(fmt.Sprintf("0x%040x", i))
+			var expectedRecipient bellatrix.ExecutionAddress
+			copy(expectedRecipient[:], ownerAddr.Bytes())
+			require.Equal(t, expectedRecipient, capturedRecipients[phase0.ValidatorIndex(i)],
+				"Validator %d should use owner address as default fee recipient", i)
+		}
+	})
+
+	t.Run("correct validator index to fee recipient mapping", func(t *testing.T) {
+		var capturedRecipients map[phase0.ValidatorIndex]bellatrix.ExecutionAddress
+
+		client := beacon.NewMockBeaconNode(ctrl)
+		client.EXPECT().SubmitProposalPreparation(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, feeRecipients map[phase0.ValidatorIndex]bellatrix.ExecutionAddress) error {
+				capturedRecipients = feeRecipients
+				return nil
+			}).Times(1)
+
+		frCtrl.beaconClient = client
+
+		err := frCtrl.prepareAndSubmit(t.Context())
+		require.NoError(t, err)
+
+		// Verify mapping has correct number of entries (100 committee validators)
+		require.Len(t, capturedRecipients, 100)
+
+		// Verify each validator index maps to correct recipient
+		for i := 0; i < 100; i++ {
+			idx := phase0.ValidatorIndex(i)
+			_, exists := capturedRecipients[idx]
+			require.True(t, exists, "Validator index %d should be in the mapping", i)
 		}
 
-		go frCtrl.Start(t.Context())
+		// Verify non-committee validator (index 2000) is not included
+		_, exists := capturedRecipients[2000]
+		require.False(t, exists, "Non-committee validator should not be included")
+	})
 
-		slots := []phase0.Slot{
-			1,  // first time
-			2,  // should not call submit
-			20, // should not call submit
-			phase0.Slot(beaconConfig.SlotsPerEpoch / 2), // halfway through epoch
-			63, // should not call submit
+	t.Run("batch processing edge cases", func(t *testing.T) {
+		// Test with exactly 500 shares (one batch)
+		db2, shareStorage2, _ := createStorageWithRecipients(t)
+		defer func() { require.NoError(t, db2.Close()) }()
+
+		// Create exactly 500 shares
+		for i := 0; i < 500; i++ {
+			ownerAddr := common.HexToAddress(fmt.Sprintf("0x%040x", i))
+			share := &types.SSVShare{
+				Share: spectypes.Share{
+					ValidatorPubKey: spectypes.ValidatorPK([]byte(fmt.Sprintf("pk%046d", i))),
+					SharePubKey:     []byte(fmt.Sprintf("pk%046d", i)),
+					ValidatorIndex:  phase0.ValidatorIndex(i),
+					Committee:       []*spectypes.ShareMember{{Signer: operatorData.ID}},
+				},
+				Status:       eth2apiv1.ValidatorStateActiveOngoing,
+				OwnerAddress: ownerAddr,
+				Liquidated:   false,
+			}
+			require.NoError(t, shareStorage2.Save(nil, share))
 		}
 
-		for _, s := range slots {
-			mockTimeChan <- time.Now()
-			mockSlotChan <- s
-			time.Sleep(time.Millisecond * 500)
-		}
+		frCtrl2 := NewController(logger, &ControllerOptions{
+			Ctx:               t.Context(),
+			BeaconConfig:      beaconConfig,
+			ShareStorage:      shareStorage2,
+			OperatorDataStore: operatorDataStore,
+		})
 
-		wg.Wait()
+		batchSize := 0
 
-		close(mockTimeChan) // Close the channel after test
-		close(mockSlotChan)
+		client := beacon.NewMockBeaconNode(ctrl)
+		client.EXPECT().SubmitProposalPreparation(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, feeRecipients map[phase0.ValidatorIndex]bellatrix.ExecutionAddress) error {
+				batchSize = len(feeRecipients)
+				return nil
+			}).Times(1)
+
+		frCtrl2.beaconClient = client
+
+		err := frCtrl2.prepareAndSubmit(t.Context())
+		require.NoError(t, err)
+
+		// Should have exactly 1 batch of 500
+		require.Equal(t, 500, batchSize)
 	})
 
 	t.Run("error handling", func(t *testing.T) {
-		var wg sync.WaitGroup
+		// Test that errors are handled gracefully
+		db3, shareStorage3, _ := createStorageWithRecipients(t)
+		defer func() { require.NoError(t, db3.Close()) }()
+		populateStorage(t, shareStorage3, operatorData)
+
+		frCtrl3 := NewController(logger, &ControllerOptions{
+			Ctx:               t.Context(),
+			BeaconConfig:      beaconConfig,
+			ShareStorage:      shareStorage3,
+			OperatorDataStore: operatorDataStore,
+		})
+
 		client := beacon.NewMockBeaconNode(ctrl)
-		client.EXPECT().SubmitProposalPreparation(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, feeRecipients map[phase0.ValidatorIndex]bellatrix.ExecutionAddress) error {
-			wg.Done()
-			return errors.New("failed to submit")
-		}).MinTimes(2).MaxTimes(2)
+		client.EXPECT().SubmitProposalPreparation(gomock.Any(), gomock.Any()).Return(errors.New("failed to submit")).Times(1)
 
-		ticker := mocks.NewMockSlotTicker(ctrl)
-		mockTimeChan := make(chan time.Time, 1)
-		ticker.EXPECT().Next().Return(mockTimeChan).AnyTimes()
-		ticker.EXPECT().Slot().Return(phase0.Slot(100)).AnyTimes()
+		frCtrl3.beaconClient = client
 
-		frCtrl.beaconClient = client
-		frCtrl.slotTickerProvider = func() slotticker.SlotTicker {
-			return ticker
-		}
-
-		go frCtrl.Start(t.Context())
-		mockTimeChan <- time.Now()
-		wg.Add(2)
-		wg.Wait()
-		close(mockTimeChan)
+		// Should handle error gracefully without panic
+		err := frCtrl3.prepareAndSubmit(t.Context())
+		require.NoError(t, err) // prepareAndSubmit logs errors but returns nil
 	})
 }
 
-func createStorage(t *testing.T) (basedb.Database, registrystorage.Shares, registrystorage.Recipients) {
+func createStorageWithRecipients(t *testing.T) (basedb.Database, registrystorage.Shares, registrystorage.Recipients) {
 	logger := log.TestLogger(t)
 	db, err := kv.NewInMemory(logger, basedb.Options{})
 	require.NoError(t, err)
 
-	shareStorage, _, err := registrystorage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, []byte("test"))
+	recipientStorage, setSharesUpdater := registrystorage.NewRecipientsStorage(logger, db, []byte("test"))
+	shareStorage, _, err := registrystorage.NewSharesStorage(networkconfig.TestNetwork.Beacon, db, recipientStorage, []byte("test"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	return db, shareStorage, registrystorage.NewRecipientsStorage(logger, db, []byte("test"))
+	setSharesUpdater(shareStorage)
+	return db, shareStorage, recipientStorage
 }
 
 func populateStorage(t *testing.T, storage registrystorage.Shares, operatorData *registrystorage.OperatorData) {
 	createShare := func(index int, operatorID spectypes.OperatorID) *types.SSVShare {
-		ownerAddr := fmt.Sprintf("%d", index)
-		ownerAddrByte := [20]byte{}
-		copy(ownerAddrByte[:], ownerAddr)
+		// Create owner address consistently with fmt.Sprintf("0x%040x", index)
+		ownerAddr := common.HexToAddress(fmt.Sprintf("0x%040x", index))
 
 		return &types.SSVShare{
 			Share: spectypes.Share{ValidatorPubKey: spectypes.ValidatorPK([]byte(fmt.Sprintf("pk%046d", index))),
@@ -151,12 +258,12 @@ func populateStorage(t *testing.T, storage registrystorage.Shares, operatorData 
 				Committee:      []*spectypes.ShareMember{{Signer: operatorID}},
 			},
 			Status:       eth2apiv1.ValidatorStateActiveOngoing,
-			OwnerAddress: common.BytesToAddress(ownerAddrByte[:]),
+			OwnerAddress: ownerAddr,
 			Liquidated:   false,
 		}
 	}
 
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 100; i++ {
 		require.NoError(t, storage.Save(nil, createShare(i, operatorData.ID)))
 	}
 
@@ -164,5 +271,5 @@ func populateStorage(t *testing.T, storage registrystorage.Shares, operatorData 
 	require.NoError(t, storage.Save(nil, createShare(2000, spectypes.OperatorID(1))))
 
 	all := storage.List(nil, registrystorage.ByOperatorID(operatorData.ID), registrystorage.ByNotLiquidated())
-	require.Equal(t, 1000, len(all))
+	require.Equal(t, 100, len(all))
 }

--- a/operator/node.go
+++ b/operator/node.go
@@ -97,7 +97,6 @@ func New(logger *zap.Logger, opts Options, exporterOpts exporter.Options, slotTi
 			BeaconClient:       opts.BeaconNode,
 			BeaconConfig:       opts.NetworkConfig.Beacon,
 			ShareStorage:       opts.ValidatorOptions.RegistryStorage.Shares(),
-			RecipientStorage:   opts.ValidatorOptions.RegistryStorage,
 			OperatorDataStore:  opts.ValidatorOptions.OperatorDataStore,
 			SlotTickerProvider: slotTickerProvider,
 		}),

--- a/operator/validator/mocks/controller.go
+++ b/operator/validator/mocks/controller.go
@@ -282,61 +282,6 @@ func (mr *MockControllerMockRecorder) ValidatorRegistrationChan() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatorRegistrationChan", reflect.TypeOf((*MockController)(nil).ValidatorRegistrationChan))
 }
 
-// MockRecipients is a mock of Recipients interface.
-type MockRecipients struct {
-	ctrl     *gomock.Controller
-	recorder *MockRecipientsMockRecorder
-	isgomock struct{}
-}
-
-// MockRecipientsMockRecorder is the mock recorder for MockRecipients.
-type MockRecipientsMockRecorder struct {
-	mock *MockRecipients
-}
-
-// NewMockRecipients creates a new mock instance.
-func NewMockRecipients(ctrl *gomock.Controller) *MockRecipients {
-	mock := &MockRecipients{ctrl: ctrl}
-	mock.recorder = &MockRecipientsMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockRecipients) EXPECT() *MockRecipientsMockRecorder {
-	return m.recorder
-}
-
-// GetRecipientData mocks base method.
-func (m *MockRecipients) GetRecipientData(r basedb.Reader, owner common.Address) (*storage.RecipientData, bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRecipientData", r, owner)
-	ret0, _ := ret[0].(*storage.RecipientData)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetRecipientData indicates an expected call of GetRecipientData.
-func (mr *MockRecipientsMockRecorder) GetRecipientData(r, owner any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecipientData", reflect.TypeOf((*MockRecipients)(nil).GetRecipientData), r, owner)
-}
-
-// SaveRecipientData mocks base method.
-func (m *MockRecipients) SaveRecipientData(rw basedb.ReadWriter, recipientData *storage.RecipientData) (*storage.RecipientData, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveRecipientData", rw, recipientData)
-	ret0, _ := ret[0].(*storage.RecipientData)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SaveRecipientData indicates an expected call of SaveRecipientData.
-func (mr *MockRecipientsMockRecorder) SaveRecipientData(rw, recipientData any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveRecipientData", reflect.TypeOf((*MockRecipients)(nil).SaveRecipientData), rw, recipientData)
-}
-
 // MockSharesStorage is a mock of SharesStorage interface.
 type MockSharesStorage struct {
 	ctrl     *gomock.Controller

--- a/operator/validator/task_executor_test.go
+++ b/operator/validator/task_executor_test.go
@@ -10,11 +10,9 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/herumi/bls-eth-go-binary/bls"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
-
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"github.com/ssvlabs/ssv-spec/types/testingutils"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ssvlabs/ssv/ssvsigner/keys"
 
@@ -48,7 +46,7 @@ func TestController_LiquidateCluster(t *testing.T) {
 	operatorPrivateKey, err := keys.GeneratePrivateKey()
 	require.NoError(t, err)
 
-	ctrl, logger, sharesStorage, network, _, recipientStorage, bc := setupCommonTestComponents(t, operatorPrivateKey)
+	ctrl, logger, sharesStorage, network, _, bc := setupCommonTestComponents(t, operatorPrivateKey)
 	defer ctrl.Finish()
 	testValidatorsMap := map[spectypes.ValidatorPK]*validator.Validator{
 		spectypes.ValidatorPK(secretKey.GetPublicKey().Serialize()): firstValidator,
@@ -63,7 +61,6 @@ func TestController_LiquidateCluster(t *testing.T) {
 		network:             network,
 		operatorDataStore:   operatorDataStore,
 		sharesStorage:       sharesStorage,
-		recipientsStorage:   recipientStorage,
 		validatorsMap:       mockValidatorsMap,
 		validatorCommonOpts: &validator.CommonOptions{},
 	}
@@ -111,7 +108,7 @@ func TestController_StopValidator(t *testing.T) {
 	operatorPrivateKey, err := keys.GeneratePrivateKey()
 	require.NoError(t, err)
 
-	ctrl, logger, sharesStorage, network, signer, recipientStorage, bc := setupCommonTestComponents(t, operatorPrivateKey)
+	ctrl, logger, sharesStorage, network, signer, bc := setupCommonTestComponents(t, operatorPrivateKey)
 
 	defer ctrl.Finish()
 
@@ -128,7 +125,6 @@ func TestController_StopValidator(t *testing.T) {
 		network:             network,
 		operatorDataStore:   operatorDataStore,
 		sharesStorage:       sharesStorage,
-		recipientsStorage:   recipientStorage,
 		validatorsMap:       mockValidatorsMap,
 		validatorCommonOpts: &validator.CommonOptions{},
 		signer:              signer,
@@ -188,7 +184,7 @@ func TestController_ReactivateCluster(t *testing.T) {
 	operatorPrivKey, err := keys.GeneratePrivateKey()
 	require.NoError(t, err)
 
-	ctrl, logger, sharesStorage, network, signer, recipientStorage, bc := setupCommonTestComponents(t, operatorPrivKey)
+	ctrl, logger, sharesStorage, network, signer, bc := setupCommonTestComponents(t, operatorPrivKey)
 	defer ctrl.Finish()
 	mockValidatorsMap := validators.New(context.TODO())
 	validatorStartFunc := func(validator *validator.Validator) (bool, error) {
@@ -199,7 +195,6 @@ func TestController_ReactivateCluster(t *testing.T) {
 		network:           network,
 		operatorDataStore: operatorDataStore,
 		sharesStorage:     sharesStorage,
-		recipientsStorage: recipientStorage,
 		validatorsMap:     mockValidatorsMap,
 		networkConfig:     networkconfig.TestNetwork,
 		validatorCommonOpts: &validator.CommonOptions{
@@ -257,8 +252,6 @@ func TestController_ReactivateCluster(t *testing.T) {
 			ActivationEpoch: 1,
 		},
 	}
-	recipientData := buildFeeRecipient("67Ce5c69260bd819B4e0AD13f4b873074D479811", "45E668aba4b7fc8761331EC3CE77584B7A99A51A")
-	recipientStorage.EXPECT().GetRecipientData(gomock.Any(), gomock.Any()).AnyTimes().Return(recipientData, true, nil)
 
 	indiciesUpdate := make(chan struct{})
 	go func() {

--- a/protocol/v2/ssv/testing/runner.go
+++ b/protocol/v2/ssv/testing/runner.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/ethereum/go-ethereum/common"
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	spectestingutils "github.com/ssvlabs/ssv-spec/types/testingutils"
@@ -117,9 +116,6 @@ var ConstructBaseRunner = func(
 	shareMap[share.ValidatorIndex] = share
 	dutyGuard := validator.NewCommitteeDutyGuard()
 
-	rStorage := mocks.NewMockrecipientsStorage()
-	rStorage.FeeRecipient = share.FeeRecipientAddress
-
 	var r runner.Runner
 	var err error
 
@@ -189,12 +185,10 @@ var ConstructBaseRunner = func(
 		r, err = runner.NewValidatorRegistrationRunner(
 			networkconfig.TestNetwork,
 			shareMap,
-			common.Address{},
 			beaconNode,
 			net,
 			km,
 			opSigner,
-			rStorage,
 			mocks.NewValidatorRegistrationSubmitter(beaconNode),
 			runner.DefaultGasLimitOld,
 		)
@@ -452,12 +446,10 @@ var ConstructBaseRunnerWithShareMap = func(
 		r, err = runner.NewValidatorRegistrationRunner(
 			networkconfig.TestNetwork,
 			shareMap,
-			common.Address{},
 			beaconNode,
 			net,
 			km,
 			opSigner,
-			nil, // recipientStorage is unused in these tests
 			mocks.NewValidatorRegistrationSubmitter(beaconNode),
 			runner.DefaultGasLimitOld,
 		)


### PR DESCRIPTION
 ## Summary
  Establishes shares storage as the single source of truth for fee recipients by fixing the architecture where fee recipients were incorrectly persisted in shares but never used. All fee recipient
  reads now go through shares storage, which internally manages the data using recipients storage.

  ## Key Changes

  ### Architecture Fix
  - **Single Interface**: All components must read fee recipients through shares storage (Validator Store)
  - **Proper Wiring**: Recipients storage notifies shares storage of updates via `SharesUpdater` interface
  - **Runtime Enrichment**: Shares automatically fetch current fee recipients when loaded from DB

  ## Why This Matters
  Previously:
  - Fee recipients stored in shares could become stale
  - Validator controller had to manually set fee recipients
  - Multiple components could access recipients storage directly
  - Risk of using outdated fee recipient data

  Now:
  - ✅ Single source of truth enforced architecturally
  - ✅ Automatic enrichment - no manual intervention needed
  - ✅ Impossible to use stale data
  - ✅ Clean separation - recipients storage is implementation detail