### PR TITLE
node-probe: stabilize

### DIFF
--- a/api/handlers/node_test.go
+++ b/api/handlers/node_test.go
@@ -43,11 +43,8 @@ func CreateTestNode(t *testing.T, n int, ctx context.Context) *Node {
 
 	nodeMock := &NodeMock{}
 	nodeMock.HealthyMock.Store(nil)
-	nodeProber := nodeprobe.NewProber(zap.L(), nil, map[string]nodeprobe.Node{
-		"consensus client": nodeMock,
-		"execution client": nodeMock,
-		"event syncer":     nodeMock,
-	})
+	nodeProber := nodeprobe.NewProber(zap.L(), nodeMock, nodeMock)
+	nodeProber.AddEventSyncer(nodeMock)
 
 	return &Node{
 		ListenAddresses: []string{

--- a/api/handlers/node_test.go
+++ b/api/handlers/node_test.go
@@ -43,7 +43,7 @@ func CreateTestNode(t *testing.T, n int, ctx context.Context) *Node {
 
 	nodeMock := &NodeMock{}
 	nodeMock.HealthyMock.Store(nil)
-	nodeProber := nodeprobe.NewProber(zap.L())
+	nodeProber := nodeprobe.New(zap.L())
 	const node1 = "node_1"
 	const node2 = "node_2"
 	const node3 = "node_3"

--- a/api/handlers/node_test.go
+++ b/api/handlers/node_test.go
@@ -43,19 +43,27 @@ func CreateTestNode(t *testing.T, n int, ctx context.Context) *Node {
 
 	nodeMock := &NodeMock{}
 	nodeMock.HealthyMock.Store(nil)
-	nodeProber := nodeprobe.NewProber(zap.L(), nodeMock, nodeMock)
-	nodeProber.AddEventSyncer(nodeMock)
+	nodeProber := nodeprobe.NewProber(zap.L())
+	const node1 = "node_1"
+	const node2 = "node_2"
+	const node3 = "node_3"
+	nodeProber.AddNode(node1, nodeMock, 10*time.Second, 5)
+	nodeProber.AddNode(node2, nodeMock, 10*time.Second, 5)
+	nodeProber.AddNode(node3, nodeMock, 10*time.Second, 5)
 
-	return &Node{
-		ListenAddresses: []string{
+	return NewNode(
+		[]string{
 			fmt.Sprintf("tcp://%s:%d", "localhost", 3030),
 			fmt.Sprintf("udp://%s:%d", "localhost", 3030),
 		},
-		PeersIndex: ln.Nodes[0].(p2pv1.PeersIndexProvider).PeersIndex(),
-		Network:    ln.Nodes[0].(p2pv1.HostProvider).Host().Network(),
-		TopicIndex: ln.Nodes[0].(TopicIndex),
-		NodeProber: nodeProber,
-	}
+		ln.Nodes[0].(p2pv1.PeersIndexProvider).PeersIndex(),
+		ln.Nodes[0].(p2pv1.HostProvider).Host().Network(),
+		ln.Nodes[0].(TopicIndex),
+		nodeProber,
+		node1,
+		node2,
+		node3,
+	)
 }
 
 // createNetworkAndSubscribe creates a local network and subscribes each node to validator topics.

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -571,7 +571,7 @@ var StartNodeCmd = &cobra.Command{
 			}()
 		}
 
-		nodeProber := nodeprobe.NewProber(logger)
+		nodeProber := nodeprobe.New(logger)
 		nodeProber.AddNode(clNodeName, consensusClient, 10*time.Second, 5)
 		nodeProber.AddNode(elNodeName, executionClient, 10*time.Second, 5)
 

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -571,11 +571,13 @@ var StartNodeCmd = &cobra.Command{
 			}()
 		}
 
-		nodeProber := nodeprobe.NewProber(logger, consensusClient, executionClient)
+		nodeProber := nodeprobe.NewProber(logger)
+		nodeProber.AddNode(clNodeName, consensusClient, 10*time.Second, 5)
+		nodeProber.AddNode(elNodeName, executionClient, 10*time.Second, 5)
 
 		probeCtx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		defer cancel()
-		if err := nodeProber.Probe(probeCtx); err != nil {
+		if err := nodeProber.ProbeAll(probeCtx); err != nil {
 			logger.Fatal("Ethereum node(s) are not healthy", zap.Error(err))
 		}
 
@@ -594,9 +596,9 @@ var StartNodeCmd = &cobra.Command{
 			doppelgangerHandler,
 		)
 		if len(cfg.LocalEventsPath) == 0 {
-			nodeProber.AddEventSyncer(eventSyncer)
+			nodeProber.AddNode(eventSyncerNodeName, eventSyncer, 10*time.Second, 5)
 		}
-		go nodeProber.Start(cmd.Context())
+		go startNodeProber(cmd.Context(), logger, nodeProber)
 
 		if _, err := metadataSyncer.SyncAll(cmd.Context()); err != nil {
 			logger.Fatal("failed to sync metadata on startup", zap.Error(err))
@@ -651,14 +653,17 @@ var StartNodeCmd = &cobra.Command{
 			apiServer := apiserver.New(
 				logger,
 				fmt.Sprintf(":%d", cfg.SSVAPIPort),
-				&handlers.Node{
+				handlers.NewNode(
 					// TODO: replace with narrower interface! (instead of accessing the entire PeersIndex)
-					ListenAddresses: []string{fmt.Sprintf("tcp://%s:%d", cfg.P2pNetworkConfig.HostAddress, cfg.P2pNetworkConfig.TCPPort), fmt.Sprintf("udp://%s:%d", cfg.P2pNetworkConfig.HostAddress, cfg.P2pNetworkConfig.UDPPort)},
-					PeersIndex:      p2pNetwork.(p2pv1.PeersIndexProvider).PeersIndex(),
-					Network:         p2pNetwork.(p2pv1.HostProvider).Host().Network(),
-					TopicIndex:      p2pNetwork.(handlers.TopicIndex),
-					NodeProber:      nodeProber,
-				},
+					[]string{fmt.Sprintf("tcp://%s:%d", cfg.P2pNetworkConfig.HostAddress, cfg.P2pNetworkConfig.TCPPort), fmt.Sprintf("udp://%s:%d", cfg.P2pNetworkConfig.HostAddress, cfg.P2pNetworkConfig.UDPPort)},
+					p2pNetwork.(p2pv1.PeersIndexProvider).PeersIndex(),
+					p2pNetwork.(p2pv1.HostProvider).Host().Network(),
+					p2pNetwork.(handlers.TopicIndex),
+					nodeProber,
+					clNodeName,
+					elNodeName,
+					eventSyncerNodeName,
+				),
 				&handlers.Validators{
 					Shares: nodeStorage.Shares(),
 				},

--- a/cli/operator/prober.go
+++ b/cli/operator/prober.go
@@ -23,6 +23,9 @@ func startNodeProber(ctx context.Context, logger *zap.Logger, p *nodeprobe.Probe
 
 	for {
 		func() {
+			logger.Debug("node-prober tick: probing all nodes")
+			defer logger.Debug("node-prober tick: probing all nodes done")
+
 			probeCtx, cancel := context.WithTimeout(ctx, probeFrequency)
 			defer cancel()
 

--- a/cli/operator/prober.go
+++ b/cli/operator/prober.go
@@ -1,0 +1,41 @@
+package operator
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/nodeprobe"
+)
+
+const (
+	clNodeName          = "consensus client"
+	elNodeName          = "execution client"
+	eventSyncerNodeName = "event-syncer"
+)
+
+func startNodeProber(ctx context.Context, logger *zap.Logger, p *nodeprobe.Prober) {
+	const probeFrequency = 60 * time.Second
+
+	ticker := time.NewTicker(probeFrequency)
+	defer ticker.Stop()
+
+	for {
+		func() {
+			probeCtx, cancel := context.WithTimeout(ctx, probeFrequency)
+			defer cancel()
+
+			if err := p.ProbeAll(probeCtx); err != nil {
+				logger.Fatal("Ethereum node(s) are either out of sync or down. Ensure the nodes are healthy to resume.", zap.Error(err))
+			}
+		}()
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			continue
+		}
+	}
+}

--- a/nodeprobe/mock_node.go
+++ b/nodeprobe/mock_node.go
@@ -1,0 +1,40 @@
+package nodeprobe
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+)
+
+type nodeMock struct {
+	healthy atomic.Pointer[error]
+}
+
+func (m *nodeMock) Healthy(context.Context) error {
+	err := m.healthy.Load()
+	if err != nil {
+		return *err
+	}
+	return nil
+}
+
+type stuckNodeMock struct {
+	healthy atomic.Pointer[error]
+}
+
+func (m *stuckNodeMock) Healthy(ctx context.Context) error {
+	<-ctx.Done() // stuck until the call is canceled
+	return ctx.Err()
+}
+
+type glitchyNodeMock struct {
+	calledCnt int
+}
+
+func (m *glitchyNodeMock) Healthy(ctx context.Context) error {
+	if m.calledCnt > 0 {
+		return nil
+	}
+	m.calledCnt++
+	return fmt.Errorf("got a glitch")
+}

--- a/nodeprobe/mock_node.go
+++ b/nodeprobe/mock_node.go
@@ -28,13 +28,13 @@ func (m *stuckNodeMock) Healthy(ctx context.Context) error {
 }
 
 type glitchyNodeMock struct {
-	calledCnt int
+	calledCnt atomic.Uint64
 }
 
 func (m *glitchyNodeMock) Healthy(ctx context.Context) error {
-	if m.calledCnt > 0 {
+	if m.calledCnt.Load() >= 2 {
 		return nil
 	}
-	m.calledCnt++
+	m.calledCnt.Add(1)
 	return fmt.Errorf("got a glitch")
 }

--- a/nodeprobe/mock_node_test.go
+++ b/nodeprobe/mock_node_test.go
@@ -18,9 +18,7 @@ func (m *nodeMock) Healthy(context.Context) error {
 	return nil
 }
 
-type stuckNodeMock struct {
-	healthy atomic.Pointer[error]
-}
+type stuckNodeMock struct{}
 
 func (m *stuckNodeMock) Healthy(ctx context.Context) error {
 	<-ctx.Done() // stuck until the call is canceled

--- a/nodeprobe/nodeprobe.go
+++ b/nodeprobe/nodeprobe.go
@@ -36,7 +36,7 @@ type Prober struct {
 	logger *zap.Logger
 
 	// nodesMu protects access to nodes, needed to handle the case when "event syncer" is added dynamically later on
-	// when the Proper is already running.
+	// when the Prober is already running.
 	nodesMu sync.Mutex
 	nodes   map[nodeName]Node
 }
@@ -85,10 +85,6 @@ func (p *Prober) Probe(ctx context.Context) error {
 
 	var wg sync.WaitGroup
 	errsCh := make(chan error)
-	go func() {
-		wg.Wait()
-		close(errsCh)
-	}()
 
 	p.nodesMu.Lock()
 	nodes := p.nodes
@@ -107,6 +103,11 @@ func (p *Prober) Probe(ctx context.Context) error {
 			}
 		}()
 	}
+
+	go func() {
+		wg.Wait()
+		close(errsCh)
+	}()
 
 	var errs error
 	for err := range errsCh {

--- a/nodeprobe/nodeprobe_test.go
+++ b/nodeprobe/nodeprobe_test.go
@@ -24,7 +24,7 @@ func TestProber(t *testing.T) {
 		clNode := &nodeMock{}
 		clNode.healthy.Store(nil)
 
-		p := NewProber(log.TestLogger(t))
+		p := New(log.TestLogger(t))
 		p.AddNode(clNodeName, clNode, 10*time.Second, 5)
 
 		err := p.Probe(ctx, clNodeName)
@@ -34,7 +34,7 @@ func TestProber(t *testing.T) {
 	t.Run("1 node, success with glitchy node", func(t *testing.T) {
 		clNode := &glitchyNodeMock{}
 
-		p := NewProber(log.TestLogger(t))
+		p := New(log.TestLogger(t))
 		p.AddNode(clNodeName, clNode, 10*time.Second, 5)
 
 		err := p.Probe(ctx, clNodeName)
@@ -45,7 +45,7 @@ func TestProber(t *testing.T) {
 		clNode := &nodeMock{}
 		clNode.healthy.Store(nil)
 
-		p := NewProber(log.TestLogger(t))
+		p := New(log.TestLogger(t))
 		p.AddNode(clNodeName, clNode, 10*time.Second, 5)
 
 		err := p.Probe(ctx, elNodeName)
@@ -57,7 +57,7 @@ func TestProber(t *testing.T) {
 		clNode := &nodeMock{}
 		clNode.healthy.Store(nil)
 
-		p := NewProber(log.TestLogger(t))
+		p := New(log.TestLogger(t))
 		p.AddNode(clNodeName, clNode, 10*time.Second, 5)
 
 		clDownErr := fmt.Errorf("some error")
@@ -71,7 +71,7 @@ func TestProber(t *testing.T) {
 	t.Run("1 node, probe failed due to node stuck", func(t *testing.T) {
 		clNode := &stuckNodeMock{}
 
-		p := NewProber(log.TestLogger(t))
+		p := New(log.TestLogger(t))
 		p.AddNode(clNodeName, clNode, 10*time.Second, 5)
 
 		probeCtx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
@@ -87,7 +87,7 @@ func TestProber(t *testing.T) {
 		elNode := &nodeMock{}
 		elNode.healthy.Store(nil)
 
-		p := NewProber(log.TestLogger(t))
+		p := New(log.TestLogger(t))
 		p.AddNode(clNodeName, clNode, 10*time.Second, 5)
 		p.AddNode(elNodeName, elNode, 10*time.Second, 5)
 
@@ -102,7 +102,7 @@ func TestProber(t *testing.T) {
 		elNode := &nodeMock{}
 		elNode.healthy.Store(nil)
 
-		p := NewProber(log.TestLogger(t))
+		p := New(log.TestLogger(t))
 		p.AddNode(clNodeName, clNode, 10*time.Second, 5)
 		p.AddNode(elNodeName, elNode, 10*time.Second, 5)
 
@@ -123,7 +123,7 @@ func TestProber(t *testing.T) {
 		elNode := &nodeMock{}
 		elNode.healthy.Store(nil)
 
-		p := NewProber(log.TestLogger(t))
+		p := New(log.TestLogger(t))
 		p.AddNode(clNodeName, clNode, 10*time.Second, 5)
 		p.AddNode(elNodeName, elNode, 10*time.Second, 5)
 
@@ -144,7 +144,7 @@ func TestProber(t *testing.T) {
 		elNode := &nodeMock{}
 		elNode.healthy.Store(nil)
 
-		p := NewProber(log.TestLogger(t))
+		p := New(log.TestLogger(t))
 		p.AddNode(clNodeName, clNode, 10*time.Second, 5)
 		p.AddNode(elNodeName, elNode, 10*time.Second, 5)
 
@@ -167,7 +167,7 @@ func TestProber(t *testing.T) {
 		elNode := &nodeMock{}
 		elNode.healthy.Store(nil)
 
-		p := NewProber(log.TestLogger(t))
+		p := New(log.TestLogger(t))
 		p.AddNode(clNodeName, clNode, 10*time.Second, 5)
 		p.AddNode(elNodeName, elNode, 10*time.Second, 5)
 
@@ -193,7 +193,7 @@ func TestProber(t *testing.T) {
 		clNode := &stuckNodeMock{}
 		elNode := &stuckNodeMock{}
 
-		p := NewProber(log.TestLogger(t))
+		p := New(log.TestLogger(t))
 		p.AddNode(clNodeName, clNode, 10*time.Second, 5)
 		p.AddNode(elNodeName, elNode, 10*time.Second, 5)
 
@@ -207,7 +207,7 @@ func TestProber(t *testing.T) {
 		clNode := &stuckNodeMock{}
 		elNode := &stuckNodeMock{}
 
-		p := NewProber(log.TestLogger(t))
+		p := New(log.TestLogger(t))
 		p.AddNode(clNodeName, clNode, 10*time.Second, 5)
 		p.AddNode(elNodeName, elNode, 10*time.Second, 5)
 
@@ -222,7 +222,7 @@ func TestProber(t *testing.T) {
 
 		elNode := &glitchyNodeMock{}
 
-		p := NewProber(log.TestLogger(t))
+		p := New(log.TestLogger(t))
 		p.AddNode(clNodeName, clNode, 10*time.Second, 5)
 		p.AddNode(elNodeName, elNode, 10*time.Second, 5)
 

--- a/utils/hashmap/hashmap.go
+++ b/utils/hashmap/hashmap.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-// Map implements a thread-safe map with a sync.Map under the hood.
+// Map implements a thread-safe map with a sync.Map under the hood, it's best for read-heavy workloads.
 type Map[Key comparable, Value any] struct {
 	m sync.Map
 }


### PR DESCRIPTION
We can make our health-check `Prober` more robust by adding retries to it.

As per the comment in this PR:
```
	// Retry health-check multiple times to make sure we do not classify an occasional glitch (or a network blip)
	// as node being unhealthy. Failing on the very 1st failed request would be too drastic a measure given it
	// may result into SSV node restart.
```

And I think we have a `5s` timeout for CL-health check - which isn't much ... if SSV node has 1 CL configured we might hit it and crash. Note, it seems we cache the health-check results for EL (where request timeout is higher as well - at `10s`) but not CL. Still that just **reduces** the likelihood of SSV node crash due to health-check failure a bit, it doesn't solve for occasional network blips or CL/EL glitches.

Restarting SSV node while CL or EL are "having bad time" probably additionally makes it worse for them (since we send quite a bit of CL/EL requests right after SSV node start, I think).

In this PR I've started with simplifying `Prober` first, the implementation was way way harder than it needs to be to get the same functionality - so I didn't want to throw retries on top of what we had. Plus the logging is somewhat improved now (eg. `context.Canceled` shouldn't be logged as `error`).
