### PR TITLE
network: make the pubsub topic whitelist slot-aware (#2968 item 3)

### DIFF
--- a/network/commons/subnets.go
+++ b/network/commons/subnets.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
 	"github.com/ssvlabs/ssv/networkconfig"
@@ -115,13 +116,17 @@ func BooleCommitteeSubnet(committee []spectypes.OperatorID) uint64 {
 	return result.Uint64()
 }
 
-// Topics returns the topic whitelist for the given network's fork state: Alan+Boole before the
-// fork (so a node started pre-fork can accept Boole subscriptions once the transition window
-// opens, without a pubsub rebuild), Boole-only after.
-func Topics(netCfg *networkconfig.Network) []string {
+// Topics returns the topic whitelist for the given network's fork state at slot: Alan+Boole
+// while Alan traffic can still be valid (pre-fork, or within the subsequent transition window
+// during which late pre-fork committee traffic keyed by a pre-fork slot may still legitimately
+// arrive on the Alan topic), Boole-only once that window has passed. Always includes the Boole
+// set, since Boole subscriptions can legitimately start opening ahead of the fork (prior window).
+func Topics(netCfg *networkconfig.Network, slot phase0.Slot) []string {
+	includeAlan := !netCfg.BooleForkAtSlot(slot) || netCfg.InBooleTransitionWindow(slot)
+
 	topics := make([]string, 0, SubnetsCount*2)
 	for subnet := uint64(0); subnet < SubnetsCount; subnet++ {
-		if !netCfg.BooleFork() {
+		if includeAlan {
 			topics = append(topics, GetTopicFullName(SubnetTopicID(subnet)))
 		}
 		topics = append(topics, BooleTopic(netCfg.SSV.Name, subnet))

--- a/network/commons/subnets_test.go
+++ b/network/commons/subnets_test.go
@@ -214,11 +214,11 @@ func TestDiffSubnets(t *testing.T) {
 	require.Equal(t, 128-62, added.ActiveCount()+removed.ActiveCount())
 }
 
-// TestTopics covers the four Boole-transition phases the pubsub startup whitelist must track in
+// TestTopics covers the five Boole-transition phases the pubsub startup whitelist must track in
 // lockstep with per-slot subscription derivation (network/p2p's subscribedSubnetsForCurrentEpoch):
 // pre-fork steady state, the prior window, the subsequent window (the bug this guards against —
 // a node started in this window must still whitelist Alan topics for late pre-fork committee
-// traffic), and well post-fork.
+// traffic), the first slot past the subsequent window, and well post-fork.
 func TestTopics(t *testing.T) {
 	booleCfg := func(booleEpoch phase0.Epoch) *networkconfig.Network {
 		cfg := *networkconfig.TestNetwork
@@ -300,6 +300,8 @@ func TestTopics(t *testing.T) {
 	t.Run("first slot past the subsequent window is Boole-only", func(t *testing.T) {
 		cfg := booleCfg(cur + 1)
 		// One slot past the window end [F, F+SlotsPerEpoch+2) — the boundary that closes Alan.
+		// The +2 mirrors networkconfig's unexported booleSubsequentWindowLateSlots; if that margin
+		// ever changes, the InBooleTransitionWindow assertion below fails loudly.
 		slot := cfg.FirstSlotAtEpoch(cur+1) + phase0.Slot(cfg.SlotsPerEpoch) + 2
 		require.True(t, cfg.BooleForkAtSlot(slot))
 		require.False(t, cfg.InBooleTransitionWindow(slot), "expected slot just past the subsequent window")

--- a/network/commons/subnets_test.go
+++ b/network/commons/subnets_test.go
@@ -5,13 +5,17 @@ import (
 	crand "crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
+	"math"
 	"math/big"
 	"strings"
 	"testing"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
+
+	"github.com/ssvlabs/ssv/networkconfig"
 )
 
 func BenchmarkBooleCommitteeSubnet(b *testing.B) {
@@ -208,6 +212,113 @@ func TestDiffSubnets(t *testing.T) {
 
 	added, removed := s1.DiffSubnets(s2)
 	require.Equal(t, 128-62, added.ActiveCount()+removed.ActiveCount())
+}
+
+// TestTopics covers the four Boole-transition phases the pubsub startup whitelist must track in
+// lockstep with per-slot subscription derivation (network/p2p's subscribedSubnetsForCurrentEpoch):
+// pre-fork steady state, the prior window, the subsequent window (the bug this guards against —
+// a node started in this window must still whitelist Alan topics for late pre-fork committee
+// traffic), and well post-fork.
+func TestTopics(t *testing.T) {
+	booleCfg := func(booleEpoch phase0.Epoch) *networkconfig.Network {
+		cfg := *networkconfig.TestNetwork
+		beaconCfg := *networkconfig.TestNetwork.Beacon
+		ssvCfg := *networkconfig.TestNetwork.SSV
+		ssvCfg.Forks.Boole = booleEpoch
+		cfg.Beacon = &beaconCfg
+		cfg.SSV = &ssvCfg
+		return &cfg
+	}
+
+	alanTopicsSet := func() map[string]struct{} {
+		set := make(map[string]struct{}, SubnetsCount)
+		for subnet := uint64(0); subnet < SubnetsCount; subnet++ {
+			set[GetTopicFullName(SubnetTopicID(subnet))] = struct{}{}
+		}
+		return set
+	}
+	booleTopicsSet := func(name string) map[string]struct{} {
+		set := make(map[string]struct{}, SubnetsCount)
+		for subnet := uint64(0); subnet < SubnetsCount; subnet++ {
+			set[BooleTopic(name, subnet)] = struct{}{}
+		}
+		return set
+	}
+
+	toSet := func(topics []string) map[string]struct{} {
+		set := make(map[string]struct{}, len(topics))
+		for _, topic := range topics {
+			set[topic] = struct{}{}
+		}
+		return set
+	}
+
+	cur := networkconfig.TestNetwork.EstimatedCurrentEpoch()
+
+	t.Run("pre-fork steady state includes Alan and Boole", func(t *testing.T) {
+		cfg := booleCfg(math.MaxUint64) // no fork scheduled
+		slot := cfg.EstimatedCurrentSlot()
+		require.False(t, cfg.BooleForkAtSlot(slot))
+		require.False(t, cfg.InBooleTransitionWindow(slot), "far from the fork, expected no transition window")
+
+		got := toSet(Topics(cfg, slot))
+		want := alanTopicsSet()
+		for topic := range booleTopicsSet(cfg.SSV.Name) {
+			want[topic] = struct{}{}
+		}
+		require.Equal(t, want, got)
+	})
+
+	t.Run("prior window includes Alan and Boole", func(t *testing.T) {
+		cfg := booleCfg(cur + 2)
+		slot := cfg.FirstSlotAtEpoch(cur + 1) // last pre-fork epoch, inside the 1-epoch prior window
+		require.False(t, cfg.BooleForkAtSlot(slot))
+		require.True(t, cfg.InBooleTransitionWindow(slot), "expected slot inside the prior window")
+
+		got := toSet(Topics(cfg, slot))
+		want := alanTopicsSet()
+		for topic := range booleTopicsSet(cfg.SSV.Name) {
+			want[topic] = struct{}{}
+		}
+		require.Equal(t, want, got)
+	})
+
+	t.Run("subsequent window includes Alan and Boole (bug fix)", func(t *testing.T) {
+		cfg := booleCfg(cur + 1)
+		slot := cfg.FirstSlotAtEpoch(cur + 1) // fork slot itself, start of the subsequent window
+		require.True(t, cfg.BooleForkAtSlot(slot))
+		require.True(t, cfg.InBooleTransitionWindow(slot), "expected slot inside the subsequent window")
+
+		got := toSet(Topics(cfg, slot))
+		want := alanTopicsSet()
+		for topic := range booleTopicsSet(cfg.SSV.Name) {
+			want[topic] = struct{}{}
+		}
+		require.Equal(t, want, got)
+	})
+
+	t.Run("first slot past the subsequent window is Boole-only", func(t *testing.T) {
+		cfg := booleCfg(cur + 1)
+		// One slot past the window end [F, F+SlotsPerEpoch+2) — the boundary that closes Alan.
+		slot := cfg.FirstSlotAtEpoch(cur+1) + phase0.Slot(cfg.SlotsPerEpoch) + 2
+		require.True(t, cfg.BooleForkAtSlot(slot))
+		require.False(t, cfg.InBooleTransitionWindow(slot), "expected slot just past the subsequent window")
+
+		got := toSet(Topics(cfg, slot))
+		want := booleTopicsSet(cfg.SSV.Name)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("well post-fork is Boole-only", func(t *testing.T) {
+		cfg := booleCfg(0)
+		slot := cfg.EstimatedCurrentSlot()
+		require.True(t, cfg.BooleForkAtSlot(slot))
+		require.False(t, cfg.InBooleTransitionWindow(slot), "well past the fork, expected no transition window")
+
+		got := toSet(Topics(cfg, slot))
+		want := booleTopicsSet(cfg.SSV.Name)
+		require.Equal(t, want, got)
+	})
 }
 
 func TestSubnetsList(t *testing.T) {

--- a/network/topics/pubsub.go
+++ b/network/topics/pubsub.go
@@ -130,7 +130,7 @@ func NewPubSub(
 
 	// Set up a SubFilter with a whitelist of known topics.
 	sf := newSubFilter()
-	for _, topic := range commons.Topics(cfg.NetworkConfig) {
+	for _, topic := range commons.Topics(cfg.NetworkConfig, cfg.NetworkConfig.EstimatedCurrentSlot()) {
 		sf.Register(topic)
 	}
 


### PR DESCRIPTION
Item 3 of #2968.

`commons.Topics` gated the Alan topic set on the coarse `BooleFork()` epoch snapshot while subscriptions derive per-slot from the transition-window predicate — so a node **started inside the ~34-slot subsequent window** whitelisted Boole-only yet legitimately subscribes to Alan topics for late pre-fork committee traffic, working only incidentally because `topicsCtrl.Subscribe` self-registers.

`Topics` now takes the evaluation slot explicitly and includes the Alan set whenever Alan traffic can still be valid at that slot (`!BooleForkAtSlot(slot) || InBooleTransitionWindow(slot)`), always including Boole; the sole caller (`NewPubSub`) passes `EstimatedCurrentSlot()`. The startup-snapshot design is unchanged — the snapshot just now matches the subscription policy at the same instant.

Deep review notes (passed): the include-Alan condition is logically identical to all three per-slot subscription-derivation sites in `network/p2p`; the whitelist gates subscriptions/peer-announcements (mesh membership), not message validation, and the widening is confined to the subsequent window where the fork design requires Alan traffic to flow; a node started past the window gets Boole-only with no Alan leak (`Boole==0` guard verified). Five-phase table test covers pre-fork steady state, prior window, subsequent window (the bug), the exact first slot past the window (the boundary that closes Alan), and well post-fork.