### PR TITLE
chore(renovate): group non-major updates into a single PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "github>ssvlabs/shared-configs//renovate/renovate.json"
+    "github>ssvlabs/shared-configs//renovate/renovate.json",
+    "group:allNonMajor"
   ],
   "baseBranches": ["stage"],
   "packageRules": [


### PR DESCRIPTION
## Summary

- Adds the `group:allNonMajor` preset to Renovate config.
- Collapses `minor` and `patch` dependency updates across all managers (gomod, npm, dockerfile, github-actions) into a single grouped PR titled `chore(deps): update all non-major dependencies`.
- Majors, digest updates, pin-dependencies PRs, and vulnerability alerts are **not** affected — they remain as individual PRs.

## Context

`ssvlabs/ssv` currently has 16 open Renovate PRs, the oldest from May 2025. Historical merge rate is ~12% (3/26) — most PRs age out and are auto-closed by `abandonments:recommended` without ever being reviewed. The main driver is per-dependency PR sprawl: each minor/patch release of each dep opens its own PR.

This pilot is intentionally a single-line change (one added preset) to isolate the effect before layering further improvements (scheduling, rebase-behavior tuning, vulnerability-alert separation).

## Expected effect on current queue

After the next Renovate run, ~8 of the 16 open PRs collapse into one grouped PR (minor/patch across otel/sdk [sec], go-ethereum [sec], btcd/btcec, litter, go-chi/render, docker/docker [sec], styled-components, postcss [sec]). The remaining 8 (digest bumps, pin-deps PRs, config migration, abandoned-tagged) are unchanged.

## Test plan

- [ ] Merge; verify Renovate's next run closes the superseded individual PRs with a "superseded by" comment.
- [ ] Verify a single `chore(deps): update all non-major dependencies` PR is opened against `stage`.
- [ ] Monitor for 2–3 weeks: compare PR creation rate and grouped-PR CI stability vs. prior baseline. If the group PR is too fat or conflict-prone, the natural next step is `matchManagers`-scoped grouping (e.g. gomod-only).