### PR TITLE
generate-operator-keys: support legacy "pubKey" field in keystore

### DIFF
--- a/cli/generate_operator_keys.go
+++ b/cli/generate_operator_keys.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"path/filepath"
 
-	ssvlog "github.com/ssvlabs/ssv/observability/log"
 	"github.com/ssvlabs/ssv/ssvsigner/keys"
 	"github.com/ssvlabs/ssv/ssvsigner/keystore"
+
+	ssvlog "github.com/ssvlabs/ssv/observability/log"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -24,6 +25,7 @@ var generateOperatorKeysCmd = &cobra.Command{
 		logger := zap.L().Named(ssvlog.NameExportKeys)
 		passwordFilePath, _ := cmd.Flags().GetString("password-file")
 		privateKeyFilePath, _ := cmd.Flags().GetString("operator-key-file")
+		legacyPubkey, _ := cmd.Flags().GetBool("legacy-pubkey")
 
 		privKey, err := keys.GeneratePrivateKey()
 		if err != nil {
@@ -53,7 +55,7 @@ var generateOperatorKeysCmd = &cobra.Command{
 				logger.Fatal("Failed to read password file", zap.Error(err))
 			}
 
-			encryptedJSON, encryptedJSONErr := keystore.EncryptKeystore(privKey.Bytes(), pubKeyBase64, string(passwordBytes))
+			encryptedJSON, encryptedJSONErr := keystore.EncryptKeystore(privKey.Bytes(), pubKeyBase64, string(passwordBytes), legacyPubkey)
 			if encryptedJSONErr != nil {
 				logger.Fatal("Failed to encrypt private key", zap.Error(err))
 			}
@@ -88,5 +90,6 @@ func readFile(filePath string) ([]byte, error) {
 func init() {
 	generateOperatorKeysCmd.Flags().StringP("password-file", "p", "", "File path to the password used to encrypt the private key")
 	generateOperatorKeysCmd.Flags().StringP("operator-key-file", "o", "", "File path to the operator private key")
+	generateOperatorKeysCmd.Flags().BoolP("legacy-pubkey", "l", false, `Store public key in keystore in legacy format ("pubKey" instead of "pubkey")`)
 	RootCmd.AddCommand(generateOperatorKeysCmd)
 }

--- a/cli/generate_operator_keys.go
+++ b/cli/generate_operator_keys.go
@@ -57,7 +57,7 @@ var generateOperatorKeysCmd = &cobra.Command{
 
 			encryptedJSON, encryptedJSONErr := keystore.EncryptKeystore(privKey.Bytes(), pubKeyBase64, string(passwordBytes), legacyPubkey)
 			if encryptedJSONErr != nil {
-				logger.Fatal("Failed to encrypt private key", zap.Error(err))
+				logger.Fatal("Failed to encrypt private key", zap.Error(encryptedJSONErr))
 			}
 
 			err = writeFile("encrypted_private_key.json", encryptedJSON)

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/ssvlabs/eth2-key-manager v1.5.5
 	github.com/ssvlabs/ssv-spec v1.1.3
-	github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250825134032-2327603275e0
+	github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250825140236-3dcbd8c693f7
 	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.10.0
 	github.com/wealdtech/go-eth2-types/v2 v2.8.1

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/ssvlabs/eth2-key-manager v1.5.5
 	github.com/ssvlabs/ssv-spec v1.1.3
-	github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250806153219-2dc63a642d9d
+	github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250825134032-2327603275e0
 	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.10.0
 	github.com/wealdtech/go-eth2-types/v2 v2.8.1

--- a/go.sum
+++ b/go.sum
@@ -765,6 +765,8 @@ github.com/ssvlabs/ssv-spec v1.1.3 h1:46K31kI4/vA7Vp3DaOuN7t2IABAmzeiMniCqYfzzpo
 github.com/ssvlabs/ssv-spec v1.1.3/go.mod h1:pto7dDv99uVfCZidiLrrKgFR6VYy6WY3PGI1TiGCsIU=
 github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250806153219-2dc63a642d9d h1:oMznS0mfgfEob1B0nSLZpGaAq0r1dhHFLOZ7PF/JbcA=
 github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250806153219-2dc63a642d9d/go.mod h1:pv9+Hl60/Vkj20g/8YhaWWLDbeq8+SHZc8Cu5f2Klb4=
+github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250825134032-2327603275e0 h1:kpk8t0fLVOXP2sWORBq76OgeJlOTo3CISLhaMorlNQ0=
+github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250825134032-2327603275e0/go.mod h1:zgC1yUHRJdzoma1q1xQCD/e/YUHawaMorqu7JQj9iCk=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -763,8 +763,6 @@ github.com/ssvlabs/go-eth2-client v0.6.31-0.20250807154556-0c7614aa26d4 h1:/Sq9p
 github.com/ssvlabs/go-eth2-client v0.6.31-0.20250807154556-0c7614aa26d4/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/ssvlabs/ssv-spec v1.1.3 h1:46K31kI4/vA7Vp3DaOuN7t2IABAmzeiMniCqYfzzpo8=
 github.com/ssvlabs/ssv-spec v1.1.3/go.mod h1:pto7dDv99uVfCZidiLrrKgFR6VYy6WY3PGI1TiGCsIU=
-github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250806153219-2dc63a642d9d h1:oMznS0mfgfEob1B0nSLZpGaAq0r1dhHFLOZ7PF/JbcA=
-github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250806153219-2dc63a642d9d/go.mod h1:pv9+Hl60/Vkj20g/8YhaWWLDbeq8+SHZc8Cu5f2Klb4=
 github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250825134032-2327603275e0 h1:kpk8t0fLVOXP2sWORBq76OgeJlOTo3CISLhaMorlNQ0=
 github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250825134032-2327603275e0/go.mod h1:zgC1yUHRJdzoma1q1xQCD/e/YUHawaMorqu7JQj9iCk=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=

--- a/go.sum
+++ b/go.sum
@@ -763,8 +763,8 @@ github.com/ssvlabs/go-eth2-client v0.6.31-0.20250807154556-0c7614aa26d4 h1:/Sq9p
 github.com/ssvlabs/go-eth2-client v0.6.31-0.20250807154556-0c7614aa26d4/go.mod h1:fvULSL9WtNskkOB4i+Yyr6BKpNHXvmpGZj9969fCrfY=
 github.com/ssvlabs/ssv-spec v1.1.3 h1:46K31kI4/vA7Vp3DaOuN7t2IABAmzeiMniCqYfzzpo8=
 github.com/ssvlabs/ssv-spec v1.1.3/go.mod h1:pto7dDv99uVfCZidiLrrKgFR6VYy6WY3PGI1TiGCsIU=
-github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250825134032-2327603275e0 h1:kpk8t0fLVOXP2sWORBq76OgeJlOTo3CISLhaMorlNQ0=
-github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250825134032-2327603275e0/go.mod h1:zgC1yUHRJdzoma1q1xQCD/e/YUHawaMorqu7JQj9iCk=
+github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250825140236-3dcbd8c693f7 h1:i1SQf6Pfs4O6gEBmjYPNf9vxiKFm24+ugRDk3WB5hHk=
+github.com/ssvlabs/ssv/ssvsigner v0.0.0-20250825140236-3dcbd8c693f7/go.mod h1:zgC1yUHRJdzoma1q1xQCD/e/YUHawaMorqu7JQj9iCk=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/ssvsigner/keystore/file.go
+++ b/ssvsigner/keystore/file.go
@@ -42,7 +42,9 @@ func DecryptKeystore(encryptedJSONData []byte, password string) ([]byte, error) 
 }
 
 // EncryptKeystore encrypts a private key using the provided password, adds in the public key and returns the encrypted keystore JSON data.
-func EncryptKeystore(privkey []byte, pubKeyBase64, password string) ([]byte, error) {
+// Initially, it used to save the public key as `pubKey`, which was changed to `pubkey` afterwards.
+// The `legacyPubkey` parameter makes the function use `pubKey` instead of `pubkey`.
+func EncryptKeystore(privkey []byte, pubKeyBase64, password string, legacyPubkey bool) ([]byte, error) {
 	if strings.TrimSpace(password) == "" {
 		return nil, errors.New("password required for encrypting keystore")
 	}
@@ -53,7 +55,11 @@ func EncryptKeystore(privkey []byte, pubKeyBase64, password string) ([]byte, err
 		return nil, fmt.Errorf("encrypt private key: %w", err)
 	}
 
-	encryptedKeystoreJSON["pubkey"] = pubKeyBase64
+	if legacyPubkey {
+		encryptedKeystoreJSON["pubKey"] = pubKeyBase64
+	} else {
+		encryptedKeystoreJSON["pubkey"] = pubKeyBase64
+	}
 
 	encryptedData, err := json.Marshal(encryptedKeystoreJSON)
 	if err != nil {

--- a/ssvsigner/keystore/file_test.go
+++ b/ssvsigner/keystore/file_test.go
@@ -66,13 +66,33 @@ func TestEncryptKeystore(t *testing.T) {
 
 		privkey := []byte("privateKey")
 
-		data, err := EncryptKeystore(privkey, testPubKeyBase64, testPassword)
+		data, err := EncryptKeystore(privkey, testPubKeyBase64, testPassword, false)
 		require.NoError(t, err)
 
 		var jsonData map[string]interface{}
 		err = json.Unmarshal(data, &jsonData)
 		require.NoError(t, err)
 		require.Equal(t, testPubKeyBase64, jsonData["pubkey"])
+		require.Nil(t, jsonData["pubKey"])
+
+		decrtypted, err := DecryptKeystore(data, testPassword)
+		require.NoError(t, err)
+		require.Equal(t, privkey, decrtypted)
+	})
+
+	t.Run("with valid data (legacy format)", func(t *testing.T) {
+		t.Parallel()
+
+		privkey := []byte("privateKey")
+
+		data, err := EncryptKeystore(privkey, testPubKeyBase64, testPassword, true)
+		require.NoError(t, err)
+
+		var jsonData map[string]interface{}
+		err = json.Unmarshal(data, &jsonData)
+		require.NoError(t, err)
+		require.Equal(t, testPubKeyBase64, jsonData["pubKey"])
+		require.Nil(t, jsonData["pubkey"])
 
 		decrtypted, err := DecryptKeystore(data, testPassword)
 		require.NoError(t, err)
@@ -85,7 +105,7 @@ func TestEncryptKeystore(t *testing.T) {
 		password := ""
 		privkey := []byte("privateKey")
 
-		_, err := EncryptKeystore(privkey, testPubKeyBase64, password)
+		_, err := EncryptKeystore(privkey, testPubKeyBase64, password, false)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "password required")
 	})
@@ -95,7 +115,7 @@ func TestEncryptKeystore(t *testing.T) {
 
 		var privkey []byte = nil
 
-		_, err := EncryptKeystore(privkey, testPubKeyBase64, testPassword)
+		_, err := EncryptKeystore(privkey, testPubKeyBase64, testPassword, false)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "encrypt private key")
 	})
@@ -164,7 +184,7 @@ func TestLoadOperatorKeystore(t *testing.T) {
 
 		privkey := []byte("privateKey")
 
-		keystore, err := EncryptKeystore(privkey, testPubKeyBase64, testPassword)
+		keystore, err := EncryptKeystore(privkey, testPubKeyBase64, testPassword, false)
 		require.NoError(t, err)
 
 		tmpEncryptedFile := createTempFile(t, "bad-for-privkey-", ".json", keystore)
@@ -185,7 +205,7 @@ func TestLoadOperatorKeystore(t *testing.T) {
 		privKey, err := keys.GeneratePrivateKey()
 		require.NoError(t, err)
 
-		keystore, err := EncryptKeystore(privKey.Bytes(), testPubKeyBase64, testPassword)
+		keystore, err := EncryptKeystore(privKey.Bytes(), testPubKeyBase64, testPassword, false)
 		require.NoError(t, err)
 
 		tmpEncryptedFile := createTempFile(t, "valid-encrypted-", ".json", keystore)

--- a/ssvsigner/keystore/file_test.go
+++ b/ssvsigner/keystore/file_test.go
@@ -78,8 +78,6 @@ func TestEncryptKeystore(t *testing.T) {
 		decrypted, err := DecryptKeystore(data, testPassword)
 		require.NoError(t, err)
 		require.Equal(t, privkey, decrypted)
-		require.NoError(t, err)
-		require.Equal(t, privkey, decrypted)
 	})
 
 	t.Run("with valid data (legacy format)", func(t *testing.T) {
@@ -97,8 +95,6 @@ func TestEncryptKeystore(t *testing.T) {
 		require.Nil(t, jsonData["pubkey"])
 
 		decrypted, err := DecryptKeystore(data, testPassword)
-		require.NoError(t, err)
-		require.Equal(t, privkey, decrypted)
 		require.NoError(t, err)
 		require.Equal(t, privkey, decrypted)
 	})

--- a/ssvsigner/keystore/file_test.go
+++ b/ssvsigner/keystore/file_test.go
@@ -75,7 +75,9 @@ func TestEncryptKeystore(t *testing.T) {
 		require.Equal(t, testPubKeyBase64, jsonData["pubkey"])
 		require.Nil(t, jsonData["pubKey"])
 
-		decrtypted, err := DecryptKeystore(data, testPassword)
+		decrypted, err := DecryptKeystore(data, testPassword)
+		require.NoError(t, err)
+		require.Equal(t, privkey, decrypted)
 		require.NoError(t, err)
 		require.Equal(t, privkey, decrtypted)
 	})
@@ -94,7 +96,9 @@ func TestEncryptKeystore(t *testing.T) {
 		require.Equal(t, testPubKeyBase64, jsonData["pubKey"])
 		require.Nil(t, jsonData["pubkey"])
 
-		decrtypted, err := DecryptKeystore(data, testPassword)
+		decrypted, err := DecryptKeystore(data, testPassword)
+		require.NoError(t, err)
+		require.Equal(t, privkey, decrypted)
 		require.NoError(t, err)
 		require.Equal(t, privkey, decrtypted)
 	})

--- a/ssvsigner/keystore/file_test.go
+++ b/ssvsigner/keystore/file_test.go
@@ -79,7 +79,7 @@ func TestEncryptKeystore(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, privkey, decrypted)
 		require.NoError(t, err)
-		require.Equal(t, privkey, decrtypted)
+		require.Equal(t, privkey, decrypted)
 	})
 
 	t.Run("with valid data (legacy format)", func(t *testing.T) {
@@ -100,7 +100,7 @@ func TestEncryptKeystore(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, privkey, decrypted)
 		require.NoError(t, err)
-		require.Equal(t, privkey, decrtypted)
+		require.Equal(t, privkey, decrypted)
 	})
 
 	t.Run("with empty password", func(t *testing.T) {


### PR DESCRIPTION
https://github.com/ssvlabs/ssv/pull/2028 changed the format of the public key in the generated keystore from `pubKey` to `pubkey`. Reverting it back might break something, and also the `pubkey` spelling seems preferrable as it's used in the [ERC-2335](https://github.com/ethereum/ercs/blob/master/ERCS/erc-2335.md#json-schema). So, this PR adds a `--legacy-pubkey` flag that makes `generate-operator-keys` use the legacy format