### PR TITLE
Enable the SSV_TEST_BOOLE_FORK=post unit-test matrix (#2964)

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -51,6 +51,43 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  # Second matrix leg: the same unit suite with the global test config flipped post-Boole-fork,
+  # mirroring how spec-test.yml gained its spec-test-boole-post pass. No codecov upload — the
+  # primary ssv job owns the core-flagged coverage report.
+  ssv-boole-post:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          lfs: true
+
+      - name: Setup Go
+        id: setup-go
+        uses: actions/setup-go@v6.3.0
+        with:
+          go-version-file: go.mod
+          # Keep setup-go cache disabled and use explicit actions/cache below so keying/restore
+          # behavior is consistent across workflows.
+          cache: false
+
+      - name: Restore Go cache (ssv boole-post)
+        uses: actions/cache@v5.0.4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-unit-ssv-boole-post-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-unit-ssv-boole-post-
+            ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-unit-ssv-
+            ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-
+
+      - name: Run unit tests (post-Boole fork config)
+        run: make unit-test
+        env:
+          SSV_TEST_BOOLE_FORK: post
+
   ssvsigner:
     runs-on: ubuntu-latest
 

--- a/network/p2p/p2p_test.go
+++ b/network/p2p/p2p_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ssvlabs/ssv/network"
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/networkconfig"
+	"github.com/ssvlabs/ssv/protocol/v2/qbft"
 	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
 )
 
@@ -243,16 +244,19 @@ func generateCommitteeMsg(ks *spectestingutils.TestKeySet, round specqbft.Round)
 	return signedSSVMessage
 }
 
+// roundLeader must agree with the validator's leader check, which delegates to the fork-aware
+// qbft.Proposer — the post-fork variant adds an epoch offset that a hand-rolled pre-fork
+// formula misses, making every committee proposal reject with ErrSignerNotLeader on the
+// post-fork CI leg for ~3 of every 4 epochs.
 func roundLeader(ks *spectestingutils.TestKeySet, height specqbft.Height, round specqbft.Round) spectypes.OperatorID {
 	share := spectestingutils.TestingShare(ks, 1)
 
-	firstRoundIndex := 0
-	if height != specqbft.FirstHeight {
-		firstRoundIndex += int(height) % len(share.Committee)
+	committee := make([]spectypes.OperatorID, 0, len(share.Committee))
+	for _, member := range share.Committee {
+		committee = append(committee, member.Signer)
 	}
 
-	index := (firstRoundIndex + int(round) - int(specqbft.FirstRound)) % len(share.Committee)
-	return share.Committee[index].Signer
+	return qbft.Proposer(height, round, committee, networkconfig.TestNetwork)
 }
 
 func dummyMsg(t *testing.T, pkHex string, height int, role spectypes.RunnerRole) (spectypes.MessageID, *spectypes.SignedSSVMessage) {

--- a/network/p2p/p2p_test.go
+++ b/network/p2p/p2p_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	eth2apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -186,7 +187,9 @@ func generateValidatorMsg(ks *spectestingutils.TestKeySet, round specqbft.Round,
 
 	fullData := spectestingutils.TestingQBFTFullData
 
-	nonCommitteeIdentifier := spectypes.NewMsgID(netCfg.DomainType, ks.ValidatorPK.Serialize(), nonCommitteeRole)
+	// Derive the domain per-slot like production (p2p_setup.go DomainTypeAtSlot) so the
+	// fixture stays valid on both sides of the Boole fork (SSV_TEST_BOOLE_FORK matrix).
+	nonCommitteeIdentifier := spectypes.NewMsgID(netCfg.DomainTypeAtSlot(phase0.Slot(height)), ks.ValidatorPK.Serialize(), nonCommitteeRole)
 
 	qbftMessage := &specqbft.Message{
 		MsgType:    specqbft.ProposalMsgType,
@@ -220,7 +223,7 @@ func generateCommitteeMsg(ks *spectestingutils.TestKeySet, round specqbft.Round)
 	fullData := spectestingutils.TestingQBFTFullData
 
 	encodedCommitteeID := append(bytes.Repeat([]byte{0}, 16), committeeID[:]...)
-	committeeIdentifier := spectypes.NewMsgID(netCfg.DomainType, encodedCommitteeID, spectypes.RoleCommittee)
+	committeeIdentifier := spectypes.NewMsgID(netCfg.DomainTypeAtSlot(phase0.Slot(height)), encodedCommitteeID, spectypes.RoleCommittee)
 
 	qbftMessage := &specqbft.Message{
 		MsgType:    specqbft.ProposalMsgType,
@@ -260,7 +263,7 @@ func dummyMsg(t *testing.T, pkHex string, height int, role spectypes.RunnerRole)
 		committeeID := ssvtypes.ComputeCommitteeID([]spectypes.OperatorID{1, 2, 3, 4})
 		dutyExecutorID = append(bytes.Repeat([]byte{0}, 16), committeeID[:]...)
 	}
-	id := spectypes.NewMsgID(networkconfig.TestNetwork.DomainType, dutyExecutorID, role)
+	id := spectypes.NewMsgID(networkconfig.TestNetwork.DomainTypeAtSlot(phase0.Slot(height)), dutyExecutorID, role)
 
 	qbftMessage := &specqbft.Message{
 		MsgType:    specqbft.CommitMsgType,

--- a/network/p2p/p2p_trimming_test.go
+++ b/network/p2p/p2p_trimming_test.go
@@ -2,9 +2,12 @@ package p2pv1
 
 import (
 	"context"
+	"math"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -47,8 +50,14 @@ func (c *testTopicsController) Peers(topicName string) ([]peer.ID, error) {
 
 func (c *testTopicsController) Topics() []string {
 	// Mirror the real controller, which lists subscribed topics by their full pubsub name.
+	// Entries already carrying a full Boole-fork name (e.g. "/ssv/testnet/boole/11") pass
+	// through unchanged; bare subnet strings are wrapped in the Alan-style full name.
 	full := make([]string, len(c.topics))
 	for i, t := range c.topics {
+		if strings.Contains(t, "/") {
+			full[i] = t
+			continue
+		}
 		full[i] = commons.GetTopicFullName(t)
 	}
 	return full
@@ -233,6 +242,43 @@ func TestBuildPeerTrimScores_ComputesScoresForAllCandidates(t *testing.T) {
 	}, scores)
 }
 
+// TestBuildPeerTrimScores_ComputesScoresForAllCandidates_BooleTopics exercises the same scoring
+// logic as TestBuildPeerTrimScores_ComputesScoresForAllCandidates but against a post-fork-pinned
+// NetworkConfig and Boole-named topics ("/ssv/<network>/boole/<subnet>"), so the post leg of the
+// SSV_TEST_BOOLE_FORK matrix isn't a pure re-run of the pre-fork case.
+func TestBuildPeerTrimScores_ComputesScoresForAllCandidates_BooleTopics(t *testing.T) {
+	highValuePeer := peer.ID("high-value")
+	mediumValuePeer := peer.ID("medium-value")
+	lowValuePeer := peer.ID("low-value")
+
+	postForkCfg := trimTestNetCfg(0)
+	booleTopic := func(subnet uint64) string {
+		return commons.BooleTopic(postForkCfg.SSV.Name, subnet)
+	}
+
+	network := newTrimTestNetworkWithConfig(
+		postForkCfg,
+		nil,
+		&testTopicsController{
+			topics: []string{booleTopic(0), booleTopic(1), booleTopic(3)},
+			peersByTopic: map[string][]peer.ID{
+				"0": {highValuePeer},
+				"1": {highValuePeer, mediumValuePeer},
+				"3": {lowValuePeer},
+			},
+		},
+		nil,
+		subnetsFor(0, 1),
+	)
+
+	scores := network.buildPeerTrimScores([]peer.ID{highValuePeer, mediumValuePeer, lowValuePeer})
+	assert.Equal(t, map[peer.ID]float64{
+		highValuePeer:   16 + 4, // dead + solo
+		mediumValuePeer: 4,      // solo
+		lowValuePeer:    0,
+	}, scores)
+}
+
 func BenchmarkChoosePeersToTrim_150Peers(b *testing.B) {
 	ctx := context.Background()
 	localHost := newBenchmarkHost(b)
@@ -282,7 +328,29 @@ func singleTrimScore(network *p2pNetwork, peerID peer.ID) float64 {
 	return network.buildPeerTrimScores([]peer.ID{peerID})[peerID]
 }
 
+// trimTestNetCfg returns a per-test NetworkConfig copy (own SSV copy) with Forks.Boole pinned to
+// the given epoch, mirroring subscribeRandomsTestNetCfg / TestSubscribedSubnetsForCurrentEpoch's
+// pattern elsewhere in this package: never mutate the shared networkconfig.TestNetwork pointer.
+func trimTestNetCfg(booleEpoch phase0.Epoch) *networkconfig.Network {
+	cfg := *networkconfig.TestNetwork
+	beaconCfg := *networkconfig.TestNetwork.Beacon
+	ssvCfg := *networkconfig.TestNetwork.SSV
+	ssvCfg.Forks.Boole = booleEpoch
+	cfg.Beacon = &beaconCfg
+	cfg.SSV = &ssvCfg
+	return &cfg
+}
+
+// newTrimTestNetwork builds a p2pNetwork pinned to a pre-fork NetworkConfig copy, so these tests
+// exercise scoring against Alan-shaped topic fixtures regardless of SSV_TEST_BOOLE_FORK: the
+// Boole side of the scoring math (SubnetPeers.Score) is already covered fork-independently by
+// TestSubnetPeers_Score_BooleTransition and TestSubnetPeers_Score_MixedSubnets in
+// p2p_discovery_test.go.
 func newTrimTestNetwork(host host.Host, topicsCtrl topics.Controller, idx peers.Index, ownSubnets commons.Subnets) *p2pNetwork {
+	return newTrimTestNetworkWithConfig(trimTestNetCfg(phase0.Epoch(math.MaxUint64)), host, topicsCtrl, idx, ownSubnets)
+}
+
+func newTrimTestNetworkWithConfig(cfg *networkconfig.Network, host host.Host, topicsCtrl topics.Controller, idx peers.Index, ownSubnets commons.Subnets) *p2pNetwork {
 	if idx == nil {
 		if host != nil {
 			idx = peers.NewPeersIndex(zap.NewNop(), host.Network(), nil, func(string) int { return 0 }, nil, peers.NewGossipScoreIndex())
@@ -310,7 +378,7 @@ func newTrimTestNetwork(host host.Host, topicsCtrl topics.Controller, idx peers.
 
 	n := &p2pNetwork{
 		logger:               zap.NewNop(),
-		cfg:                  &Config{NetworkConfig: networkconfig.TestNetwork},
+		cfg:                  &Config{NetworkConfig: cfg},
 		topicsCtrl:           topicsCtrl,
 		idx:                  idx,
 		persistentSubnets:    ownSubnets,

--- a/network/p2p/p2p_trimming_test.go
+++ b/network/p2p/p2p_trimming_test.go
@@ -52,6 +52,8 @@ func (c *testTopicsController) Topics() []string {
 	// Mirror the real controller, which lists subscribed topics by their full pubsub name.
 	// Entries already carrying a full Boole-fork name (e.g. "/ssv/testnet/boole/11") pass
 	// through unchanged; bare subnet strings are wrapped in the Alan-style full name.
+	// Only those two input shapes are supported: an already-wrapped Alan name (e.g.
+	// "ssv.v2.11") has no slash and would be wrapped again, yielding a mangled topic.
 	full := make([]string, len(c.topics))
 	for i, t := range c.topics {
 		if strings.Contains(t, "/") {

--- a/network/p2p/testutils.go
+++ b/network/p2p/testutils.go
@@ -204,7 +204,8 @@ func (ln *LocalNet) NewTestP2pNetwork(ctx context.Context, nodeIndex uint64, key
 	cfg := NewNetConfig(keys, ln.Bootnode, 0, 0, options.Nodes)
 	cfg.Ctx = ctx
 	cfg.MdnsDiscoveryTag = ln.mdnsTag
-	cfg.Subnets = "00000000000000000100000400000400" // calculated for topics 64, 90, 114; PAY ATTENTION for future test scenarios which use more than one eth-validator we need to make this field dynamically changing
+	testSubnets := fixedTestSubnets(options.Shares)
+	cfg.Subnets = testSubnets.StringHex() // PAY ATTENTION for future test scenarios which use more than one eth-validator we need to make this field dynamically changing
 	cfg.NodeStorage = nodeStorage
 	cfg.MessageValidator = validation.New(
 		networkconfig.TestNetwork,
@@ -290,6 +291,28 @@ func NewLocalNet(ctx context.Context, logger *zap.Logger, options LocalNetOption
 	ln.Nodes = nodes
 
 	return ln, nil
+}
+
+// fixedTestSubnets returns the persistent subnet set used by local test networks: two fixed
+// subnets (64, 90) unrelated to any share, plus - for every configured share's committee - both
+// its Alan-fork subnet (CommitteeID-hash based) and its Boole-fork subnet (lowest-operator-hash
+// based). persistentSubnets is a raw, fork-agnostic bit vector (see initCfg), so covering both
+// mappings here is what keeps the committee's subnet persistently subscribed on either side of
+// the Boole fork, rather than depending solely on the later Subscribe(vpk) path.
+func fixedTestSubnets(shares []*ssvtypes.SSVShare) p2pcommons.Subnets {
+	subnets := p2pcommons.ZeroSubnets
+	subnets.Set(64)
+	subnets.Set(90)
+	for _, share := range shares {
+		subnets.Set(p2pcommons.AlanCommitteeSubnet(share.CommitteeID()))
+
+		operators := make([]spectypes.OperatorID, 0, len(share.Committee))
+		for _, member := range share.Committee {
+			operators = append(operators, member.Signer)
+		}
+		subnets.Set(p2pcommons.BooleCommitteeSubnet(operators))
+	}
+	return subnets
 }
 
 // NewNetConfig creates a new config for tests

--- a/network/p2p/testutils.go
+++ b/network/p2p/testutils.go
@@ -213,6 +213,9 @@ func (ln *LocalNet) NewTestP2pNetwork(ctx context.Context, nodeIndex uint64, key
 		nodeStorage,
 		dutyStore,
 		signatureVerifier,
+		// Surface verdicts (rejecting/ignoring invalid message) in test output — validation
+		// defaults to a nop logger, which makes CI failures undiagnosable from logs.
+		validation.WithLogger(logger),
 	)
 	cfg.NetworkConfig = networkconfig.TestNetwork
 	if options.TotalValidators > 0 {
@@ -240,6 +243,7 @@ func (ln *LocalNet) NewTestP2pNetwork(ctx context.Context, nodeIndex uint64, key
 			dutyStore,
 			signatureVerifier,
 			validation.WithSelfAccept(selfPeerID, true),
+			validation.WithLogger(logger),
 		)
 	}
 

--- a/network/p2p/testutils.go
+++ b/network/p2p/testutils.go
@@ -205,7 +205,7 @@ func (ln *LocalNet) NewTestP2pNetwork(ctx context.Context, nodeIndex uint64, key
 	cfg.Ctx = ctx
 	cfg.MdnsDiscoveryTag = ln.mdnsTag
 	testSubnets := fixedTestSubnets(options.Shares)
-	cfg.Subnets = testSubnets.StringHex() // PAY ATTENTION for future test scenarios which use more than one eth-validator we need to make this field dynamically changing
+	cfg.Subnets = testSubnets.StringHex()
 	cfg.NodeStorage = nodeStorage
 	cfg.MessageValidator = validation.New(
 		networkconfig.TestNetwork,
@@ -298,7 +298,9 @@ func NewLocalNet(ctx context.Context, logger *zap.Logger, options LocalNetOption
 }
 
 // fixedTestSubnets returns the persistent subnet set used by local test networks: two fixed
-// subnets (64, 90) unrelated to any share, plus - for every configured share's committee - both
+// subnets (64, 90) unrelated to any share - bit positions carried over from the legacy fixture
+// constant this function replaced, kept so every node also stays subscribed to subnets with no
+// local committee - plus - for every configured share's committee - both
 // its Alan-fork subnet (CommitteeID-hash based) and its Boole-fork subnet (lowest-operator-hash
 // based). persistentSubnets is a raw, fork-agnostic bit vector (see initCfg), so covering both
 // mappings here is what keeps the committee's subnet persistently subscribed on either side of


### PR DESCRIPTION
Items 1–3 of #2964.

- **Fork-agnostic p2p fixtures** — `TestP2pNetwork_SubscribeBroadcast`'s fixtures built MsgIDs from the static `netCfg.DomainType`, which post-flip receivers reject (the LocalNet nodes run on the global `TestNetwork`, so under the flip they're post-fork on the Boole domain while the fixture carried Alan). The three fixture sites now derive the domain per-slot via `DomainTypeAtSlot`, exactly like production (`p2p_setup.go`). Chosen over pinning the test pre-fork: unlike the validation/topics pins, p2p has no separate post-fork subtest, so pinning would leave the matrix with zero post-fork p2p coverage.
- **Full-suite sweep** — all 112 packages were run locally under `SSV_TEST_BOOLE_FORK=post`: everything passes except `network/p2p`/`network/topics`, which hang **identically in default mode** locally (the known mdns env-hang, not a fork gap) and are verified by this new CI leg on Linux. Notably the spec-test packages (LFS fixtures present) also pass post-mode locally.
- **CI matrix leg** — new `ssv-boole-post` job in `unit-test.yml`, mirroring how `spec-test.yml` gained `spec-test-boole-post`: same job with `SSV_TEST_BOOLE_FORK: post`, its own cache key (falling back to the primary's), and **no codecov upload** (the primary job owns the core-flagged report; `make unit-test` already excludes spectest, so nothing double-runs).

Item 4 (the `RunSyncCommitteeAggProof` alan-spec port) is deliberately not included — it's a ~half-day non-mechanical port (the alan build predates the committee/aggregator-committee duty split); leaving it tracked on the issue.

Why this matters (from the issue): until this leg exists, the global-config flip path stays permanently unexercised in CI — exactly the gap that let the metadata-syncer fixture regress unnoticed.