### PR TITLE
backport: duties: clarify & fix typos & fix sync-committee subscription

### DIFF
--- a/operator/duties/attester.go
+++ b/operator/duties/attester.go
@@ -299,7 +299,7 @@ func (h *AttesterHandler) fetchAndProcessDuties(ctx context.Context, epoch phase
 		attribute.Int("ssv.validator.duty.subscriptions", len(subscriptions)),
 	))
 	go func(h *AttesterHandler, subscriptions []*eth2apiv1.BeaconCommitteeSubscription) {
-		subscriptionCtx, cancel := context.WithDeadline(ctx, deadline)
+		subscriptionCtx, cancel := context.WithDeadline(context.Background(), deadline)
 		defer cancel()
 
 		if err := h.beaconNode.SubmitBeaconCommitteeSubscriptions(subscriptionCtx, subscriptions); err != nil {

--- a/operator/duties/proposer.go
+++ b/operator/duties/proposer.go
@@ -131,9 +131,6 @@ func (h *ProposerHandler) processFetching(ctx context.Context, epoch phase0.Epoc
 		))
 	defer span.End()
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	span.AddEvent("fetching duties")
 	if err := h.fetchAndProcessDuties(ctx, epoch); err != nil {
 		// Set empty duties to inform DutyStore that fetch for this epoch is done.

--- a/operator/duties/sync_committee.go
+++ b/operator/duties/sync_committee.go
@@ -156,9 +156,6 @@ func (h *SyncCommitteeHandler) processFetching(ctx context.Context, epoch phase0
 		))
 	defer span.End()
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	if h.fetchCurrentPeriod {
 		span.AddEvent("fetching current period duties")
 		if err := h.fetchAndProcessDuties(ctx, epoch, period, waitForInitial); err != nil {
@@ -298,7 +295,7 @@ func (h *SyncCommitteeHandler) fetchAndProcessDuties(ctx context.Context, epoch 
 		attribute.Int("ssv.validator.duty.subscriptions", len(subscriptions)),
 	))
 	go func(ctx context.Context, h *SyncCommitteeHandler, subscriptions []*eth2apiv1.SyncCommitteeSubscription) {
-		subscriptionCtx, cancel := context.WithDeadline(ctx, deadline)
+		subscriptionCtx, cancel := context.WithDeadline(context.Background(), deadline)
 		defer cancel()
 
 		if err := h.beaconNode.SubmitSyncCommitteeSubscriptions(subscriptionCtx, subscriptions); err != nil {


### PR DESCRIPTION
This is a backport of https://github.com/ssvlabs/ssv/pull/2476 - but instead of being its full blown carbon-copy it's a minimal working solution to fix the issue for **version/optimization** branch (so it can go into the upcoming v2.3.5 release ASAP without much of extra testing required). 

These changes are "minimal" to keep the future resolving of merge conflicts as simple as possible (once we eventually merge branches like **main**->**stage**).
