### PR TITLE
node-probe: introduce delay between retries

### DIFF
--- a/api/handlers/node/node_test.go
+++ b/api/handlers/node/node_test.go
@@ -47,9 +47,9 @@ func CreateTestNode(t *testing.T, n int, ctx context.Context) *Node {
 	const node1 = "node_1"
 	const node2 = "node_2"
 	const node3 = "node_3"
-	nodeProber.AddNode(node1, nodeMock, 10*time.Second, 5)
-	nodeProber.AddNode(node2, nodeMock, 10*time.Second, 5)
-	nodeProber.AddNode(node3, nodeMock, 10*time.Second, 5)
+	nodeProber.AddNode(node1, nodeMock, 10*time.Second, 5, 0)
+	nodeProber.AddNode(node2, nodeMock, 10*time.Second, 5, 0)
+	nodeProber.AddNode(node3, nodeMock, 10*time.Second, 5, 0)
 
 	return NewNode(
 		[]string{

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -569,8 +569,8 @@ var StartNodeCmd = &cobra.Command{
 		}
 
 		nodeProber := nodeprobe.New(logger)
-		nodeProber.AddNode(clNodeName, consensusClient, 10*time.Second, 5)
-		nodeProber.AddNode(elNodeName, executionClient, 10*time.Second, 5)
+		nodeProber.AddNode(clNodeName, consensusClient, 10*time.Second, 5, 10*time.Second)
+		nodeProber.AddNode(elNodeName, executionClient, 10*time.Second, 5, 10*time.Second)
 
 		probeCtx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 		defer cancel()
@@ -593,7 +593,7 @@ var StartNodeCmd = &cobra.Command{
 			doppelgangerHandler,
 		)
 		if len(cfg.LocalEventsPath) == 0 {
-			nodeProber.AddNode(eventSyncerNodeName, eventSyncer, 10*time.Second, 5)
+			nodeProber.AddNode(eventSyncerNodeName, eventSyncer, 10*time.Second, 5, 10*time.Second)
 		}
 		go startNodeProber(cmd.Context(), logger, nodeProber)
 

--- a/nodeprobe/mock_node_test.go
+++ b/nodeprobe/mock_node_test.go
@@ -26,13 +26,20 @@ func (m *stuckNodeMock) Healthy(ctx context.Context) error {
 }
 
 type glitchyNodeMock struct {
-	calledCnt atomic.Uint64
+	calledCnt        atomic.Uint64
+	glitchedCallsCnt uint64
+}
+
+func newGlitchyNodeMock(glitchedCallsCnt uint64) *glitchyNodeMock {
+	return &glitchyNodeMock{
+		glitchedCallsCnt: glitchedCallsCnt,
+	}
 }
 
 func (m *glitchyNodeMock) Healthy(ctx context.Context) error {
-	if m.calledCnt.Load() >= 2 {
+	m.calledCnt.Add(1)
+	if m.calledCnt.Load() > m.glitchedCallsCnt {
 		return nil
 	}
-	m.calledCnt.Add(1)
 	return fmt.Errorf("got a glitch")
 }

--- a/nodeprobe/nodeprobe.go
+++ b/nodeprobe/nodeprobe.go
@@ -25,6 +25,7 @@ type pNode struct {
 
 	healthcheckTimeout time.Duration
 	retriesMax         int
+	retryDelay         time.Duration
 }
 
 // Prober allows for probing (checking the health of) the nodes it is configured with. It supports retries
@@ -122,16 +123,19 @@ func (p *Prober) probeNode(ctx context.Context, n pNode) (err error) {
 			zap.Int("attempt", attempt),
 			zap.Error(err),
 		)
+
+		time.Sleep(n.retryDelay) // wait before the next retry attempt
 	}
 
 	return fmt.Errorf("node is unhealthy: %w", err)
 }
 
-func (p *Prober) AddNode(nodeName string, node node, healthcheckTimeout time.Duration, retriesMax int) {
+func (p *Prober) AddNode(nodeName string, node node, healthcheckTimeout time.Duration, retriesMax int, retryDelay time.Duration) {
 	p.nodes.Set(nodeName, pNode{
 		name:               nodeName,
 		n:                  node,
 		healthcheckTimeout: healthcheckTimeout,
 		retriesMax:         retriesMax,
+		retryDelay:         retryDelay,
 	})
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/ssvlabs/ssv/pull/2492 to introduce some delay between the actual retry attempts, 

this is pretty much necessary to ensure we don't exhaust all retry attempts too rapidly (eg. if the Node replies immediately - perhaps due to caching its health-value), which is what we observed happen during recent testing:

<img width="1500" height="300" alt="image" src="https://github.com/user-attachments/assets/8baab558-ed03-427e-925c-50de8c555060" />
