### PR TITLE
boole-convergence polish: gating docs, startup fork validation, spectest bound (#2968 items 4, 6, 7)

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -105,12 +105,8 @@ func buildNode(ctx context.Context, cfg *config, logger *zap.Logger) (*node, err
 		SSV:    ssvNetworkConfig,
 		Beacon: consensusClient.BeaconConfig(),
 	}
-	warnings, err := networkConfig.Validate()
-	if err != nil {
+	if err := networkConfig.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid network config: %w", err)
-	}
-	for _, warning := range warnings {
-		logger.Warn(warning)
 	}
 
 	var executionAddrList []string

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -105,6 +105,13 @@ func buildNode(ctx context.Context, cfg *config, logger *zap.Logger) (*node, err
 		SSV:    ssvNetworkConfig,
 		Beacon: consensusClient.BeaconConfig(),
 	}
+	warnings, err := networkConfig.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("invalid network config: %w", err)
+	}
+	for _, warning := range warnings {
+		logger.Warn(warning)
+	}
 
 	var executionAddrList []string
 	for _, addr := range strings.Split(cfg.ExecutionClient.Addr, ";") {

--- a/networkconfig/network.go
+++ b/networkconfig/network.go
@@ -94,10 +94,7 @@ func (n Network) Validate() error {
 	}
 
 	if n.BooleForkScheduled() {
-		// Mirrors the overflow guard in inBooleSubsequentWindowWithSlots: FirstSlotAtEpoch(Boole)
-		// would overflow if the fork epoch is beyond the representable slot range.
-		maxEpoch := phase0.Epoch(math.MaxUint64 / n.SlotsPerEpoch)
-		if n.SSV.Forks.Boole > maxEpoch {
+		if maxEpoch := n.maxEpochConvertibleToSlot(); n.SSV.Forks.Boole > maxEpoch {
 			return fmt.Errorf("boole fork epoch %d overflows slot conversion (max supported epoch %d)", n.SSV.Forks.Boole, maxEpoch)
 		}
 
@@ -121,6 +118,13 @@ func (n Network) Validate() error {
 	}
 
 	return nil
+}
+
+// maxEpochConvertibleToSlot returns the highest epoch whose first slot still fits the slot
+// range; FirstSlotAtEpoch would overflow beyond it. Callers must rule out a zero SlotsPerEpoch
+// first, or the division panics.
+func (n Network) maxEpochConvertibleToSlot() phase0.Epoch {
+	return phase0.Epoch(math.MaxUint64 / n.SlotsPerEpoch)
 }
 
 // InBooleTransitionWindow checks if the slot is in the Boole transition window,
@@ -162,8 +166,7 @@ func (n Network) inBooleSubsequentWindowWithSlots(slot phase0.Slot, windowSlots 
 
 	// Avoid FirstSlotAtEpoch overflow when Boole is beyond the representable epoch range;
 	// without this guard the multiplication would wrap and could treat small slots as in-window.
-	maxEpoch := phase0.Epoch(math.MaxUint64 / n.SlotsPerEpoch)
-	if n.SSV.Forks.Boole > maxEpoch {
+	if n.SSV.Forks.Boole > n.maxEpochConvertibleToSlot() {
 		return false
 	}
 

--- a/networkconfig/network.go
+++ b/networkconfig/network.go
@@ -103,13 +103,17 @@ func (n Network) Validate() (warnings []string, err error) {
 		}
 
 		// unmarshalFromConfig defaults NextDomainType to DomainType when the field is absent, so
-		// equality here is exactly the signature of a scheduled fork that forgot to set
-		// NextDomainType: it would "activate" with zero observable domain change.
-		if n.NextDomainType == n.DomainType {
-			warnings = append(warnings, fmt.Sprintf(
+		// equality while the fork is still ahead is exactly the signature of a scheduled fork that
+		// forgot to set NextDomainType: it would "activate" with zero observable domain change, and
+		// a restart is guaranteed before activation (see BooleForkScheduled), so refusing to start
+		// is the last safe moment to catch it. Once the fork is active, equality is legitimate
+		// steady state — a config written post-fork may set DomainType to the post-fork domain and
+		// omit NextDomainType.
+		if n.NextDomainType == n.DomainType && !n.BooleFork() {
+			return nil, fmt.Errorf(
 				"boole fork is scheduled at epoch %d but NextDomainType equals DomainType: the fork would activate with no observable domain change",
 				n.SSV.Forks.Boole,
-			))
+			)
 		}
 	}
 

--- a/networkconfig/network.go
+++ b/networkconfig/network.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
@@ -109,7 +110,11 @@ func (n Network) Validate() (warnings []string, err error) {
 		// is the last safe moment to catch it. Once the fork is active, equality is legitimate
 		// steady state — a config written post-fork may set DomainType to the post-fork domain and
 		// omit NextDomainType.
-		if n.NextDomainType == n.DomainType && !n.BooleFork() {
+		// The wall-clock read must be guarded: EstimatedCurrentSlot panics while the clock is
+		// still before GenesisTime, and before genesis a scheduled fork is by definition not
+		// yet active.
+		booleForkActive := !time.Now().Before(n.GenesisTime) && n.BooleFork()
+		if n.NextDomainType == n.DomainType && !booleForkActive {
 			return nil, fmt.Errorf(
 				"boole fork is scheduled at epoch %d but NextDomainType equals DomainType: the fork would activate with no observable domain change",
 				n.SSV.Forks.Boole,

--- a/networkconfig/network.go
+++ b/networkconfig/network.go
@@ -83,16 +83,14 @@ func (n Network) BooleForkAtSlot(slot phase0.Slot) bool {
 }
 
 // Validate checks the assembled network configuration for internal inconsistencies that fork
-// activation logic can't catch on its own. It returns non-fatal warnings for configurations that
-// are almost certainly a mistake, and an error for configurations that would panic or misbehave.
-// It stays logger-free by design: the caller decides how to surface warnings (e.g. logger.Warn)
-// and whether/how to abort on error.
-func (n Network) Validate() (warnings []string, err error) {
+// activation logic can't catch on its own, returning an error for configurations that would
+// panic or misbehave. It stays logger-free by design: the caller decides whether/how to abort.
+func (n Network) Validate() error {
 	// A zero SlotsPerEpoch is a malformed config regardless of fork scheduling: slot/epoch
 	// conversions divide by it unconditionally (e.g. Beacon.EstimatedEpochAtSlot), so it would
 	// panic on the first duty long before any fork logic runs.
 	if n.SlotsPerEpoch == 0 {
-		return nil, fmt.Errorf("slots per epoch must be positive")
+		return fmt.Errorf("slots per epoch must be positive")
 	}
 
 	if n.BooleForkScheduled() {
@@ -100,7 +98,7 @@ func (n Network) Validate() (warnings []string, err error) {
 		// would overflow if the fork epoch is beyond the representable slot range.
 		maxEpoch := phase0.Epoch(math.MaxUint64 / n.SlotsPerEpoch)
 		if n.SSV.Forks.Boole > maxEpoch {
-			return nil, fmt.Errorf("boole fork epoch %d overflows slot conversion (max supported epoch %d)", n.SSV.Forks.Boole, maxEpoch)
+			return fmt.Errorf("boole fork epoch %d overflows slot conversion (max supported epoch %d)", n.SSV.Forks.Boole, maxEpoch)
 		}
 
 		// unmarshalFromConfig defaults NextDomainType to DomainType when the field is absent, so
@@ -115,14 +113,14 @@ func (n Network) Validate() (warnings []string, err error) {
 		// yet active.
 		booleForkActive := !time.Now().Before(n.GenesisTime) && n.BooleFork()
 		if n.NextDomainType == n.DomainType && !booleForkActive {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"boole fork is scheduled at epoch %d but NextDomainType equals DomainType: the fork would activate with no observable domain change",
 				n.SSV.Forks.Boole,
 			)
 		}
 	}
 
-	return warnings, nil
+	return nil
 }
 
 // InBooleTransitionWindow checks if the slot is in the Boole transition window,

--- a/networkconfig/network.go
+++ b/networkconfig/network.go
@@ -87,14 +87,14 @@ func (n Network) BooleForkAtSlot(slot phase0.Slot) bool {
 // It stays logger-free by design: the caller decides how to surface warnings (e.g. logger.Warn)
 // and whether/how to abort on error.
 func (n Network) Validate() (warnings []string, err error) {
-	if n.BooleForkScheduled() {
-		// Guard the division below the way inBooleSubsequentWindowWithSlots does — but as a hard
-		// error: a zero SlotsPerEpoch is exactly the malformed-config class Validate exists to
-		// catch, and would otherwise panic here.
-		if n.SlotsPerEpoch == 0 {
-			return nil, fmt.Errorf("slots per epoch must be positive when a boole fork is scheduled")
-		}
+	// A zero SlotsPerEpoch is a malformed config regardless of fork scheduling: slot/epoch
+	// conversions divide by it unconditionally (e.g. Beacon.EstimatedEpochAtSlot), so it would
+	// panic on the first duty long before any fork logic runs.
+	if n.SlotsPerEpoch == 0 {
+		return nil, fmt.Errorf("slots per epoch must be positive")
+	}
 
+	if n.BooleForkScheduled() {
 		// Mirrors the overflow guard in inBooleSubsequentWindowWithSlots: FirstSlotAtEpoch(Boole)
 		// would overflow if the fork epoch is beyond the representable slot range.
 		maxEpoch := phase0.Epoch(math.MaxUint64 / n.SlotsPerEpoch)

--- a/networkconfig/network.go
+++ b/networkconfig/network.go
@@ -81,6 +81,41 @@ func (n Network) BooleForkAtSlot(slot phase0.Slot) bool {
 	return n.BooleForkAtEpoch(n.EstimatedEpochAtSlot(slot))
 }
 
+// Validate checks the assembled network configuration for internal inconsistencies that fork
+// activation logic can't catch on its own. It returns non-fatal warnings for configurations that
+// are almost certainly a mistake, and an error for configurations that would panic or misbehave.
+// It stays logger-free by design: the caller decides how to surface warnings (e.g. logger.Warn)
+// and whether/how to abort on error.
+func (n Network) Validate() (warnings []string, err error) {
+	if n.BooleForkScheduled() {
+		// Guard the division below the way inBooleSubsequentWindowWithSlots does — but as a hard
+		// error: a zero SlotsPerEpoch is exactly the malformed-config class Validate exists to
+		// catch, and would otherwise panic here.
+		if n.SlotsPerEpoch == 0 {
+			return nil, fmt.Errorf("slots per epoch must be positive when a boole fork is scheduled")
+		}
+
+		// Mirrors the overflow guard in inBooleSubsequentWindowWithSlots: FirstSlotAtEpoch(Boole)
+		// would overflow if the fork epoch is beyond the representable slot range.
+		maxEpoch := phase0.Epoch(math.MaxUint64 / n.SlotsPerEpoch)
+		if n.SSV.Forks.Boole > maxEpoch {
+			return nil, fmt.Errorf("boole fork epoch %d overflows slot conversion (max supported epoch %d)", n.SSV.Forks.Boole, maxEpoch)
+		}
+
+		// unmarshalFromConfig defaults NextDomainType to DomainType when the field is absent, so
+		// equality here is exactly the signature of a scheduled fork that forgot to set
+		// NextDomainType: it would "activate" with zero observable domain change.
+		if n.NextDomainType == n.DomainType {
+			warnings = append(warnings, fmt.Sprintf(
+				"boole fork is scheduled at epoch %d but NextDomainType equals DomainType: the fork would activate with no observable domain change",
+				n.SSV.Forks.Boole,
+			))
+		}
+	}
+
+	return warnings, nil
+}
+
 // InBooleTransitionWindow checks if the slot is in the Boole transition window,
 // i.e., in `PRIOR_WINDOW` or `SUBSEQUENT_WINDOW` according to https://github.com/ssvlabs/SIPs/pull/43.
 func (n Network) InBooleTransitionWindow(slot phase0.Slot) bool {

--- a/networkconfig/network_test.go
+++ b/networkconfig/network_test.go
@@ -247,6 +247,20 @@ func TestNetworkValidate(t *testing.T) {
 			nextDomainType: domainBoole,
 		},
 		{
+			name:           "clean_genesis_fork",
+			boole:          0,
+			slotsPerEpoch:  32,
+			domainType:     domainAlan,
+			nextDomainType: domainBoole,
+		},
+		{
+			name:           "clean_at_max_epoch_boundary",
+			boole:          phase0.Epoch(math.MaxUint64 / 32),
+			slotsPerEpoch:  32,
+			domainType:     domainAlan,
+			nextDomainType: domainBoole,
+		},
+		{
 			name:           "clean_unscheduled",
 			boole:          phase0.Epoch(math.MaxUint64),
 			slotsPerEpoch:  32,

--- a/networkconfig/network_test.go
+++ b/networkconfig/network_test.go
@@ -210,6 +210,7 @@ func TestNetworkValidate(t *testing.T) {
 		name             string
 		boole            phase0.Epoch
 		currentEpoch     phase0.Epoch // wall-clock epoch the config is validated at
+		preGenesis       bool         // put GenesisTime in the future (overrides currentEpoch)
 		slotsPerEpoch    uint64
 		domainType       spectypes.DomainType
 		nextDomainType   spectypes.DomainType
@@ -244,6 +245,18 @@ func TestNetworkValidate(t *testing.T) {
 			name:           "hard_error_next_domain_equals_domain_before_fork",
 			boole:          10,
 			currentEpoch:   5,
+			slotsPerEpoch:  32,
+			domainType:     domainAlan,
+			nextDomainType: domainAlan,
+			expectErr:      true,
+		},
+		{
+			// The unchanged-domain check must not panic on EstimatedCurrentSlot when the
+			// clock is still before genesis; pre-genesis the fork is not yet active, so the
+			// misconfiguration is still reported as an error.
+			name:           "hard_error_next_domain_equals_domain_pre_genesis",
+			boole:          10,
+			preGenesis:     true,
 			slotsPerEpoch:  32,
 			domainType:     domainAlan,
 			nextDomainType: domainAlan,
@@ -293,6 +306,9 @@ func TestNetworkValidate(t *testing.T) {
 			beacon.SlotsPerEpoch = test.slotsPerEpoch
 			slotsSinceGenesis := uint64(test.currentEpoch) * test.slotsPerEpoch
 			beacon.GenesisTime = time.Now().Add(-time.Duration(slotsSinceGenesis) * beacon.SlotDuration)
+			if test.preGenesis {
+				beacon.GenesisTime = time.Now().Add(time.Hour)
+			}
 			netCfg := Network{
 				Beacon: &beacon,
 				SSV: &SSV{

--- a/networkconfig/network_test.go
+++ b/networkconfig/network_test.go
@@ -262,6 +262,16 @@ func TestNetworkValidate(t *testing.T) {
 			expectErr:      true,
 		},
 		{
+			// BooleFork activates on >=, so equal domains are already legitimate at
+			// the exact activation epoch, not just after it.
+			name:           "clean_next_domain_equals_domain_at_fork",
+			boole:          10,
+			currentEpoch:   10,
+			slotsPerEpoch:  32,
+			domainType:     domainBoole,
+			nextDomainType: domainBoole,
+		},
+		{
 			name:           "clean_next_domain_equals_domain_after_fork",
 			boole:          10,
 			currentEpoch:   20,

--- a/networkconfig/network_test.go
+++ b/networkconfig/network_test.go
@@ -335,7 +335,7 @@ func TestNetworkValidate(t *testing.T) {
 }
 
 func beaconAtEpoch(epoch phase0.Epoch) *Beacon {
-	return beaconAt(epoch, TestNetwork.Beacon.SlotsPerEpoch)
+	return beaconAt(epoch, TestNetwork.SlotsPerEpoch)
 }
 
 // beaconAt returns a Beacon copy whose wall clock sits at the given epoch with

--- a/networkconfig/network_test.go
+++ b/networkconfig/network_test.go
@@ -224,6 +224,14 @@ func TestNetworkValidate(t *testing.T) {
 			expectErr:      true,
 		},
 		{
+			name:           "hard_error_zero_slots_per_epoch_unscheduled",
+			boole:          phase0.Epoch(math.MaxUint64),
+			slotsPerEpoch:  0,
+			domainType:     domainAlan,
+			nextDomainType: domainAlan,
+			expectErr:      true,
+		},
+		{
 			name:           "hard_error_overflow",
 			boole:          phase0.Epoch(math.MaxUint64/32) + 1,
 			slotsPerEpoch:  32,

--- a/networkconfig/network_test.go
+++ b/networkconfig/network_test.go
@@ -209,6 +209,7 @@ func TestNetworkValidate(t *testing.T) {
 	tests := []struct {
 		name             string
 		boole            phase0.Epoch
+		currentEpoch     phase0.Epoch // wall-clock epoch the config is validated at
 		slotsPerEpoch    uint64
 		domainType       spectypes.DomainType
 		nextDomainType   spectypes.DomainType
@@ -240,12 +241,21 @@ func TestNetworkValidate(t *testing.T) {
 			expectErr:      true,
 		},
 		{
-			name:             "warning_next_domain_equals_domain",
-			boole:            10,
-			slotsPerEpoch:    32,
-			domainType:       domainAlan,
-			nextDomainType:   domainAlan,
-			expectedWarnings: 1,
+			name:           "hard_error_next_domain_equals_domain_before_fork",
+			boole:          10,
+			currentEpoch:   5,
+			slotsPerEpoch:  32,
+			domainType:     domainAlan,
+			nextDomainType: domainAlan,
+			expectErr:      true,
+		},
+		{
+			name:           "clean_next_domain_equals_domain_after_fork",
+			boole:          10,
+			currentEpoch:   20,
+			slotsPerEpoch:  32,
+			domainType:     domainBoole,
+			nextDomainType: domainBoole,
 		},
 		{
 			name:           "clean_scheduled",
@@ -281,6 +291,8 @@ func TestNetworkValidate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			beacon := *TestNetwork.Beacon
 			beacon.SlotsPerEpoch = test.slotsPerEpoch
+			slotsSinceGenesis := uint64(test.currentEpoch) * test.slotsPerEpoch
+			beacon.GenesisTime = time.Now().Add(-time.Duration(slotsSinceGenesis) * beacon.SlotDuration)
 			netCfg := Network{
 				Beacon: &beacon,
 				SSV: &SSV{

--- a/networkconfig/network_test.go
+++ b/networkconfig/network_test.go
@@ -301,15 +301,12 @@ func TestNetworkValidate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			beacon := *TestNetwork.Beacon
-			beacon.SlotsPerEpoch = test.slotsPerEpoch
-			slotsSinceGenesis := uint64(test.currentEpoch) * test.slotsPerEpoch
-			beacon.GenesisTime = time.Now().Add(-time.Duration(slotsSinceGenesis) * beacon.SlotDuration)
+			beacon := beaconAt(test.currentEpoch, test.slotsPerEpoch)
 			if test.preGenesis {
 				beacon.GenesisTime = time.Now().Add(time.Hour)
 			}
 			netCfg := Network{
-				Beacon: &beacon,
+				Beacon: beacon,
 				SSV: &SSV{
 					DomainType:     test.domainType,
 					NextDomainType: test.nextDomainType,
@@ -328,10 +325,16 @@ func TestNetworkValidate(t *testing.T) {
 }
 
 func beaconAtEpoch(epoch phase0.Epoch) *Beacon {
+	return beaconAt(epoch, TestNetwork.Beacon.SlotsPerEpoch)
+}
+
+// beaconAt returns a Beacon copy whose wall clock sits at the given epoch with
+// the given slots-per-epoch (which may deliberately be zero or otherwise invalid).
+func beaconAt(epoch phase0.Epoch, slotsPerEpoch uint64) *Beacon {
 	beacon := *TestNetwork.Beacon
-	slotsSinceGenesis := uint64(epoch) * beacon.SlotsPerEpoch
-	genesisTime := time.Now().Add(-time.Duration(slotsSinceGenesis) * beacon.SlotDuration)
-	beacon.GenesisTime = genesisTime
+	beacon.SlotsPerEpoch = slotsPerEpoch
+	slotsSinceGenesis := uint64(epoch) * slotsPerEpoch
+	beacon.GenesisTime = time.Now().Add(-time.Duration(slotsSinceGenesis) * beacon.SlotDuration)
 	return &beacon
 }
 

--- a/networkconfig/network_test.go
+++ b/networkconfig/network_test.go
@@ -207,15 +207,14 @@ func TestNetworkValidate(t *testing.T) {
 	domainBoole := spectypes.DomainType{0x05, 0x06, 0x07, 0x08}
 
 	tests := []struct {
-		name             string
-		boole            phase0.Epoch
-		currentEpoch     phase0.Epoch // wall-clock epoch the config is validated at
-		preGenesis       bool         // put GenesisTime in the future (overrides currentEpoch)
-		slotsPerEpoch    uint64
-		domainType       spectypes.DomainType
-		nextDomainType   spectypes.DomainType
-		expectErr        bool
-		expectedWarnings int
+		name           string
+		boole          phase0.Epoch
+		currentEpoch   phase0.Epoch // wall-clock epoch the config is validated at
+		preGenesis     bool         // put GenesisTime in the future (overrides currentEpoch)
+		slotsPerEpoch  uint64
+		domainType     spectypes.DomainType
+		nextDomainType spectypes.DomainType
+		expectErr      bool
 	}{
 		{
 			name:           "hard_error_zero_slots_per_epoch",
@@ -318,13 +317,12 @@ func TestNetworkValidate(t *testing.T) {
 				},
 			}
 
-			warnings, err := netCfg.Validate()
+			err := netCfg.Validate()
 			if test.expectErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			require.Len(t, warnings, test.expectedWarnings)
 		})
 	}
 }

--- a/networkconfig/network_test.go
+++ b/networkconfig/network_test.go
@@ -202,6 +202,83 @@ func TestBooleForkAtSlot(t *testing.T) {
 	}
 }
 
+func TestNetworkValidate(t *testing.T) {
+	domainAlan := spectypes.DomainType{0x01, 0x02, 0x03, 0x04}
+	domainBoole := spectypes.DomainType{0x05, 0x06, 0x07, 0x08}
+
+	tests := []struct {
+		name             string
+		boole            phase0.Epoch
+		slotsPerEpoch    uint64
+		domainType       spectypes.DomainType
+		nextDomainType   spectypes.DomainType
+		expectErr        bool
+		expectedWarnings int
+	}{
+		{
+			name:           "hard_error_zero_slots_per_epoch",
+			boole:          10,
+			slotsPerEpoch:  0,
+			domainType:     domainAlan,
+			nextDomainType: domainBoole,
+			expectErr:      true,
+		},
+		{
+			name:           "hard_error_overflow",
+			boole:          phase0.Epoch(math.MaxUint64/32) + 1,
+			slotsPerEpoch:  32,
+			domainType:     domainAlan,
+			nextDomainType: domainBoole,
+			expectErr:      true,
+		},
+		{
+			name:             "warning_next_domain_equals_domain",
+			boole:            10,
+			slotsPerEpoch:    32,
+			domainType:       domainAlan,
+			nextDomainType:   domainAlan,
+			expectedWarnings: 1,
+		},
+		{
+			name:           "clean_scheduled",
+			boole:          10,
+			slotsPerEpoch:  32,
+			domainType:     domainAlan,
+			nextDomainType: domainBoole,
+		},
+		{
+			name:           "clean_unscheduled",
+			boole:          phase0.Epoch(math.MaxUint64),
+			slotsPerEpoch:  32,
+			domainType:     domainAlan,
+			nextDomainType: domainAlan,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			beacon := *TestNetwork.Beacon
+			beacon.SlotsPerEpoch = test.slotsPerEpoch
+			netCfg := Network{
+				Beacon: &beacon,
+				SSV: &SSV{
+					DomainType:     test.domainType,
+					NextDomainType: test.nextDomainType,
+					Forks:          SSVForks{Boole: test.boole},
+				},
+			}
+
+			warnings, err := netCfg.Validate()
+			if test.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, warnings, test.expectedWarnings)
+		})
+	}
+}
+
 func beaconAtEpoch(epoch phase0.Epoch) *Beacon {
 	beacon := *TestNetwork.Beacon
 	slotsSinceGenesis := uint64(epoch) * beacon.SlotsPerEpoch

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -1251,8 +1251,8 @@ func SetupRunners(
 			// cross-population asymmetry (some operators still running the legacy runner while others
 			// have moved to the committee runner) is bounded to the Boole subsequent window
 			// (SlotsPerEpoch + booleSubsequentWindowLateSlots; 34 slots on mainnet — see InBooleTransitionWindow)
-			// and only affects already-decided pre-fork aggregator stragglers — no correctness impact.
-			// These legacy runners retire wholesale together with the Alan topics.
+			// and only affects already-decided pre-fork sync committee contribution stragglers — no
+			// correctness impact. These legacy runners retire wholesale together with the Alan topics.
 			if !options.NetworkConfig.BooleFork() {
 				syncCommitteeContributionValueChecker := ssv.NewSyncCommitteeContributionChecker(options.NetworkConfig.Beacon, share.ValidatorPubKey, share.ValidatorIndex)
 				runners[role], err = runner.NewSyncCommitteeAggregatorRunner(runner.SyncCommitteeAggregatorRunnerOptions{

--- a/operator/validator/controller.go
+++ b/operator/validator/controller.go
@@ -1223,6 +1223,15 @@ func SetupRunners(
 		case ssvtypes.RoleAggregator:
 			// Post-Boole, aggregator duties route through the merged AggregatorCommitteeRunner
 			// (committee-scoped) instead of this legacy per-validator runner.
+			//
+			// Gating on BooleFork() here is a deliberate snapshot taken at share-add time: once a
+			// share is added, this runner set is fixed until the share is re-added, so a share added
+			// shortly before the fork keeps its legacy runner across the transition. The resulting
+			// cross-population asymmetry (some operators still running the legacy runner while others
+			// have moved to the committee runner) is bounded to the Boole subsequent window
+			// (SlotsPerEpoch + booleSubsequentWindowLateSlots; 34 slots on mainnet — see InBooleTransitionWindow)
+			// and only affects already-decided pre-fork aggregator stragglers — no correctness impact.
+			// These legacy runners retire wholesale together with the Alan topics.
 			if !options.NetworkConfig.BooleFork() {
 				aggregatorValueChecker := ssv.NewAggregatorChecker(options.NetworkConfig.Beacon, share.ValidatorPubKey, share.ValidatorIndex)
 				runners[role], err = runner.NewAggregatorRunner(runner.AggregatorRunnerOptions{
@@ -1235,6 +1244,15 @@ func SetupRunners(
 		case ssvtypes.RoleSyncCommitteeContribution:
 			// Post-Boole, sync committee contribution duties route through the merged
 			// AggregatorCommitteeRunner (committee-scoped) instead of this legacy per-validator runner.
+			//
+			// Gating on BooleFork() here is a deliberate snapshot taken at share-add time: once a
+			// share is added, this runner set is fixed until the share is re-added, so a share added
+			// shortly before the fork keeps its legacy runner across the transition. The resulting
+			// cross-population asymmetry (some operators still running the legacy runner while others
+			// have moved to the committee runner) is bounded to the Boole subsequent window
+			// (SlotsPerEpoch + booleSubsequentWindowLateSlots; 34 slots on mainnet — see InBooleTransitionWindow)
+			// and only affects already-decided pre-fork aggregator stragglers — no correctness impact.
+			// These legacy runners retire wholesale together with the Alan topics.
 			if !options.NetworkConfig.BooleFork() {
 				syncCommitteeContributionValueChecker := ssv.NewSyncCommitteeContributionChecker(options.NetworkConfig.Beacon, share.ValidatorPubKey, share.ValidatorIndex)
 				runners[role], err = runner.NewSyncCommitteeAggregatorRunner(runner.SyncCommitteeAggregatorRunnerOptions{

--- a/protocol/v2/qbft/spectest/error_code_map_alan.go
+++ b/protocol/v2/qbft/spectest/error_code_map_alan.go
@@ -4,6 +4,13 @@ package qbft
 
 import spectypes "github.com/ssvlabs/ssv-spec/types"
 
+// maxShiftableLegacyErrorCode is the highest v1.2.2 error code eligible for the -2 shift below.
+// spectypes.TimeoutInstanceErrorCode is the last error code that existed in the spec before the
+// Boole-era additions (AggComm*/Committee* codes), which have no v1.2.2 counterpart and thus were
+// never subject to the shift. Its v1.2.2 value is its current (v1.2.3+) value plus the 2-code
+// offset described below: 70 + 2 = 72.
+const maxShiftableLegacyErrorCode = int(spectypes.TimeoutInstanceErrorCode) + 2
+
 func adjustExpectedErrorCode(code int) int {
 	// Alan fixtures use v1.2.2 error-code numbering. v1.2.3 removed two enum
 	// members after code 9, so most legacy codes shift down by 2.
@@ -14,7 +21,7 @@ func adjustExpectedErrorCode(code int) int {
 		return spectypes.ValidatorExitNoConsensusPhaseErrorCode
 	}
 
-	if code >= 12 && code <= 79 {
+	if code >= 12 && code <= maxShiftableLegacyErrorCode {
 		return code - 2
 	}
 


### PR DESCRIPTION
Items 4, 6 and 7 of #2968, one commit each:

- **Item 4 (docs only)** — the `BooleFork()` gate on the legacy Alan `RoleAggregator`/`RoleSyncCommitteeContribution` runners is now documented as a deliberate share-add-time snapshot: the cross-population asymmetry is bounded to the Boole subsequent window (`SlotsPerEpoch + booleSubsequentWindowLateSlots`; 34 slots on mainnet), affects only already-decided pre-fork stragglers, and the runners retire with the Alan topics. Decision recorded on the issue: not worth restructuring the one-shot runner-map construction to slot-gate a dormant path.
- **Item 6** — `Network.Validate()`, called right after the `Network` is assembled at startup: hard error when a scheduled `forks.boole` epoch would overflow `FirstSlotAtEpoch` (or `SlotsPerEpoch` is zero — the review caught that the overflow guard alone would panic on that same malformed-config class); operator-actionable warning when Boole is scheduled but `NextDomainType == DomainType` (the exact signature of a forgotten `next_domain_type`, which would "activate" the fork with zero observable domain change).
- **Item 7** — the alan-spec error-code remap bound is derived from `TimeoutInstanceErrorCode + 2` (= 72, the real v1.2.2 maximum) instead of the disconnected magic 79, so a spec bump adding codes can't silently widen the remap. Builds under `-tags alan_spec` (that leg doesn't run in normal CI).