### PR TITLE
fix(threshold): Add validation to threshold signature split

### DIFF
--- a/utils/threshold/threshold.go
+++ b/utils/threshold/threshold.go
@@ -9,6 +9,17 @@ import (
 // Create receives a bls.SecretKey hex and count.
 // Will split the secret key into count shares
 func Create(skBytes []byte, threshold uint64, count uint64) (map[uint64]*bls.SecretKey, error) {
+
+	// Validate threshold parameter - must be at least 2 for meaningful threshold schemes
+	if threshold <= 1 {
+		return nil, fmt.Errorf("invalid threshold: threshold must be greater than 1, got %d", threshold)
+	}
+
+	// Validate that we have enough shares for the threshold
+	if count < threshold {
+		return nil, fmt.Errorf("insufficient count: need at least %d shares for threshold %d, got %d", threshold, threshold, count)
+	}
+
 	// master key Polynomial
 	msk := make([]bls.SecretKey, threshold)
 

--- a/utils/threshold/threshold.go
+++ b/utils/threshold/threshold.go
@@ -17,7 +17,7 @@ func Create(skBytes []byte, threshold uint64, count uint64) (map[uint64]*bls.Sec
 
 	// Validate that we have enough shares for the threshold
 	if count < threshold {
-		return nil, fmt.Errorf("insufficient count: need at least %d shares for threshold %d, got %d", threshold, threshold, count)
+		return nil, fmt.Errorf("insufficient shares: need at least %d shares for threshold %d, got %d", threshold, threshold, count)
 	}
 
 	// master key Polynomial


### PR DESCRIPTION
We are running a differential fuzzer and in the process fixing issues as they come. 

The go code crashes with an index out of bounds if the threshold is set at 0. I realize this is an unrealistic parameter, but figure it's worth handling the edge case. 