### PR TITLE
CL: misc WAD-related improvements

### DIFF
--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -95,21 +95,12 @@ func (gc *GoClient) GetAttestationData(ctx context.Context, slot phase0.Slot) (*
 
 func (gc *GoClient) weightedAttestationData(ctx context.Context, slot phase0.Slot) (*phase0.AttestationData, error) {
 	logger := gc.log.With(fields.Slot(slot), weightedAttestationDataRequestIDField(uuid.New()))
-	// We have two timeouts: a soft timeout and a hard timeout.
-	// At the soft timeout, we return if we have any responses so far.
-	// At the hard timeout, we return unconditionally.
-	// The soft timeout is half the duration of the hard timeout.
-	ctx, cancel := context.WithTimeout(ctx, gc.weightedAttestationDataHardTimeout)
-	defer cancel()
-
-	softCtx, softCancel := context.WithTimeout(ctx, gc.weightedAttestationDataSoftTimeout)
-	defer softCancel()
 
 	started := time.Now()
 
-	numberOfRequests := len(gc.clients)
-	respCh := make(chan *attestationDataResponse, numberOfRequests)
-	errCh := make(chan *attestationDataError, numberOfRequests)
+	reqTotal := len(gc.clients)
+	respCh := make(chan *attestationDataResponse, reqTotal)
+	errCh := make(chan *attestationDataError, reqTotal)
 
 	for _, client := range gc.clients {
 		go gc.fetchWeightedAttestationData(ctx, client, respCh, errCh, slot, logger)
@@ -117,140 +108,101 @@ func (gc *GoClient) weightedAttestationData(ctx context.Context, slot phase0.Slo
 
 	// Wait for all responses (or context done).
 	var (
-		succeeded,
-		errored,
-		softTimedOut,
-		hardTimedOut int
-		bestScore           float64
-		bestAttestationData *phase0.AttestationData
-		bestClientAddr      string
+		reqSucceeded, reqErrored, reqTimedOut int
+		bestScore                             float64
+		bestAttestationData                   *phase0.AttestationData
+		bestClientAddr                        string
 	)
 
-	for shouldWaitForAttestationDataResponse(succeeded, errored, softTimedOut, numberOfRequests) {
+	onSuccess := func(resp *attestationDataResponse) {
+		reqSucceeded++
+
+		logger.With(
+			fields.Took(time.Since(started)),
+			zap.String("client_addr", resp.clientAddr),
+		).Debug("fetch attestation data, successful response received")
+
+		if bestAttestationData == nil || resp.score > bestScore {
+			if bestAttestationData != nil {
+				logger.Debug("updating best attestation data because of higher score",
+					zap.String("client_addr", resp.clientAddr),
+					zap.Float64("score", resp.score),
+					fields.Root(resp.attestationData.BeaconBlockRoot),
+				)
+			}
+			bestAttestationData = resp.attestationData
+			bestScore = resp.score
+			bestClientAddr = resp.clientAddr
+		}
+	}
+	onFailure := func(resp *attestationDataError) {
+		reqErrored++
+
+		logger.With(
+			fields.Took(time.Since(started)),
+			zap.String("client_addr", resp.clientAddr),
+			zap.Int("succeeded", reqSucceeded),
+			zap.Int("errored", reqErrored),
+			zap.Error(resp.err),
+		).Error("fetch attestation data, error received")
+	}
+
+loop:
+	for haveAttestationDataReqInFlight(reqSucceeded, reqErrored, reqTotal) {
 		select {
 		case resp := <-respCh:
-			succeeded++
-			logger.With(
-				zap.Duration("elapsed", time.Since(started)),
-				zap.String("client_addr", resp.clientAddr),
-				zap.Int("succeeded", succeeded),
-				zap.Int("errored", errored),
-			).Debug("response received")
-
-			if bestAttestationData == nil || resp.score > bestScore {
-				if bestAttestationData != nil {
-					logger.Debug("updating best attestation data because of higher score",
-						zap.String("client_addr", resp.clientAddr),
-						zap.Float64("score", resp.score),
-						fields.Root(resp.attestationData.BeaconBlockRoot),
-					)
-				}
-				bestAttestationData = resp.attestationData
-				bestScore = resp.score
-				bestClientAddr = resp.clientAddr
-			}
-		case err := <-errCh:
-			errored++
-			logger.With(
-				zap.Duration("elapsed", time.Since(started)),
-				zap.String("client_addr", err.clientAddr),
-				zap.Int("succeeded", succeeded),
-				zap.Int("errored", errored),
-				zap.Error(err.err),
-			).Error("error received")
-		case <-softCtx.Done():
-			softTimedOut = numberOfRequests - (succeeded + errored)
-
-			logger.With(
-				zap.Duration("elapsed", time.Since(started)),
-				zap.Int("succeeded", succeeded),
-				zap.Int("errored", errored),
-				zap.Int("soft_timed_out", softTimedOut),
-			).Debug("soft timeout reached")
+			onSuccess(resp)
+		case resp := <-errCh:
+			onFailure(resp)
+		case <-ctx.Done():
+			reqTimedOut = reqTotal - (reqSucceeded + reqErrored)
+			break loop
 		}
 	}
 
-	if succeeded == 0 {
-		for shouldWaitForAttestationDataResponse(succeeded, errored, hardTimedOut, numberOfRequests) {
-			select {
-			case resp := <-respCh:
-				succeeded++
-				logger.With(
-					zap.Duration("elapsed", time.Since(started)),
-					zap.String("client_addr", resp.clientAddr),
-					zap.Int("succeeded", succeeded),
-					zap.Int("errored", errored),
-				).Debug("response received")
-
-				if bestAttestationData == nil || resp.score > bestScore {
-					if bestAttestationData != nil {
-						logger.Debug("updating best attestation data because of higher score",
-							zap.String("client_addr", resp.clientAddr),
-							zap.Float64("score", resp.score),
-							fields.Root(resp.attestationData.BeaconBlockRoot),
-						)
-					}
-					bestAttestationData = resp.attestationData
-					bestScore = resp.score
-					bestClientAddr = resp.clientAddr
-				}
-			case err := <-errCh:
-				errored++
-				logger.With(
-					zap.Duration("elapsed", time.Since(started)),
-					zap.String("client_addr", err.clientAddr),
-					zap.Int("succeeded", succeeded),
-					zap.Int("errored", errored),
-					zap.Error(err.err),
-				).Error("received error fetching attestation data")
-			case <-ctx.Done():
-				hardTimedOut = numberOfRequests - (succeeded + errored)
-				logger.With(
-					zap.Duration("elapsed", time.Since(started)),
-					zap.Int("succeeded", succeeded),
-					zap.Int("errored", errored),
-					zap.Int("hard_timed_out", hardTimedOut),
-				).Error("hard timeout reached")
-			}
+	// Wait for requests that timed out to complete (every one of those should return shortly after reaching
+	// timeout) since we might have some successful results coming in at the very last moment.
+	for haveAttestationDataReqInFlight(reqSucceeded, reqErrored, reqTotal) {
+		select {
+		case resp := <-respCh:
+			onSuccess(resp)
+		case resp := <-errCh:
+			onFailure(resp)
 		}
 	}
 
-	resultLogger := logger.With(
-		zap.Duration("elapsed", time.Since(started)),
-		zap.Int("succeeded", succeeded),
-		zap.Int("errored", errored),
-		zap.Int("soft_timed_out", softTimedOut),
-		zap.Int("hard_timed_out", hardTimedOut),
+	logger.With(
+		zap.Int("succeeded", reqSucceeded),
+		zap.Int("errored", reqErrored),
+		zap.Int("timed_out", reqTimedOut),
 		zap.Bool("with_weighted_attestation_data", true),
-	)
+		zap.String("client_addr", bestClientAddr),
+		zap.Float64("best_score", bestScore),
+		fields.Took(time.Since(started)),
+	).Debug("done fetching weighted attestation data")
+
 	if bestAttestationData == nil {
-		resultLogger.Error("no attestations received")
 		return nil, fmt.Errorf("no attestations received")
 	}
-
-	resultLogger.With(
-		zap.String("client_addr", bestClientAddr),
-		zap.Float64("score", bestScore)).
-		Debug("successfully fetched attestation data")
 
 	recordAttestationDataClientSelection(ctx, bestClientAddr)
 
 	return bestAttestationData, nil
 }
 
-func shouldWaitForAttestationDataResponse(responded, errored, timedOut, requestsTotal int) bool {
-	return responded+errored+timedOut != requestsTotal
+func haveAttestationDataReqInFlight(responded, errored, requestsTotal int) bool {
+	return responded+errored != requestsTotal
 }
 
 func (gc *GoClient) simpleAttestationData(ctx context.Context, slot phase0.Slot) (*phase0.AttestationData, error) {
 	logger := gc.log.With(fields.Slot(slot))
 
-	attDataReqStart := time.Now()
+	reqStart := time.Now()
 	resp, err := gc.multiClient.AttestationData(ctx, &api.AttestationDataOpts{
 		Slot:           slot,
 		CommitteeIndex: 0,
 	})
-	recordRequest(ctx, logger, "AttestationData", gc.multiClient, http.MethodGet, true, time.Since(attDataReqStart), err)
+	recordRequest(ctx, logger, "AttestationData", gc.multiClient, http.MethodGet, true, time.Since(reqStart), err)
 	if err != nil {
 		return nil, errMultiClient(fmt.Errorf("get attestation data: %w", err), "AttestationData")
 	}
@@ -313,6 +265,7 @@ func (gc *GoClient) fetchWeightedAttestationData(
 
 	logger.Debug("scoring attestation data")
 	score := gc.scoreAttestationData(ctx, client, attestationData, logger)
+	logger.Debug("scoring attestation data, got score", zap.Float64("score", score))
 
 	respCh <- &attestationDataResponse{
 		clientAddr:      client.Address(),
@@ -321,31 +274,28 @@ func (gc *GoClient) fetchWeightedAttestationData(
 	}
 }
 
-// scoreAttestationData generates a score for attestation data.
-// The score is relative to the reward expected from the contents of the attestation.
-func (gc *GoClient) scoreAttestationData(ctx context.Context,
+// scoreAttestationData generates a score for attestation data. The score is relative to the reward expected from
+// the contents of the attestation. This function retries multiple times in case the CL hasn't indexed the block
+// with the corresponding root by the time we issue our 1st request.
+func (gc *GoClient) scoreAttestationData(
+	ctx context.Context,
 	client Client,
 	attestationData *phase0.AttestationData,
 	logger *zap.Logger,
 ) float64 {
-	// Initial score is based on height of source and target epochs.
+	// The initial score is based on the height of source and target epochs.
 	score := float64(attestationData.Source.Epoch + attestationData.Target.Epoch)
 	logger.
 		With(zap.Float64("base_score", score)).
 		Debug("base score was set. Fetching slot for block root")
 
-	ctx, cancel := context.WithTimeout(ctx, gc.weightedAttestationDataSoftTimeout/2)
-	defer cancel()
-
-	ticker := time.NewTicker(time.Millisecond * 100)
-	defer ticker.Stop()
-
 	var (
-		retries uint32
-		start   = time.Now()
+		attempt = 1
+		started = time.Now()
 	)
+	for attempt <= 5 {
+		logger = logger.With(zap.Int("attempt", attempt))
 
-	for {
 		slot, err := gc.blockRootToSlot(ctx, client, attestationData.BeaconBlockRoot, logger)
 		if err == nil {
 			// Increase score based on the nearness of the head slot.
@@ -359,7 +309,7 @@ func (gc *GoClient) scoreAttestationData(ctx context.Context,
 			}
 
 			logger.With(
-				zap.Duration("elapsed", time.Since(start)),
+				fields.Took(time.Since(started)),
 				zap.Uint64("head_slot", uint64(slot)),
 				zap.Uint64("source_epoch", uint64(attestationData.Source.Epoch)),
 				zap.Uint64("target_epoch", uint64(attestationData.Target.Epoch)),
@@ -372,23 +322,37 @@ func (gc *GoClient) scoreAttestationData(ctx context.Context,
 		logger.
 			With(zap.Error(err)).
 			Warn("couldn't fetch slot for block root")
+
+		const retryDelay = 100 * time.Millisecond
 		select {
 		case <-ctx.Done():
 			logger.
-				With(zap.Uint32("try", retries)).
-				With(zap.Duration("total_elapsed", time.Since(start))).
+				With(fields.Took(time.Since(started))).
 				Error("timeout for obtaining slot for block root was reached. Returning base score")
 			return score
-		case <-ticker.C:
-			retries++
+		case <-time.After(retryDelay):
 			logger.
-				With(zap.Uint32("try", retries)).
-				With(zap.Duration("total_elapsed", time.Since(start))).
+				With(fields.Took(time.Since(started))).
 				Warn("retrying to obtain slot for block root")
+			attempt++
+			continue
 		}
 	}
+
+	logger.
+		With(fields.Took(time.Since(started))).
+		Error("ran out of retries for obtaining slot for block root. Returning base score")
+	return score
 }
 
+// blockRootToSlot looks up slot number by the provided block-root making a request to the provided CL client
+// if necessary, caching the result for future re-use.
+// Note, a block root "commits" (hashes over it) to a specific slot number - hence we can't accidentally
+// update gc.blockRootToSlotCache here overwriting the freshest slot value with a different one regardless
+// of whether blockRootToSlot is called concurrently. Hence, there is no need to worry about the atomicity of
+// gc.blockRootToSlotCache updates, on the contrary - we shouldn't prevent concurrent blockRootToSlot calls
+// for different clients from executing in parallel (such requests should execute in parallel so we can start
+// using the results from those that finish faster than the rest of them).
 func (gc *GoClient) blockRootToSlot(ctx context.Context, client Client, root phase0.Root, logger *zap.Logger) (phase0.Slot, error) {
 	cacheResult := gc.blockRootToSlotCache.Get(root)
 	if cacheResult != nil {
@@ -402,23 +366,22 @@ func (gc *GoClient) blockRootToSlot(ctx context.Context, client Client, root pha
 
 	logger.Debug("slot was not found in cache, fetching from the client")
 
-	timeoutContext, cancel := context.WithTimeout(ctx, gc.weightedAttestationDataSoftTimeout/4)
-	defer cancel()
-
-	blockResponse, err := client.BeaconBlockHeader(timeoutContext, &api.BeaconBlockHeaderOpts{
+	reqStart := time.Now()
+	blockResponse, err := client.BeaconBlockHeader(ctx, &api.BeaconBlockHeaderOpts{
 		Block: root.String(),
 	})
-
+	recordRequest(ctx, logger, "BeaconBlockHeader", client, http.MethodGet, false, time.Since(reqStart), err)
 	if err != nil {
-		return 0, fmt.Errorf("failed to fetch block header from the client: %w", err)
+		return 0, errSingleClient(fmt.Errorf("failed to fetch block header from the client: %w", err), client.Address(), "BeaconBlockHeader")
 	}
-
 	if !isBlockHeaderResponseValid(blockResponse) {
-		return 0, fmt.Errorf("block header response was not valid")
+		return 0, errSingleClient(fmt.Errorf("block header response was not valid"), client.Address(), "BeaconBlockHeader")
 	}
 
 	slot := blockResponse.Data.Header.Message.Slot
+
 	gc.blockRootToSlotCache.Set(root, slot, ttlcache.NoTTL)
+
 	logger.
 		With(zap.Uint64("cached_slot", uint64(slot))).
 		Debug("block root to slot cache updated from the BeaconBlockHeader call")

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -156,6 +156,7 @@ func (gc *GoClient) weightedAttestationData(ctx context.Context, slot phase0.Slo
 		).Error("fetch attestation data, error received")
 	}
 
+	// Wait until all requests finish, or until we hit soft-deadline.
 loopSoft:
 	for haveAttestationDataReqInFlight(reqSucceeded, reqErrored, reqTotal) {
 		select {
@@ -164,14 +165,13 @@ loopSoft:
 		case resp := <-errCh:
 			onFailure(resp)
 		case <-time.After(time.Until(softDeadline)):
-			// We've hit the soft deadline, let's see if we got any responses so far.
 			break loopSoft
 		}
 	}
 
-	// If we got at least 1 response already - we'll use that, and cancel the rest inflight
-	// requests. Otherwise, we'll keep waiting for the first success or the hard deadline
-	// in the loop below.
+	// If we got some responses already - we'll use that, and cancel the rest inflight
+	// requests. Otherwise, we'll keep waiting for the first success or until all requests
+	// time out in the loop below.
 	if reqSucceeded == 0 {
 	loopHard:
 		for haveAttestationDataReqInFlight(reqSucceeded, reqErrored, reqTotal) {

--- a/beacon/goclient/attest.go
+++ b/beacon/goclient/attest.go
@@ -102,17 +102,28 @@ func (gc *GoClient) weightedAttestationData(ctx context.Context, slot phase0.Slo
 	respCh := make(chan *attestationDataResponse, reqTotal)
 	errCh := make(chan *attestationDataError, reqTotal)
 
+	// reqCtx is used to control the lifetime of CL requests issued below.
+	reqCtx, reqCancel := context.WithCancel(ctx)
+	defer reqCancel()
+
 	for _, client := range gc.clients {
-		go gc.fetchWeightedAttestationData(ctx, client, respCh, errCh, slot, logger)
+		go gc.fetchWeightedAttestationData(reqCtx, client, respCh, errCh, slot, logger)
 	}
 
-	// Wait for all responses (or context done).
+	// Wait for all responses and compare them, or if we hit soft deadline use the 1st response
+	// that becomes available, or if we hit the hard-deadline (context done) just return.
 	var (
 		reqSucceeded, reqErrored, reqTimedOut int
 		bestScore                             float64
 		bestAttestationData                   *phase0.AttestationData
 		bestClientAddr                        string
 	)
+
+	softDeadline := time.Unix(1<<63-62135596801, 999999999).UTC() // infinity
+	hardDeadline, ok := ctx.Deadline()
+	if ok {
+		softDeadline = hardDeadline.Add(-300 * time.Millisecond)
+	}
 
 	onSuccess := func(resp *attestationDataResponse) {
 		reqSucceeded++
@@ -141,35 +152,40 @@ func (gc *GoClient) weightedAttestationData(ctx context.Context, slot phase0.Slo
 		logger.With(
 			fields.Took(time.Since(started)),
 			zap.String("client_addr", resp.clientAddr),
-			zap.Int("succeeded", reqSucceeded),
-			zap.Int("errored", reqErrored),
 			zap.Error(resp.err),
 		).Error("fetch attestation data, error received")
 	}
 
-loop:
+loopSoft:
 	for haveAttestationDataReqInFlight(reqSucceeded, reqErrored, reqTotal) {
 		select {
 		case resp := <-respCh:
 			onSuccess(resp)
 		case resp := <-errCh:
 			onFailure(resp)
-		case <-ctx.Done():
-			reqTimedOut = reqTotal - (reqSucceeded + reqErrored)
-			break loop
+		case <-time.After(time.Until(softDeadline)):
+			// We've hit the soft deadline, let's see if we got any responses so far.
+			break loopSoft
 		}
 	}
 
-	// Wait for requests that timed out to complete (every one of those should return shortly after reaching
-	// timeout) since we might have some successful results coming in at the very last moment.
-	for haveAttestationDataReqInFlight(reqSucceeded, reqErrored, reqTotal) {
-		select {
-		case resp := <-respCh:
-			onSuccess(resp)
-		case resp := <-errCh:
-			onFailure(resp)
+	// If we got at least 1 response already - we'll use that, and cancel the rest inflight
+	// requests. Otherwise, we'll keep waiting for the first success or the hard deadline
+	// in the loop below.
+	if reqSucceeded == 0 {
+	loopHard:
+		for haveAttestationDataReqInFlight(reqSucceeded, reqErrored, reqTotal) {
+			select {
+			case resp := <-respCh:
+				onSuccess(resp)
+				break loopHard // 1 success is good enough at this point
+			case resp := <-errCh:
+				onFailure(resp)
+			}
 		}
 	}
+
+	reqTimedOut = reqTotal - (reqSucceeded + reqErrored)
 
 	logger.With(
 		zap.Int("succeeded", reqSucceeded),

--- a/beacon/goclient/attest_test.go
+++ b/beacon/goclient/attest_test.go
@@ -26,7 +26,7 @@ var (
 	epochs = []phase0.Epoch{318584, 318585, 318586, 318587, 318588}
 
 	defaultHardTimeout = time.Second * 2
-	defaultSoftTimeout = time.Duration(float64(defaultHardTimeout) / 2.5)
+	defaultSoftTimeout = defaultHardTimeout - 300*time.Millisecond
 
 	// roots is a bunch of random roots.
 	roots = []string{
@@ -396,7 +396,7 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		client, err := createClient(ctx, strings.Join(beaconServersURLs, ";"), withWeightedAttestationData)
 		require.NoError(t, err)
 
-		reqCtx, cancel := context.WithTimeout(ctx, defaultSoftTimeout)
+		reqCtx, cancel := context.WithTimeout(ctx, defaultHardTimeout)
 		defer cancel()
 
 		startTime := time.Now()

--- a/beacon/goclient/attest_test.go
+++ b/beacon/goclient/attest_test.go
@@ -266,35 +266,16 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 
 	t.Run("single beacon client: returns response provided by server", func(t *testing.T) {
 		const testSlot = phase0.Slot(100)
-		beaconServer, serverHandledRequests := createBeaconServer(t, beaconServerResponseOptions{WithAttestationDataEndpointError: false})
-		client, err := createClient(ctx, beaconServer.URL, withWeightedAttestationData)
-		require.NoError(t, err)
-
-		response, dataVersion, err := client.GetAttestationData(ctx, testSlot)
-
-		require.NoError(t, err)
-		require.Equal(t, spec.DataVersionPhase0, dataVersion)
-		require.NotNil(t, response)
-		require.Contains(t, roots, "0x"+hex.EncodeToString(response.BeaconBlockRoot[:]))
-		require.Contains(t, roots, "0x"+hex.EncodeToString(response.Source.Root[:]))
-		require.Contains(t, roots, "0x"+hex.EncodeToString(response.Target.Root[:]))
-		require.Contains(t, epochs, response.Target.Epoch)
-		require.Contains(t, epochs, response.Source.Epoch)
-		require.Equal(t, testSlot, response.Slot)
-		slotRequests, contains := serverHandledRequests.Get(testSlot)
-		require.True(t, contains)
-		require.NotZero(t, slotRequests)
-	})
-
-	t.Run("single beacon client: returns response provided by server when soft timeout reached", func(t *testing.T) {
-		const testSlot = phase0.Slot(100)
 		beaconServer, serverHandledRequests := createBeaconServer(t, beaconServerResponseOptions{
-			AttestationDataResponseDuration: time.Duration(float64(defaultSoftTimeout) * 1.1),
+			AttestationDataResponseDuration: defaultSoftTimeout + 100*time.Millisecond,
 		})
 		client, err := createClient(ctx, beaconServer.URL, withWeightedAttestationData)
 		require.NoError(t, err)
 
-		response, dataVersion, err := client.GetAttestationData(ctx, testSlot)
+		reqCtx, cancel := context.WithTimeout(ctx, defaultHardTimeout)
+		defer cancel()
+		startTime := time.Now()
+		response, dataVersion, err := client.GetAttestationData(reqCtx, testSlot)
 
 		require.NoError(t, err)
 		require.Equal(t, spec.DataVersionPhase0, dataVersion)
@@ -308,6 +289,8 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		slotRequests, contains := serverHandledRequests.Get(testSlot)
 		require.True(t, contains)
 		require.NotZero(t, slotRequests)
+		require.Greater(t, time.Since(startTime), defaultSoftTimeout)
+		require.Less(t, time.Since(startTime), defaultHardTimeout)
 	})
 
 	t.Run("single beacon client: does not await soft timeout", func(t *testing.T) {
@@ -315,8 +298,10 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		client, err := createClient(ctx, beaconServer.URL, withWeightedAttestationData)
 		require.NoError(t, err)
 
+		reqCtx, cancel := context.WithTimeout(ctx, defaultHardTimeout)
+		defer cancel()
 		startTime := time.Now()
-		_, _, err = client.GetAttestationData(ctx, phase0.Slot(100))
+		_, _, err = client.GetAttestationData(reqCtx, phase0.Slot(100))
 
 		require.NoError(t, err)
 		require.Less(t, time.Since(startTime), defaultSoftTimeout)
@@ -376,8 +361,10 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		client, err := createClient(ctx, strings.Join(beaconServersURLs, ";"), withWeightedAttestationData)
 		require.NoError(t, err)
 
+		reqCtx, cancel := context.WithTimeout(ctx, defaultHardTimeout)
+		defer cancel()
 		startTime := time.Now()
-		_, _, err = client.GetAttestationData(ctx, phase0.Slot(100))
+		_, _, err = client.GetAttestationData(reqCtx, phase0.Slot(100))
 		require.NoError(t, err)
 
 		require.Less(t, time.Since(startTime), defaultSoftTimeout)
@@ -398,14 +385,13 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 
 		reqCtx, cancel := context.WithTimeout(ctx, defaultHardTimeout)
 		defer cancel()
-
 		startTime := time.Now()
 		_, _, err = client.GetAttestationData(reqCtx, phase0.Slot(100))
 
 		require.NoError(t, err)
 		timeElapsed := time.Since(startTime)
 		require.GreaterOrEqual(t, timeElapsed, defaultSoftTimeout)
-		require.LessOrEqual(t, timeElapsed, defaultSoftTimeout+(defaultSoftTimeout/10)) //time elapsed should not be greater than soft timeout + 10%
+		require.Less(t, timeElapsed, defaultHardTimeout)
 	})
 
 	t.Run("multiple beacon clients: awaits for hard timeout when no responses after soft timeout reached", func(t *testing.T) {
@@ -418,8 +404,10 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		client, err := createClient(ctx, strings.Join(beaconServersURLs, ";"), withWeightedAttestationData)
 		require.NoError(t, err)
 
+		reqCtx, cancel := context.WithTimeout(ctx, defaultHardTimeout)
+		defer cancel()
 		startTime := time.Now()
-		response, version, err := client.GetAttestationData(ctx, phase0.Slot(100))
+		response, version, err := client.GetAttestationData(reqCtx, phase0.Slot(100))
 
 		require.Error(t, err)
 		require.Equal(t, err.Error(), "no attestations received")
@@ -430,7 +418,7 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		require.LessOrEqual(t, timeElapsed, defaultHardTimeout+(defaultHardTimeout/10)) //time elapsed should not be greater than hard timeout + 10%
 	})
 
-	t.Run("multiple beacon clients: succeeds within soft timeout when BeaconBlockHeader(scoring) has timeout higher than hard timeout", func(t *testing.T) {
+	t.Run("multiple beacon clients: succeeds within hard timeout when BeaconBlockHeader(scoring) has timeout higher than hard timeout", func(t *testing.T) {
 		const numberOfServers = 3
 		var beaconServersURLs []string
 		for i := 0; i < numberOfServers; i++ {
@@ -440,10 +428,17 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		client, err := createClient(ctx, strings.Join(beaconServersURLs, ";"), withWeightedAttestationData)
 		require.NoError(t, err)
 
-		response, version, err := client.GetAttestationData(ctx, phase0.Slot(100))
+		reqCtx, cancel := context.WithTimeout(ctx, defaultHardTimeout)
+		defer cancel()
+		startTime := time.Now()
+		response, version, err := client.GetAttestationData(reqCtx, phase0.Slot(100))
+
 		require.NoError(t, err)
 		require.NotNil(t, response)
 		require.Equal(t, spec.DataVersionPhase0, version)
+		timeElapsed := time.Since(startTime)
+		require.GreaterOrEqual(t, timeElapsed, defaultHardTimeout)
+		require.LessOrEqual(t, timeElapsed, defaultHardTimeout+(defaultHardTimeout/10)) //time elapsed should not be greater than hard timeout + 10%
 	})
 
 	t.Run("multiple beacon clients: responses are correctly weighted", func(t *testing.T) {
@@ -501,7 +496,7 @@ func createClient(
 		zap.NewNop(),
 		Options{
 			BeaconNodeAddr:              beaconServerURL,
-			CommonTimeout:               defaultHardTimeout,
+			CommonTimeout:               3 * defaultHardTimeout,
 			LongTimeout:                 time.Second,
 			WithWeightedAttestationData: withWeightedAttestationData,
 		},

--- a/beacon/goclient/attest_test.go
+++ b/beacon/goclient/attest_test.go
@@ -93,6 +93,8 @@ var (
 )
 
 func TestGoClient_GetAttestationData_Simple(t *testing.T) {
+	ctx := t.Context()
+
 	const withWeightedAttestationData = false
 
 	t.Run("requests must be cached (per slot)", func(t *testing.T) {
@@ -101,11 +103,11 @@ func TestGoClient_GetAttestationData_Simple(t *testing.T) {
 
 		server, serverGotRequests := createBeaconServer(t, beaconServerResponseOptions{})
 
-		client, err := createClient(t.Context(), server.URL, withWeightedAttestationData)
+		client, err := createClient(ctx, server.URL, withWeightedAttestationData)
 		require.NoError(t, err)
 
 		// First request with slot1.
-		gotResult1a, gotVersion, err := client.GetAttestationData(t.Context(), slot1)
+		gotResult1a, gotVersion, err := client.GetAttestationData(ctx, slot1)
 		require.NoError(t, err)
 		require.Equal(t, spec.DataVersionPhase0, gotVersion)
 		require.Equal(t, slot1, gotResult1a.Slot)
@@ -116,7 +118,7 @@ func TestGoClient_GetAttestationData_Simple(t *testing.T) {
 		require.NotEmpty(t, gotResult1a.Target.Root)
 
 		// Second request with slot1, result should have been cached.
-		gotResult1b, gotVersion, err := client.GetAttestationData(t.Context(), slot1)
+		gotResult1b, gotVersion, err := client.GetAttestationData(ctx, slot1)
 		require.NoError(t, err)
 		require.Equal(t, spec.DataVersionPhase0, gotVersion)
 		require.Equal(t, slot1, gotResult1b.Slot)
@@ -133,7 +135,7 @@ func TestGoClient_GetAttestationData_Simple(t *testing.T) {
 		require.Equal(t, gotResult1b.Target.Root, gotResult1a.Target.Root)
 
 		// Third request with slot2.
-		gotResult2a, gotVersion, err := client.GetAttestationData(t.Context(), slot2)
+		gotResult2a, gotVersion, err := client.GetAttestationData(ctx, slot2)
 		require.NoError(t, err)
 		require.Equal(t, spec.DataVersionPhase0, gotVersion)
 		require.Equal(t, slot2, gotResult2a.Slot)
@@ -144,7 +146,7 @@ func TestGoClient_GetAttestationData_Simple(t *testing.T) {
 		require.NotEmpty(t, gotResult2a.Target.Root)
 
 		// Fourth request with slot2, result should have been cached.
-		gotResult2b, gotVersion, err := client.GetAttestationData(t.Context(), slot2)
+		gotResult2b, gotVersion, err := client.GetAttestationData(ctx, slot2)
 		require.NoError(t, err)
 		require.Equal(t, spec.DataVersionPhase0, gotVersion)
 		require.Equal(t, slot2, gotResult2b.Slot)
@@ -161,7 +163,7 @@ func TestGoClient_GetAttestationData_Simple(t *testing.T) {
 		require.Equal(t, gotResult2b.Target.Root, gotResult2a.Target.Root)
 
 		// Second request with slot1, result STILL should be cached.
-		gotResult1c, gotVersion, err := client.GetAttestationData(t.Context(), slot1)
+		gotResult1c, gotVersion, err := client.GetAttestationData(ctx, slot1)
 		require.NoError(t, err)
 		require.Equal(t, spec.DataVersionPhase0, gotVersion)
 		require.Equal(t, slot1, gotResult1c.Slot)
@@ -189,10 +191,10 @@ func TestGoClient_GetAttestationData_Simple(t *testing.T) {
 
 	t.Run("returns error when server responds with error", func(t *testing.T) {
 		beaconServer, _ := createBeaconServer(t, beaconServerResponseOptions{WithAttestationDataEndpointError: true})
-		client, err := createClient(t.Context(), beaconServer.URL, withWeightedAttestationData)
+		client, err := createClient(ctx, beaconServer.URL, withWeightedAttestationData)
 		require.NoError(t, err)
 
-		response, dataVersion, err := client.GetAttestationData(t.Context(), phase0.Slot(100))
+		response, dataVersion, err := client.GetAttestationData(ctx, phase0.Slot(100))
 
 		require.Nil(t, response)
 		require.Equal(t, DataVersionNil, dataVersion)
@@ -204,7 +206,7 @@ func TestGoClient_GetAttestationData_Simple(t *testing.T) {
 		server, serverGotRequests := createBeaconServer(t, beaconServerResponseOptions{WithAttestationDataEndpointError: false})
 
 		client, err := New(
-			t.Context(),
+			ctx,
 			zap.NewNop(),
 			Options{
 				BeaconNodeAddr: server.URL,
@@ -226,7 +228,7 @@ func TestGoClient_GetAttestationData_Simple(t *testing.T) {
 		for i := 0; i < 1000; i++ {
 			slot := phase0.Slot(slotStartPos + i%slotsTotalCnt)
 			p.Go(func() {
-				gotResult, gotVersion, err := client.GetAttestationData(t.Context(), slot)
+				gotResult, gotVersion, err := client.GetAttestationData(ctx, slot)
 				require.NoError(t, err)
 				require.Equal(t, spec.DataVersionPhase0, gotVersion)
 				require.Equal(t, slot, gotResult.Slot)
@@ -259,6 +261,7 @@ func TestGoClient_GetAttestationData_Simple(t *testing.T) {
 
 func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 	ctx := t.Context()
+
 	const withWeightedAttestationData = true
 
 	t.Run("single beacon client: returns response provided by server", func(t *testing.T) {
@@ -267,7 +270,7 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		client, err := createClient(ctx, beaconServer.URL, withWeightedAttestationData)
 		require.NoError(t, err)
 
-		response, dataVersion, err := client.GetAttestationData(t.Context(), testSlot)
+		response, dataVersion, err := client.GetAttestationData(ctx, testSlot)
 
 		require.NoError(t, err)
 		require.Equal(t, spec.DataVersionPhase0, dataVersion)
@@ -291,7 +294,7 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		client, err := createClient(ctx, beaconServer.URL, withWeightedAttestationData)
 		require.NoError(t, err)
 
-		response, dataVersion, err := client.GetAttestationData(t.Context(), testSlot)
+		response, dataVersion, err := client.GetAttestationData(ctx, testSlot)
 
 		require.NoError(t, err)
 		require.Equal(t, spec.DataVersionPhase0, dataVersion)
@@ -313,7 +316,7 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		require.NoError(t, err)
 
 		startTime := time.Now()
-		_, _, err = client.GetAttestationData(t.Context(), phase0.Slot(100))
+		_, _, err = client.GetAttestationData(ctx, phase0.Slot(100))
 
 		require.NoError(t, err)
 		require.Less(t, time.Since(startTime), defaultSoftTimeout)
@@ -325,7 +328,7 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		client, err := createClient(ctx, beaconServer.URL, withWeightedAttestationData)
 		require.NoError(t, err)
 
-		response, dataVersion, err := client.GetAttestationData(t.Context(), testSlot)
+		response, dataVersion, err := client.GetAttestationData(ctx, testSlot)
 
 		require.Nil(t, response)
 		require.Equal(t, DataVersionNil, dataVersion)
@@ -340,7 +343,7 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		client, err := createClient(ctx, beaconServer.URL, withWeightedAttestationData)
 		require.NoError(t, err)
 
-		_, _, err = client.GetAttestationData(t.Context(), phase0.Slot(100))
+		_, _, err = client.GetAttestationData(ctx, phase0.Slot(100))
 
 		require.NoError(t, err)
 	})
@@ -353,7 +356,8 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		client, err := createClient(ctx, beaconServer.URL, withWeightedAttestationData)
 		require.NoError(t, err)
 
-		client.GetAttestationData(t.Context(), phase0.Slot(100))
+		_, _, err = client.GetAttestationData(ctx, phase0.Slot(100))
+		require.NoError(t, err)
 
 		require.Equal(t, 1, client.blockRootToSlotCache.Len())
 		for root, item := range client.blockRootToSlotCache.Items() {
@@ -373,12 +377,13 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		require.NoError(t, err)
 
 		startTime := time.Now()
-		client.GetAttestationData(t.Context(), phase0.Slot(100))
+		_, _, err = client.GetAttestationData(ctx, phase0.Slot(100))
+		require.NoError(t, err)
 
 		require.Less(t, time.Since(startTime), defaultSoftTimeout)
 	})
 
-	t.Run("multiple beacon clients: awaits for soft timeout when one of the servers is a slow responder", func(t *testing.T) {
+	t.Run("multiple beacon clients: awaits for ctx deadline when one of the servers is a slow responder", func(t *testing.T) {
 		const numberOfFastServers = 2
 		var beaconServersURLs []string
 		for i := 0; i < numberOfFastServers; i++ {
@@ -391,8 +396,11 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		client, err := createClient(ctx, strings.Join(beaconServersURLs, ";"), withWeightedAttestationData)
 		require.NoError(t, err)
 
+		reqCtx, cancel := context.WithTimeout(ctx, defaultSoftTimeout)
+		defer cancel()
+
 		startTime := time.Now()
-		_, _, err = client.GetAttestationData(t.Context(), phase0.Slot(100))
+		_, _, err = client.GetAttestationData(reqCtx, phase0.Slot(100))
 
 		require.NoError(t, err)
 		timeElapsed := time.Since(startTime)
@@ -411,7 +419,7 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		require.NoError(t, err)
 
 		startTime := time.Now()
-		response, version, err := client.GetAttestationData(t.Context(), phase0.Slot(100))
+		response, version, err := client.GetAttestationData(ctx, phase0.Slot(100))
 
 		require.Error(t, err)
 		require.Equal(t, err.Error(), "no attestations received")
@@ -432,14 +440,10 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		client, err := createClient(ctx, strings.Join(beaconServersURLs, ";"), withWeightedAttestationData)
 		require.NoError(t, err)
 
-		startTime := time.Now()
-		response, version, err := client.GetAttestationData(t.Context(), phase0.Slot(100))
-
+		response, version, err := client.GetAttestationData(ctx, phase0.Slot(100))
 		require.NoError(t, err)
 		require.NotNil(t, response)
 		require.Equal(t, spec.DataVersionPhase0, version)
-		timeElapsed := time.Since(startTime)
-		require.LessOrEqual(t, timeElapsed, client.weightedAttestationDataSoftTimeout)
 	})
 
 	t.Run("multiple beacon clients: responses are correctly weighted", func(t *testing.T) {
@@ -474,7 +478,7 @@ func TestGoClient_GetAttestationData_Weighted(t *testing.T) {
 		client, err := createClient(ctx, strings.Join(beaconServersURLs, ";"), withWeightedAttestationData)
 		require.NoError(t, err)
 
-		response, version, err := client.GetAttestationData(t.Context(), testSlot)
+		response, version, err := client.GetAttestationData(ctx, testSlot)
 
 		require.NoError(t, err)
 		require.Equal(t, spec.DataVersionPhase0, version)

--- a/beacon/goclient/goclient.go
+++ b/beacon/goclient/goclient.go
@@ -130,14 +130,10 @@ type GoClient struct {
 	// attestationDataCache helps reuse recently fetched attestation data.
 	// AttestationData is cached by slot only, because Beacon nodes should return the same
 	// data regardless of the requested committeeIndex.
-	attestationDataCache               *ttlcache.Cache[phase0.Slot, *phase0.AttestationData]
-	weightedAttestationDataSoftTimeout time.Duration
-	weightedAttestationDataHardTimeout time.Duration
+	attestationDataCache *ttlcache.Cache[phase0.Slot, *phase0.AttestationData]
 
 	// blockRootToSlotCache is used for attestation data scoring. When multiple Consensus clients are used,
-	// the cache helps reduce the number of Consensus Client calls by `n-1`, where `n` is the number of Consensus clients
-	// that successfully fetched attestation data and proceeded to the scoring phase. Capacity is rather an arbitrary number,
-	// intended for cases where some objects within the application may need to fetch attestation data for more than one slot.
+	// the cache helps reduce the number of calls we issue to CLs.
 	blockRootToSlotCache *ttlcache.Cache[phase0.Root, phase0.Slot]
 
 	// committeesCache caches Beacon committees by epoch to avoid repeated fetching
@@ -182,17 +178,15 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 	}
 
 	client := &GoClient{
-		log:                                logger.Named(log.NameConsensusClient),
-		beaconConfigInit:                   make(chan struct{}),
-		syncDistanceTolerance:              phase0.Slot(opt.SyncDistanceTolerance),
-		commonTimeout:                      commonTimeout,
-		longTimeout:                        longTimeout,
-		withWeightedAttestationData:        opt.WithWeightedAttestationData,
-		withParallelSubmissions:            opt.WithParallelSubmissions,
-		weightedAttestationDataSoftTimeout: time.Duration(float64(commonTimeout) / 2.5),
-		weightedAttestationDataHardTimeout: commonTimeout,
-		supportedTopics:                    []eventTopic{eventTopicHead, eventTopicBlock},
-		activatedClients:                   hashmap.New[string, struct{}](),
+		log:                         logger.Named(log.NameConsensusClient),
+		beaconConfigInit:            make(chan struct{}),
+		syncDistanceTolerance:       phase0.Slot(opt.SyncDistanceTolerance),
+		commonTimeout:               commonTimeout,
+		longTimeout:                 longTimeout,
+		withWeightedAttestationData: opt.WithWeightedAttestationData,
+		withParallelSubmissions:     opt.WithParallelSubmissions,
+		supportedTopics:             []eventTopic{eventTopicHead, eventTopicBlock},
+		activatedClients:            hashmap.New[string, struct{}](),
 	}
 
 	for _, beaconAddr := range beaconAddrList {
@@ -231,7 +225,7 @@ func New(ctx context.Context, logger *zap.Logger, opt Options) (*GoClient, error
 
 	client.attestationDataCache = ttlcache.New(
 		// we only fetch attestation data during the slot of the relevant duty (and never later),
-		// hence caching it for 2 slots is sufficient
+		// hence caching it for 2 slots should be good enough
 		ttlcache.WithTTL[phase0.Slot, *phase0.AttestationData](2 * config.SlotDuration),
 	)
 

--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -161,19 +161,36 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 		return nil
 	}
 
+	// We must submit aggregate data before a certain deadline is reached to be able to participate and
+	// complete QBFT round 1 in time before QBFT round-change happens, that deadline is defined as:
+	//
+	// `slot_start_time + round1_timeout - qbft_consensus_duration - misc_time`
+	//
+	// plugging in the following estimates we get the deadline of `slot_start_time + 9.5s`:
+	// - round1_timeout = 10s (https://github.com/ssvlabs/ssv/blob/stage/protocol/v2/qbft/roundtimer/timer.go#L77-L135)
+	// - qbft_consensus_duration = 350ms (as per previous estimates in https://github.com/ssvlabs/ssv/blob/stage/docs/MEV_CONSIDERATIONS.md)
+	// - misc_time = 150ms (to account for miscellaneous delays in code execution)
+	deadline := r.BaseRunner.NetworkConfig.SlotStartTime(duty.DutySlot()).Add(9500 * time.Millisecond)
+	reqCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
 	span.AddEvent("submitting aggregate and proof",
 		trace.WithAttributes(
 			observability.CommitteeIndexAttribute(duty.CommitteeIndex),
 			observability.ValidatorIndexAttribute(duty.ValidatorIndex)),
 	)
-	res, ver, err := r.GetBeaconNode().SubmitAggregateSelectionProof(ctx, duty.Slot, duty.CommitteeIndex, duty.CommitteeLength, duty.ValidatorIndex, fullSig)
+	reqStart := time.Now()
+	res, ver, err := r.GetBeaconNode().SubmitAggregateSelectionProof(reqCtx, duty.DutySlot(), duty.CommitteeIndex, duty.CommitteeLength, duty.ValidatorIndex, fullSig)
 	if err != nil {
 		return fmt.Errorf("failed to submit aggregate and proof: %w", err)
 	}
-
 	const submittedAggregateAndProofEvent = "submitted aggregate and proof"
-	logger.Debug(submittedAggregateAndProofEvent)
-	span.AddEvent(submittedAggregateAndProofEvent)
+	logger.Debug(submittedAggregateAndProofEvent, fields.Took(time.Since(reqStart)))
+	span.AddEvent(submittedAggregateAndProofEvent,
+		trace.WithAttributes(
+			observability.CommitteeIndexAttribute(duty.CommitteeIndex),
+			observability.ValidatorIndexAttribute(duty.ValidatorIndex)),
+	)
 
 	byts, err := res.MarshalSSZ()
 	if err != nil {
@@ -186,7 +203,7 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 	}
 
 	r.measurements.StartConsensus()
-	if err := r.BaseRunner.decide(ctx, logger, duty.Slot, input, r.ValCheck); err != nil {
+	if err := r.BaseRunner.decide(ctx, logger, duty.DutySlot(), input, r.ValCheck); err != nil {
 		return fmt.Errorf("qbft-decide: %w", err)
 	}
 

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -1040,17 +1040,32 @@ func (r *CommitteeRunner) executeDuty(ctx context.Context, logger *zap.Logger, d
 
 	r.measurements.StartDutyFlow()
 
-	start := time.Now()
-	slot := duty.DutySlot()
+	// We must fetch the attestation data before a certain deadline is reached to be able to participate and
+	// complete QBFT round 1 in time before QBFT round-change happens, that deadline is defined as:
+	//
+	// `slot_start_time + round1_timeout - qbft_consensus_duration - misc_time`
+	//
+	// plugging in the following estimates we get the deadline of `slot_start_time + 5.5s`:
+	// - round1_timeout = 6s (https://github.com/ssvlabs/ssv/blob/stage/protocol/v2/qbft/roundtimer/timer.go#L77-L135)
+	// - qbft_consensus_duration = 350ms (as per previous estimates in https://github.com/ssvlabs/ssv/blob/stage/docs/MEV_CONSIDERATIONS.md)
+	// - misc_time = 150ms (to account for miscellaneous delays in code execution)
+	deadline := r.BaseRunner.NetworkConfig.SlotStartTime(duty.DutySlot()).Add(5500 * time.Millisecond)
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
 
-	attData, _, err := r.GetBeaconNode().GetAttestationData(ctx, slot)
+	span.AddEvent("fetching attestation data",
+		trace.WithAttributes(observability.BeaconSlotAttribute(duty.DutySlot())),
+	)
+	reqStart := time.Now()
+	attData, _, err := r.GetBeaconNode().GetAttestationData(ctx, duty.DutySlot())
 	if err != nil {
 		return fmt.Errorf("failed to get attestation data: %w", err)
 	}
-
 	const attestationDataFetchedEvent = "fetched attestation data from CL"
-	logger.Debug(attestationDataFetchedEvent, fields.Took(time.Since(start)))
-	span.AddEvent(attestationDataFetchedEvent)
+	logger.Debug(attestationDataFetchedEvent, fields.Took(time.Since(reqStart)))
+	span.AddEvent(attestationDataFetchedEvent,
+		trace.WithAttributes(observability.BeaconSlotAttribute(duty.DutySlot())),
+	)
 
 	vote := &spectypes.BeaconVote{
 		BlockRoot: attData.BeaconBlockRoot,
@@ -1061,7 +1076,7 @@ func (r *CommitteeRunner) executeDuty(ctx context.Context, logger *zap.Logger, d
 	r.measurements.StartConsensus()
 	r.ValCheck = ssv.NewVoteChecker(
 		r.signer,
-		slot,
+		duty.DutySlot(),
 		r.attestingValidators,
 		r.GetNetworkConfig().EstimatedCurrentEpoch(),
 		vote,


### PR DESCRIPTION
Depends on https://github.com/ssvlabs/ssv/issues/1825 in a sense that until QBFT instance can work with "absent" value(s) there is no point in having a hard timeout/deadline for a CL request ... hence marking this PR as draft for now.

This PR improves couple of WAD-related things, mostly:
- improves logs & adds/clarifies some comments
- `record` the `BeaconBlockHeader` request so it's visible on Grafana charts that track CL-related metrics
- wraps the errors `BeaconBlockHeader` returns such that we log/track these correctly
- and most importantly, replaces the previous "soft-hard timeout" approach with a more fitting/precise deadline-based one

To expand on that last point, the issue(s) we want to solve:
- we want to make sure we are done with attestation-fetch request well before `slot_start_time + 6s` mark, so that attestation-duty can participate in and complete its QBFT in round 1 which times out at exactly 6s since slot start ... while with the current implementation we are setting **the same request timeout** (currently we use soft-timeout = 2s, hard-timeout = 4s) **regardless of when** the attestation-fetch request has started, so we are either aborting requests sooner than necessary or skipping round 1 entirely (which isn't great because of https://github.com/ssvlabs/ssv/issues/1825)
- we want to let the caller of `GoClient.GetAttestationData` to specify the deadline (think of it as a hard-deadline) because we call this method not only for attestation-duty but also for aggregator-duty (and we wouldn't want to make any unnecessary assumptions about the callers anyway)
- see also [a concrete example](https://github.com/ssvlabs/ssv/pull/2628#issuecomment-3689244396) presented below

the solution:
- the caller configures the hard-deadline on the `ctx` passed to `GetAttestationData`
- for attestation-duty that hard-deadline is `slot_start_time + 6s - pre_consensus_duration - qbft_consensus_duration - misc_time` (where `pre_consensus_duration=0ms` since it's absent for this duty-type, `qbft_consensus_duration=350ms` as [per our previous estimates here](https://github.com/ssvlabs/ssv/blob/af176b531548c20e444495423ce3e8a4a7810f84/docs/MEV_CONSIDERATIONS.md#L94-L94), `misc_time=150ms` to account for miscellaneous delays); The deadline effectively comes out to be = `slot_start_time + 5.5s` which gives us `~1.5s` to fetch attestation data in the worst-case scenario (when we started the duty `4s` since the slot start)
- for aggregator-duty, it typically waits 8s since slot start and then fetches the attestation data + submits aggregate data [before round 1 times out (at 8s + 2s since slot start)](https://github.com/ssvlabs/ssv/blob/stage/protocol/v2/qbft/roundtimer/timer.go#L77-L135) ... so by the same reasoning the deadline effectively comes out to be = `slot_start_time + 9.5s` giving us the same `~1.5s` to complete these 2 requests (attestation data should be fetched from cache though)
- upon reaching that hard-deadline (or prior to it in case all CL clients are done with the request) we terminate all the pending CL requests and check what responses we've got, returning the best
- additionally, we can also introduce a soft-deadline (which is what I'm doing in this PR as well, setting it to be = "hard-deadline - 300ms"), it functions similar to soft-timeout we had previously where upon reaching it we would try to return the best result we've got so far, or wait until the 1st result that comes after that (or reaching the hard-deadline returning without any results)
- one other notable change to call out is in `scoreAttestationData` func, previously it would time out (and return the base score) at `min(gc.weightedAttestationDataSoftTimeout/2, gc.weightedAttestationDataHardTimeout)` which is a bit unpredictable ... with this PR we just use the hard-deadline every time (we could use the soft-deadline for this instead, using hard-deadline for this just makes more sense to me)