### PR TITLE
fix(multi client submit) - return wrapped error to the caller

### DIFF
--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sync/atomic"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/api"
@@ -13,7 +12,6 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/google/uuid"
 	"github.com/jellydator/ttlcache/v3"
-	"github.com/sourcegraph/conc/pool"
 	"go.uber.org/zap"
 
 	"github.com/ssvlabs/ssv/observability/log/fields"
@@ -453,51 +451,6 @@ func isBlockHeaderResponseValid(response *api.Response[*eth2apiv1.BeaconBlockHea
 
 func weightedAttestationDataRequestIDField(id uuid.UUID) zap.Field {
 	return zap.String("weighted_data_request_id", id.String())
-}
-
-// multiClientSubmit is a generic function that submits data to multiple beacon clients concurrently.
-// Returns nil if at least one client successfully submitted the data.
-func (gc *GoClient) multiClientSubmit(
-	ctx context.Context,
-	operationName string,
-	submitFunc func(ctx context.Context, client Client) error,
-) error {
-	logger := gc.log.With(zap.String("api", operationName))
-
-	submissions := atomic.Int32{}
-	p := pool.New().WithErrors().WithContext(ctx).WithMaxGoroutines(len(gc.clients))
-	for _, client := range gc.clients {
-		p.Go(func(ctx context.Context) error {
-			clientAddress := client.Address()
-			logger := logger.With(zap.String("client_addr", clientAddress))
-
-			start := time.Now()
-			err := submitFunc(ctx, client)
-			recordRequestDuration(ctx, operationName, clientAddress, http.MethodPost, time.Since(start), err)
-			if err != nil {
-				logger.Debug("a client failed to submit",
-					zap.Error(err))
-				return fmt.Errorf("client %s failed to submit %s: %w", clientAddress, operationName, err)
-			}
-
-			logger.Debug("a client submitted successfully")
-
-			submissions.Add(1)
-			return nil
-		})
-	}
-	err := p.Wait()
-	if submissions.Load() > 0 {
-		// At least one client has submitted successfully,
-		// so we can return without error.
-		return nil
-	}
-	if err != nil {
-		logger.Error("all clients failed to submit",
-			zap.Error(err))
-		return fmt.Errorf("failed to submit %s", operationName)
-	}
-	return nil
 }
 
 // SubmitAttestations implements Beacon interface and sends attestations to the first client that succeeds


### PR DESCRIPTION
## Background

`multiClientSubmit` is used for submitting attestations and sync committee messages **when** parallel submissions are enabled in the config, and is **always** used for submitting proposals and subscriptions (is that by design? see the [description](https://github.com/ssvlabs/ssv/blob/stage/beacon/goclient/options.go#L15) of the config).  

Previously, `multiClientSubmit` did not return errors (usually originating from `go-eth2-client` calls). Instead, it simply logged them. In many cases, the caller had valuable context for the call (such as the Duty ID), so errors logged only in `multiClientSubmit` were disconnected from the overall flow while looking into the logs.

## Changes
- Return wrapped errors from `multiClientSubmit`  
- Move the `multiClientSubmit` method from `attest.go` to `goclient.go` (a more appropriate location)  