### PR TITLE
networkconfig: single-source the aggregator-selection formula (#2968 item 5)

### DIFF
--- a/beacon/goclient/aggregator.go
+++ b/beacon/goclient/aggregator.go
@@ -2,8 +2,6 @@ package goclient
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/binary"
 	"fmt"
 	"net/http"
 	"time"
@@ -13,6 +11,8 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/electra"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	ssz "github.com/ferranbt/fastssz"
+
+	"github.com/ssvlabs/ssv/networkconfig"
 )
 
 // IsAggregator returns true if the validator is selected as an aggregator for the given
@@ -24,15 +24,7 @@ func (gc *GoClient) IsAggregator(
 	committeeLength uint64,
 	slotSig []byte,
 ) bool {
-	modulo := committeeLength / gc.beaconConfig.TargetAggregatorsPerCommittee
-	if modulo == 0 {
-		modulo = 1
-	}
-
-	h := sha256.Sum256(slotSig)
-	x := binary.LittleEndian.Uint64(h[:8])
-
-	return x%modulo == 0
+	return networkconfig.IsAggregatorSelected(gc.beaconConfig.TargetAggregatorsPerCommittee, committeeLength, slotSig)
 }
 
 // GetAggregateAttestation returns the aggregate attestation for the given slot and committee.

--- a/networkconfig/aggregator.go
+++ b/networkconfig/aggregator.go
@@ -6,7 +6,7 @@ import (
 )
 
 // IsAggregatorSelected returns true if the given slot signature selects the validator as an
-// aggregator for a committee of committeeCount, given targetAggregatorsPerCommittee.
+// aggregator for a committee of committeeLength members, given targetAggregatorsPerCommittee.
 //
 // This is the shared implementation of the beacon-chain aggregator-selection check, used by both
 // beacon/goclient and protocol/v2/ssv/runner. It must stay bit-identical across pre/post-Boole
@@ -18,8 +18,8 @@ import (
 //	 committee = get_beacon_committee(state, slot, index)
 //	 modulo = max(1, len(committee) // TARGET_AGGREGATORS_PER_COMMITTEE)
 //	 return bytes_to_uint64(hash(slot_signature)[0:8]) % modulo == 0
-func IsAggregatorSelected(targetAggregatorsPerCommittee, committeeCount uint64, slotSig []byte) bool {
-	modulo := committeeCount / targetAggregatorsPerCommittee
+func IsAggregatorSelected(targetAggregatorsPerCommittee, committeeLength uint64, slotSig []byte) bool {
+	modulo := committeeLength / targetAggregatorsPerCommittee
 	if modulo == 0 {
 		// Modulo must be at least 1.
 		modulo = 1

--- a/networkconfig/aggregator.go
+++ b/networkconfig/aggregator.go
@@ -1,0 +1,30 @@
+package networkconfig
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+)
+
+// IsAggregatorSelected returns true if the given slot signature selects the validator as an
+// aggregator for a committee of committeeCount, given targetAggregatorsPerCommittee.
+//
+// This is the shared implementation of the beacon-chain aggregator-selection check, used by both
+// beacon/goclient and protocol/v2/ssv/runner. It must stay bit-identical across pre/post-Boole
+// call sites.
+//
+// Spec pseudocode definition:
+//
+//	def is_aggregator(state: BeaconState, slot: Slot, index: CommitteeIndex, slot_signature: BLSSignature) -> bool:
+//	 committee = get_beacon_committee(state, slot, index)
+//	 modulo = max(1, len(committee) // TARGET_AGGREGATORS_PER_COMMITTEE)
+//	 return bytes_to_uint64(hash(slot_signature)[0:8]) % modulo == 0
+func IsAggregatorSelected(targetAggregatorsPerCommittee, committeeCount uint64, slotSig []byte) bool {
+	modulo := committeeCount / targetAggregatorsPerCommittee
+	if modulo == 0 {
+		// Modulo must be at least 1.
+		modulo = 1
+	}
+
+	h := sha256.Sum256(slotSig)
+	return binary.LittleEndian.Uint64(h[:8])%modulo == 0
+}

--- a/networkconfig/aggregator.go
+++ b/networkconfig/aggregator.go
@@ -18,11 +18,16 @@ import (
 //	 committee = get_beacon_committee(state, slot, index)
 //	 modulo = max(1, len(committee) // TARGET_AGGREGATORS_PER_COMMITTEE)
 //	 return bytes_to_uint64(hash(slot_signature)[0:8]) % modulo == 0
+//
+// A zero targetAggregatorsPerCommittee (never the case in practice — the spec constant is 16)
+// is clamped to modulo 1 rather than panicking on division.
 func IsAggregatorSelected(targetAggregatorsPerCommittee, committeeLength uint64, slotSig []byte) bool {
-	modulo := committeeLength / targetAggregatorsPerCommittee
-	if modulo == 0 {
-		// Modulo must be at least 1.
-		modulo = 1
+	// Modulo must be at least 1. The guard on targetAggregatorsPerCommittee keeps the helper
+	// total: a misconfigured zero target degrades to modulo 1 ("selected", so aggregation
+	// duties are still attempted) instead of a division panic.
+	modulo := uint64(1)
+	if targetAggregatorsPerCommittee > 0 {
+		modulo = max(1, committeeLength/targetAggregatorsPerCommittee)
 	}
 
 	h := sha256.Sum256(slotSig)

--- a/networkconfig/aggregator_test.go
+++ b/networkconfig/aggregator_test.go
@@ -11,8 +11,8 @@ import (
 // computeExpectedIsAggregatorSelected is an independent recompute of the aggregator-selection
 // formula, mirroring the documented spec pseudocode so a bug in IsAggregatorSelected (e.g. wrong
 // endianness or hash) fails this test rather than silently drifting.
-func computeExpectedIsAggregatorSelected(targetAggregatorsPerCommittee, committeeCount uint64, slotSig []byte) bool {
-	modulo := committeeCount / targetAggregatorsPerCommittee
+func computeExpectedIsAggregatorSelected(targetAggregatorsPerCommittee, committeeLength uint64, slotSig []byte) bool {
+	modulo := committeeLength / targetAggregatorsPerCommittee
 	if modulo == 0 {
 		modulo = 1
 	}
@@ -30,23 +30,23 @@ func TestIsAggregatorSelected(t *testing.T) {
 	testCases := []struct {
 		name           string
 		target         uint64
-		committeeCount uint64
+		committeeLength uint64
 		slotSig        []byte
 	}{
-		{name: "small committee forces modulo to one", target: 16, committeeCount: 2, slotSig: slotSigA},
-		{name: "zero committee count forces modulo to one", target: 16, committeeCount: 0, slotSig: slotSigA},
-		{name: "committeeCount equal to target forces modulo to one", target: 16, committeeCount: 16, slotSig: slotSigA},
-		{name: "large committee uses computed modulo (sig A)", target: 16, committeeCount: 128, slotSig: slotSigA},
-		{name: "large committee uses computed modulo (sig B)", target: 16, committeeCount: 128, slotSig: slotSigB},
-		{name: "small target", target: 3, committeeCount: 10, slotSig: slotSigA},
+		{name: "small committee forces modulo to one", target: 16, committeeLength: 2, slotSig: slotSigA},
+		{name: "zero committee length forces modulo to one", target: 16, committeeLength: 0, slotSig: slotSigA},
+		{name: "committeeLength equal to target forces modulo to one", target: 16, committeeLength: 16, slotSig: slotSigA},
+		{name: "large committee uses computed modulo (sig A)", target: 16, committeeLength: 128, slotSig: slotSigA},
+		{name: "large committee uses computed modulo (sig B)", target: 16, committeeLength: 128, slotSig: slotSigB},
+		{name: "small target", target: 3, committeeLength: 10, slotSig: slotSigA},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := IsAggregatorSelected(tc.target, tc.committeeCount, tc.slotSig)
-			want := computeExpectedIsAggregatorSelected(tc.target, tc.committeeCount, tc.slotSig)
+			got := IsAggregatorSelected(tc.target, tc.committeeLength, tc.slotSig)
+			want := computeExpectedIsAggregatorSelected(tc.target, tc.committeeLength, tc.slotSig)
 			require.Equal(t, want, got)
 		})
 	}

--- a/networkconfig/aggregator_test.go
+++ b/networkconfig/aggregator_test.go
@@ -12,9 +12,9 @@ import (
 // formula, mirroring the documented spec pseudocode so a bug in IsAggregatorSelected (e.g. wrong
 // endianness or hash) fails this test rather than silently drifting.
 func computeExpectedIsAggregatorSelected(targetAggregatorsPerCommittee, committeeLength uint64, slotSig []byte) bool {
-	modulo := committeeLength / targetAggregatorsPerCommittee
-	if modulo == 0 {
-		modulo = 1
+	modulo := uint64(1)
+	if targetAggregatorsPerCommittee > 0 {
+		modulo = max(1, committeeLength/targetAggregatorsPerCommittee)
 	}
 	h := sha256.Sum256(slotSig)
 	x := binary.LittleEndian.Uint64(h[:8])
@@ -39,6 +39,7 @@ func TestIsAggregatorSelected(t *testing.T) {
 		{name: "large committee uses computed modulo (sig A)", target: 16, committeeLength: 128, slotSig: slotSigA},
 		{name: "large committee uses computed modulo (sig B)", target: 16, committeeLength: 128, slotSig: slotSigB},
 		{name: "small target", target: 3, committeeLength: 10, slotSig: slotSigA},
+		{name: "zero target clamps to modulo one instead of panicking", target: 0, committeeLength: 128, slotSig: slotSigA},
 	}
 
 	for _, tc := range testCases {

--- a/networkconfig/aggregator_test.go
+++ b/networkconfig/aggregator_test.go
@@ -8,9 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// computeExpectedIsAggregatorSelected is an independent recompute of the aggregator-selection
-// formula, mirroring the documented spec pseudocode so a bug in IsAggregatorSelected (e.g. wrong
-// endianness or hash) fails this test rather than silently drifting.
+// computeExpectedIsAggregatorSelected is a recompute of the aggregator-selection formula,
+// mirroring the documented spec pseudocode. Being a mirror, it catches a divergence in one copy
+// but not a conceptual error replicated in both (e.g. wrong endianness); the golden vectors in
+// TestIsAggregatorSelected_GoldenVectors pin known-good outputs for that.
 func computeExpectedIsAggregatorSelected(targetAggregatorsPerCommittee, committeeLength uint64, slotSig []byte) bool {
 	modulo := uint64(1)
 	if targetAggregatorsPerCommittee > 0 {
@@ -28,10 +29,10 @@ func TestIsAggregatorSelected(t *testing.T) {
 	slotSigB := []byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 
 	testCases := []struct {
-		name           string
-		target         uint64
+		name            string
+		target          uint64
 		committeeLength uint64
-		slotSig        []byte
+		slotSig         []byte
 	}{
 		{name: "small committee forces modulo to one", target: 16, committeeLength: 2, slotSig: slotSigA},
 		{name: "zero committee length forces modulo to one", target: 16, committeeLength: 0, slotSig: slotSigA},
@@ -49,6 +50,44 @@ func TestIsAggregatorSelected(t *testing.T) {
 			got := IsAggregatorSelected(tc.target, tc.committeeLength, tc.slotSig)
 			want := computeExpectedIsAggregatorSelected(tc.target, tc.committeeLength, tc.slotSig)
 			require.Equal(t, want, got)
+		})
+	}
+}
+
+// TestIsAggregatorSelected_GoldenVectors pins the selection formula to hardcoded known-good
+// outputs, so a conceptual error present in both the implementation and the mirrored recompute
+// above (e.g. wrong endianness, hash, or slice bounds) still fails.
+//
+// Golden values: sha256(64×'a')[0:8] little-endian = 7911663989264015615,
+// sha256(64×'b')[0:8] little-endian = 6460213001230351008; selected ⇔ value % modulo == 0 with
+// modulo = max(1, committeeLength/target).
+func TestIsAggregatorSelected_GoldenVectors(t *testing.T) {
+	t.Parallel()
+
+	slotSigA := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	slotSigB := []byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+	testCases := []struct {
+		name            string
+		target          uint64
+		committeeLength uint64
+		slotSig         []byte
+		want            bool
+	}{
+		{name: "sig A, modulo 8, not selected", target: 16, committeeLength: 128, slotSig: slotSigA, want: false},
+		{name: "sig B, modulo 8, selected", target: 16, committeeLength: 128, slotSig: slotSigB, want: true},
+		{name: "sig A, modulo clamped to 1, always selected", target: 16, committeeLength: 2, slotSig: slotSigA, want: true},
+		{name: "sig A, modulo 100, not selected", target: 1, committeeLength: 100, slotSig: slotSigA, want: false},
+		{name: "sig A, modulo 3, not selected", target: 3, committeeLength: 10, slotSig: slotSigA, want: false},
+		{name: "sig B, modulo 3, selected", target: 3, committeeLength: 10, slotSig: slotSigB, want: true},
+		{name: "zero target clamps to modulo 1, always selected", target: 0, committeeLength: 10, slotSig: slotSigA, want: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.want, IsAggregatorSelected(tc.target, tc.committeeLength, tc.slotSig))
 		})
 	}
 }

--- a/networkconfig/aggregator_test.go
+++ b/networkconfig/aggregator_test.go
@@ -1,0 +1,53 @@
+package networkconfig
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// computeExpectedIsAggregatorSelected is an independent recompute of the aggregator-selection
+// formula, mirroring the documented spec pseudocode so a bug in IsAggregatorSelected (e.g. wrong
+// endianness or hash) fails this test rather than silently drifting.
+func computeExpectedIsAggregatorSelected(targetAggregatorsPerCommittee, committeeCount uint64, slotSig []byte) bool {
+	modulo := committeeCount / targetAggregatorsPerCommittee
+	if modulo == 0 {
+		modulo = 1
+	}
+	h := sha256.Sum256(slotSig)
+	x := binary.LittleEndian.Uint64(h[:8])
+	return x%modulo == 0
+}
+
+func TestIsAggregatorSelected(t *testing.T) {
+	t.Parallel()
+
+	slotSigA := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	slotSigB := []byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+	testCases := []struct {
+		name           string
+		target         uint64
+		committeeCount uint64
+		slotSig        []byte
+	}{
+		{name: "small committee forces modulo to one", target: 16, committeeCount: 2, slotSig: slotSigA},
+		{name: "zero committee count forces modulo to one", target: 16, committeeCount: 0, slotSig: slotSigA},
+		{name: "committeeCount equal to target forces modulo to one", target: 16, committeeCount: 16, slotSig: slotSigA},
+		{name: "large committee uses computed modulo (sig A)", target: 16, committeeCount: 128, slotSig: slotSigA},
+		{name: "large committee uses computed modulo (sig B)", target: 16, committeeCount: 128, slotSig: slotSigB},
+		{name: "small target", target: 3, committeeCount: 10, slotSig: slotSigA},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := IsAggregatorSelected(tc.target, tc.committeeCount, tc.slotSig)
+			want := computeExpectedIsAggregatorSelected(tc.target, tc.committeeCount, tc.slotSig)
+			require.Equal(t, want, got)
+		})
+	}
+}

--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -3,12 +3,9 @@ package runner
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"hash"
-	"sync"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec"
@@ -21,6 +18,7 @@ import (
 
 	"github.com/ssvlabs/ssv/ssvsigner/ekm"
 
+	"github.com/ssvlabs/ssv/networkconfig"
 	"github.com/ssvlabs/ssv/observability"
 	"github.com/ssvlabs/ssv/observability/log/fields"
 	"github.com/ssvlabs/ssv/protocol/v2/blockchain/beacon"
@@ -596,54 +594,9 @@ func constructVersionedSignedAggregateAndProof(aggregateAndProof spec.VersionedA
 	return ret, nil
 }
 
-// isAggregatorFn returns IsAggregator func that performs hashing in an allocation-efficient manner.
+// isAggregatorFn returns the default IsAggregator func, delegating to the shared
+// networkconfig.IsAggregatorSelected helper so pre/post-Boole selection stays bit-identical
+// with beacon/goclient's implementation.
 func isAggregatorFn() func(targetAggregatorsPerCommittee uint64, committeeCount uint64, slotSig []byte) bool {
-	h := newHasher()
-	return func(targetAggregatorsPerCommittee uint64, committeeCount uint64, slotSig []byte) bool {
-		modulo := committeeCount / targetAggregatorsPerCommittee
-		if modulo == 0 {
-			// Modulo must be at least 1.
-			modulo = 1
-		}
-
-		b := h.hashSha256(slotSig)
-		return binary.LittleEndian.Uint64(b[:8])%modulo == 0
-	}
-}
-
-// hasher implements efficient thread-safe data-hashing functionality by pooling hash.Hash
-// instances to re-use them for different hash-requests.
-type hasher struct {
-	sha256Pool sync.Pool
-}
-
-func newHasher() *hasher {
-	return &hasher{
-		sha256Pool: sync.Pool{
-			New: func() any {
-				return sha256.New()
-			},
-		},
-	}
-}
-
-// hashSha256 defines a function that returns the sha256 checksum of the data passed in.
-// https://github.com/ethereum/consensus-specs/blob/v0.9.3/specs/core/0_beacon-chain.md#hash
-func (h *hasher) hashSha256(data []byte) [32]byte {
-	hsr := h.sha256Pool.Get().(hash.Hash)
-	defer h.sha256Pool.Put(hsr)
-
-	hsr.Reset()
-
-	var b [32]byte
-
-	// The hash interface never returns an error, for that reason
-	// we are not handling the error below. For reference, it is
-	// stated here https://golang.org/pkg/hash/#Hash
-
-	// #nosec G104
-	hsr.Write(data)
-	hsr.Sum(b[:0])
-
-	return b
+	return networkconfig.IsAggregatorSelected
 }

--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -41,8 +41,8 @@ type AggregatorRunner struct {
 	ValCheck ssv.ValueChecker
 
 	// IsAggregator returns true if the signature is from the input validator. The committee
-	// count is provided as an argument rather than imported implementation from spec. Having
-	// committee count as an argument allows cheaper computation at run time.
+	// length is provided as an argument rather than imported implementation from spec. Having
+	// committee length as an argument allows cheaper computation at run time.
 	//
 	// Spec pseudocode definition:
 	//
@@ -52,7 +52,7 @@ type AggregatorRunner struct {
 	//	 return bytes_to_uint64(hash(slot_signature)[0:8]) % modulo == 0
 	//
 	// IsAggregator is an exported struct field, so it can be mocked out for easy testing.
-	IsAggregator func(targetAggregatorsPerCommittee uint64, committeeCount uint64, slotSig []byte) bool `json:"-"`
+	IsAggregator func(targetAggregatorsPerCommittee uint64, committeeLength uint64, slotSig []byte) bool `json:"-"`
 }
 
 var _ Runner = &AggregatorRunner{}
@@ -597,6 +597,6 @@ func constructVersionedSignedAggregateAndProof(aggregateAndProof spec.VersionedA
 // isAggregatorFn returns the default IsAggregator func, delegating to the shared
 // networkconfig.IsAggregatorSelected helper so pre/post-Boole selection stays bit-identical
 // with beacon/goclient's implementation.
-func isAggregatorFn() func(targetAggregatorsPerCommittee uint64, committeeCount uint64, slotSig []byte) bool {
+func isAggregatorFn() func(targetAggregatorsPerCommittee uint64, committeeLength uint64, slotSig []byte) bool {
 	return networkconfig.IsAggregatorSelected
 }

--- a/protocol/v2/ssv/runner/aggregator_test.go
+++ b/protocol/v2/ssv/runner/aggregator_test.go
@@ -13,18 +13,18 @@ import (
 // networkconfig.IsAggregatorSelected helper) is deterministic (in concurrent setting).
 func Test_isAggregatorFn(t *testing.T) {
 	const targetAggregatorsPerCommittee = 3
-	const committeeCount = 10
+	const committeeLength = 10
 
 	slotSig := []byte(randStringBytes(64))
 
 	isAggFn := isAggregatorFn()
-	sampleResult := isAggFn(targetAggregatorsPerCommittee, committeeCount, slotSig)
+	sampleResult := isAggFn(targetAggregatorsPerCommittee, committeeLength, slotSig)
 
 	const goRoutines = 1000
 	results := make(chan bool)
 	for range goRoutines {
 		go func() {
-			result := isAggFn(targetAggregatorsPerCommittee, committeeCount, slotSig)
+			result := isAggFn(targetAggregatorsPerCommittee, committeeLength, slotSig)
 			results <- result
 		}()
 	}
@@ -37,7 +37,7 @@ func Test_isAggregatorFn(t *testing.T) {
 // Test_isAggregatorFn_MatchesSharedHelper asserts the runner's default IsAggregator func is a
 // thin, bit-identical wrapper over the shared networkconfig.IsAggregatorSelected helper — the
 // same helper beacon/goclient.GoClient.IsAggregator delegates to — across a spread of committee
-// sizes (including committeeCount < target, which clamps modulo to 1).
+// sizes (including committeeLength < target, which clamps modulo to 1).
 func Test_isAggregatorFn_MatchesSharedHelper(t *testing.T) {
 	isAggFn := isAggregatorFn()
 
@@ -49,14 +49,14 @@ func Test_isAggregatorFn_MatchesSharedHelper(t *testing.T) {
 	}
 
 	targets := []uint64{1, 3, 16}
-	committeeCounts := []uint64{0, 1, 2, 10, 16, 128}
+	committeeLengths := []uint64{0, 1, 2, 10, 16, 128}
 
 	for _, target := range targets {
-		for _, committeeCount := range committeeCounts {
+		for _, committeeLength := range committeeLengths {
 			for _, slotSig := range slotSigs {
-				want := networkconfig.IsAggregatorSelected(target, committeeCount, slotSig)
-				got := isAggFn(target, committeeCount, slotSig)
-				require.Equal(t, want, got, "target=%d committeeCount=%d", target, committeeCount)
+				want := networkconfig.IsAggregatorSelected(target, committeeLength, slotSig)
+				got := isAggFn(target, committeeLength, slotSig)
+				require.Equal(t, want, got, "target=%d committeeLength=%d", target, committeeLength)
 			}
 		}
 	}

--- a/protocol/v2/ssv/runner/aggregator_test.go
+++ b/protocol/v2/ssv/runner/aggregator_test.go
@@ -5,9 +5,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/ssvlabs/ssv/networkconfig"
 )
 
-// Test_isAggregatorFn checks that isAggregatorFn is deterministic (in concurrent setting).
+// Test_isAggregatorFn checks that the default IsAggregator func (delegating to the shared
+// networkconfig.IsAggregatorSelected helper) is deterministic (in concurrent setting).
 func Test_isAggregatorFn(t *testing.T) {
 	const targetAggregatorsPerCommittee = 3
 	const committeeCount = 10
@@ -29,6 +32,42 @@ func Test_isAggregatorFn(t *testing.T) {
 		result := <-results
 		require.Equal(t, sampleResult, result)
 	}
+}
+
+// Test_isAggregatorFn_MatchesSharedHelper asserts the runner's default IsAggregator func is a
+// thin, bit-identical wrapper over the shared networkconfig.IsAggregatorSelected helper — the
+// same helper beacon/goclient.GoClient.IsAggregator delegates to — across a spread of committee
+// sizes (including committeeCount < target, which clamps modulo to 1).
+func Test_isAggregatorFn_MatchesSharedHelper(t *testing.T) {
+	isAggFn := isAggregatorFn()
+
+	slotSigs := [][]byte{
+		[]byte(randStringBytes(64)),
+		[]byte(randStringBytes(64)),
+		bytes64(0xAA),
+		bytes64(0xBB),
+	}
+
+	targets := []uint64{1, 3, 16}
+	committeeCounts := []uint64{0, 1, 2, 10, 16, 128}
+
+	for _, target := range targets {
+		for _, committeeCount := range committeeCounts {
+			for _, slotSig := range slotSigs {
+				want := networkconfig.IsAggregatorSelected(target, committeeCount, slotSig)
+				got := isAggFn(target, committeeCount, slotSig)
+				require.Equal(t, want, got, "target=%d committeeCount=%d", target, committeeCount)
+			}
+		}
+	}
+}
+
+func bytes64(b byte) []byte {
+	out := make([]byte, 64)
+	for i := range out {
+		out[i] = b
+	}
+	return out
 }
 
 func randStringBytes(n int) string {

--- a/protocol/v2/ssv/runner/aggregator_test.go
+++ b/protocol/v2/ssv/runner/aggregator_test.go
@@ -38,6 +38,11 @@ func Test_isAggregatorFn(t *testing.T) {
 // thin, bit-identical wrapper over the shared networkconfig.IsAggregatorSelected helper — the
 // same helper beacon/goclient.GoClient.IsAggregator delegates to — across a spread of committee
 // sizes (including committeeLength < target, which clamps modulo to 1).
+//
+// Note: today isAggregatorFn returns networkconfig.IsAggregatorSelected verbatim, so both sides
+// invoke the same function value and this assertion is trivially true. The test exists purely as
+// a regression guard: it fails the day the runner's default stops delegating to the shared helper
+// (or wraps it with anything that changes the result).
 func Test_isAggregatorFn_MatchesSharedHelper(t *testing.T) {
 	isAggFn := isAggregatorFn()
 


### PR DESCRIPTION
Item 5 of #2968. Pure refactor — zero behavioral change.

`beacon/goclient` (pre-fork path) and `protocol/v2/ssv/runner` (post-fork AggregatorCommittee path) each hand-rolled the same selection computation — sha256(slotSig), first 8 bytes little-endian, mod `max(1, committeeCount/targetAggregatorsPerCommittee)`, `== 0` — which must stay bit-identical or pre/post-Boole aggregator selection diverges (a consensus-level split on who aggregates).

Extract `networkconfig.IsAggregatorSelected` and delegate both sites. The runner keeps its mockable `IsAggregator` field (default now wraps the shared helper); the pooled hasher is dropped (no remaining users; selection runs once per aggregator duty, not per message).

Deep review notes (passed): byte-for-byte equivalence verified in both directions against the pre-change implementations (hash input, digest slicing, endianness, clamp-before-mod order, truncating division); with `AggregatorCommitteeRunner` already routing through `goclient.IsAggregator`, **every** selection path now converges on the single helper, making drift structurally impossible; test seam (`protocol/v2/ssv/testing/runner.go` overrides) intact; parity test covers the clamp-to-1 case.