### PR TITLE
network/discovery: stop undecodable packets from wedging discv5

### DIFF
--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -348,6 +348,13 @@ func (dvs *DiscV5Service) checkPeer(ctx context.Context, e PeerEvent) error {
 	return nil
 }
 
+// listenV5 is indirected so tests can wrap or fail listener creation to
+// exercise initDiscV5Listener's error-path cleanup; it returns the Listener
+// interface, not *discover.UDPv5, so a wrapper can be substituted.
+var listenV5 = func(conn discover.UDPConn, ln *enode.LocalNode, cfg discover.Config) (Listener, error) {
+	return discover.ListenV5(conn, ln, cfg)
+}
+
 // initDiscV5Listener creates a new listener and starts it
 func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) (err error) {
 	opts := discOpts.DiscV5Opts
@@ -414,7 +421,7 @@ func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) (err error) {
 		return err
 	}
 
-	dv5PostForkListener, err := discover.ListenV5(udpConn, localNode, *dv5PostForkCfg)
+	dv5PostForkListener, err := listenV5(udpConn, localNode, *dv5PostForkCfg)
 	if err != nil {
 		return fmt.Errorf("could not create discV5 listener: %w", err)
 	}
@@ -434,7 +441,7 @@ func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) (err error) {
 		return err
 	}
 
-	dv5PreForkListener, err := discover.ListenV5(sharedConn, localNode, *dv5PreForkCfg)
+	dv5PreForkListener, err := listenV5(sharedConn, localNode, *dv5PreForkCfg)
 	if err != nil {
 		return fmt.Errorf("could not create discV5 pre-fork listener: %w", err)
 	}

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -363,6 +363,16 @@ func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) (err error) {
 	}
 	dvs.conn = udpConn
 
+	// Registered before anything else can fail, so every error path below
+	// releases the socket. Runs last of the deferred cleanups, by which point a
+	// listener may already have closed it.
+	defer func() {
+		if err != nil {
+			_ = udpConn.Close()
+			dvs.conn = nil
+		}
+	}()
+
 	localNode, err := dvs.createLocalNode(discOpts, ipAddr)
 	if err != nil {
 		return fmt.Errorf("could not create local node: %w", err)
@@ -376,7 +386,7 @@ func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) (err error) {
 	}
 
 	// New discovery, with ProtocolID restriction, to be kept post-fork
-	unhandled := make(chan discover.ReadPacket, 100) // size taken from https://github.com/ethereum/go-ethereum/blob/v1.13.5/p2p/server.go#L551
+	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
 	sharedConn := NewSharedUDPConn(dvs.ctx, udpConn, unhandled)
 	dvs.sharedConn = sharedConn
 
@@ -396,8 +406,7 @@ func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) (err error) {
 		_ = sharedConn.Close() // never returns an error
 		close(unhandled)
 		sharedConn.WaitDrained()
-		_ = udpConn.Close() // no-op once the listener above has closed it
-		dvs.sharedConn, dvs.conn = nil, nil
+		dvs.sharedConn = nil
 	}()
 
 	dv5PostForkCfg, err := opts.DiscV5Cfg(dvs.logger, WithProtocolID(protocolID), WithUnhandled(unhandled))

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -111,6 +111,10 @@ func NewDiscV5Service(pctx context.Context, logger *zap.Logger, opts *Options) (
 		zap.Any("hostDNS", opts.HostDNS),
 	)
 	if err := dvs.initDiscV5Listener(opts); err != nil {
+		// initDiscV5Listener unwinds its own resources, but the context we
+		// derived above is ours to release on this failure path — the discarded
+		// service's Close (which would cancel it) never runs.
+		cancel()
 		return nil, err
 	}
 	return &dvs, nil
@@ -394,7 +398,7 @@ func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) (err error) {
 
 	// New discovery, with ProtocolID restriction, to be kept post-fork
 	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
-	sharedConn := NewSharedUDPConn(dvs.ctx, udpConn, unhandled)
+	sharedConn := NewSharedUDPConn(dvs.ctx, dvs.logger, udpConn, unhandled)
 	dvs.sharedConn = sharedConn
 
 	// Everything below can fail before dv5Listener is set, and the caller drops

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/discover"
@@ -80,6 +81,9 @@ type DiscV5Service struct {
 	subnets   commons.Subnets
 
 	publishLock chan struct{}
+
+	closeOnce sync.Once
+	closeErr  error
 }
 
 func NewDiscV5Service(pctx context.Context, logger *zap.Logger, opts *Options) (*DiscV5Service, error) {
@@ -112,21 +116,37 @@ func NewDiscV5Service(pctx context.Context, logger *zap.Logger, opts *Options) (
 	return &dvs, nil
 }
 
-// Close implements io.Closer
+// Close implements io.Closer. It is safe to call more than once; callers above
+// don't guard against that, and closing sharedConn.Unhandled twice would panic.
 func (dvs *DiscV5Service) Close() error {
+	dvs.closeOnce.Do(func() {
+		dvs.closeErr = dvs.close()
+	})
+	return dvs.closeErr
+}
+
+func (dvs *DiscV5Service) close() error {
 	if dvs.cancel != nil {
 		dvs.cancel()
 	}
-	if dvs.conn != nil {
-		if err := dvs.conn.Close(); err != nil {
-			return err
-		}
+	// Order matters. The post-fork listener produces into sharedConn.Unhandled,
+	// so it must be fully stopped before that channel is closed — closing it
+	// mid-send panics the producer. Stopping the listeners first is safe:
+	// SharedUDPConn.Close releases the pre-fork reader, and draining continues
+	// throughout so the post-fork listener cannot wedge on its way down.
+	if dvs.dv5Listener != nil {
+		dvs.dv5Listener.Close()
 	}
 	if dvs.sharedConn != nil {
 		close(dvs.sharedConn.Unhandled)
+		dvs.sharedConn.WaitDrained()
 	}
-	if dvs.dv5Listener != nil {
-		dvs.dv5Listener.Close()
+	if dvs.conn != nil {
+		// The post-fork listener owns this socket and closes it on shutdown, so
+		// finding it already closed is expected rather than an error.
+		if err := dvs.conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			return err
+		}
 	}
 	return nil
 }
@@ -357,7 +377,7 @@ func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) error {
 
 	// New discovery, with ProtocolID restriction, to be kept post-fork
 	unhandled := make(chan discover.ReadPacket, 100) // size taken from https://github.com/ethereum/go-ethereum/blob/v1.13.5/p2p/server.go#L551
-	sharedConn := &SharedUDPConn{udpConn, unhandled}
+	sharedConn := NewSharedUDPConn(dvs.ctx, udpConn, unhandled)
 	dvs.sharedConn = sharedConn
 
 	dv5PostForkCfg, err := opts.DiscV5Cfg(dvs.logger, WithProtocolID(protocolID), WithUnhandled(unhandled))

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -356,7 +356,13 @@ func (dvs *DiscV5Service) checkPeer(ctx context.Context, e PeerEvent) error {
 // exercise initDiscV5Listener's error-path cleanup; it returns the Listener
 // interface, not *discover.UDPv5, so a wrapper can be substituted.
 var listenV5 = func(conn discover.UDPConn, ln *enode.LocalNode, cfg discover.Config) (Listener, error) {
-	return discover.ListenV5(conn, ln, cfg)
+	// Return an untyped nil on error, never a (*discover.UDPv5)(nil) wrapped in
+	// the interface, so a nil check on the result is meaningful for any caller.
+	listener, err := discover.ListenV5(conn, ln, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return listener, nil
 }
 
 // initDiscV5Listener creates a new listener and starts it

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -120,8 +120,10 @@ func NewDiscV5Service(pctx context.Context, logger *zap.Logger, opts *Options) (
 	return &dvs, nil
 }
 
-// Close implements io.Closer. It is safe to call more than once; callers above
-// don't guard against that, and closing sharedConn.Unhandled twice would panic.
+// Close implements io.Closer and is idempotent: a repeat call would panic
+// re-closing sharedConn.Unhandled, so the guard lives here. The sole production
+// caller (p2pNetwork.Close) already closes once, but tests and any future caller
+// reach this directly.
 func (dvs *DiscV5Service) Close() error {
 	dvs.closeOnce.Do(func() {
 		dvs.closeErr = dvs.close()

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -349,7 +349,7 @@ func (dvs *DiscV5Service) checkPeer(ctx context.Context, e PeerEvent) error {
 }
 
 // initDiscV5Listener creates a new listener and starts it
-func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) error {
+func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) (err error) {
 	opts := discOpts.DiscV5Opts
 	if err := opts.Validate(); err != nil {
 		return fmt.Errorf("invalid opts: %w", err)
@@ -380,6 +380,26 @@ func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) error {
 	sharedConn := NewSharedUDPConn(dvs.ctx, udpConn, unhandled)
 	dvs.sharedConn = sharedConn
 
+	// Everything below can fail before dv5Listener is set, and the caller drops
+	// the half-built service without calling Close, so unwind here instead. The
+	// order mirrors Close: stop the producer first, since by the time the
+	// pre-fork listener is being built the post-fork one is already forwarding
+	// into unhandled, and closing that channel under a live producer panics.
+	var postForkListener Listener
+	defer func() {
+		if err == nil {
+			return
+		}
+		if postForkListener != nil {
+			postForkListener.Close() // also closes udpConn
+		}
+		_ = sharedConn.Close() // never returns an error
+		close(unhandled)
+		sharedConn.WaitDrained()
+		_ = udpConn.Close() // no-op once the listener above has closed it
+		dvs.sharedConn, dvs.conn = nil, nil
+	}()
+
 	dv5PostForkCfg, err := opts.DiscV5Cfg(dvs.logger, WithProtocolID(protocolID), WithUnhandled(unhandled))
 	if err != nil {
 		return err
@@ -389,6 +409,7 @@ func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) error {
 	if err != nil {
 		return fmt.Errorf("could not create discV5 listener: %w", err)
 	}
+	postForkListener = dv5PostForkListener
 
 	dvs.logger.Debug("started discv5 post-fork listener (UDP)",
 		fields.BindIP(bindIP),

--- a/network/discovery/forking_dv5_listener.go
+++ b/network/discovery/forking_dv5_listener.go
@@ -14,14 +14,13 @@ import (
 // forkingDV5Listener wraps a pre-fork and a post-fork listener and queries both
 // on every operation.
 //
-// The naming is historical. The pre-fork listener was meant to be dropped once
-// the protocol-ID fork completed, but #1774 removed that shutdown deliberately
-// and it has run permanently since. There is no fork check anywhere here, so
-// both listeners stay live for the lifetime of the service.
+// The naming is historical: the pre-fork listener was meant to be dropped after
+// the protocol-ID fork, but #1774 removed that shutdown, so it runs permanently.
+// No fork check remains; both listeners stay live for the service's lifetime.
 //
-// It still earns its keep: the pre-fork listener sets no protocol ID, so it is
-// the only way to reach nodes that predate the fork. That also makes it the
-// path by which unrelated discv5 traffic enters the node — see SharedUDPConn.
+// It still earns its keep: with no protocol ID set, the pre-fork listener is the
+// only way to reach nodes that predate the fork — and the path by which
+// unrelated discv5 traffic enters the node (see SharedUDPConn).
 type forkingDV5Listener struct {
 	logger           *zap.Logger
 	preForkListener  Listener
@@ -76,15 +75,10 @@ func (l *forkingDV5Listener) LocalNode() *enode.LocalNode {
 	return l.postForkListener.LocalNode()
 }
 
-// Closes both listeners
+// Close closes both listeners.
 func (l *forkingDV5Listener) Close() {
-	l.closePreForkListener()
-	l.postForkListener.Close()
-}
-
-// closePreForkListener ensures preForkListener is closed once
-func (l *forkingDV5Listener) closePreForkListener() {
 	l.preForkListener.Close()
+	l.postForkListener.Close()
 }
 
 // annotatedIterator wraps an enode.Iterator with metrics collection.

--- a/network/discovery/forking_dv5_listener.go
+++ b/network/discovery/forking_dv5_listener.go
@@ -11,9 +11,17 @@ import (
 	"go.uber.org/zap"
 )
 
-// forkingDV5Listener wraps a pre-fork and a post-fork listener.
-// Before the fork, it performs operations on both services.
-// After the fork, it performs operations only on the post-fork service.
+// forkingDV5Listener wraps a pre-fork and a post-fork listener and queries both
+// on every operation.
+//
+// The naming is historical. The pre-fork listener was meant to be dropped once
+// the protocol-ID fork completed, but #1774 removed that shutdown deliberately
+// and it has run permanently since. There is no fork check anywhere here, so
+// both listeners stay live for the lifetime of the service.
+//
+// It still earns its keep: the pre-fork listener sets no protocol ID, so it is
+// the only way to reach nodes that predate the fork. That also makes it the
+// path by which unrelated discv5 traffic enters the node — see SharedUDPConn.
 type forkingDV5Listener struct {
 	logger           *zap.Logger
 	preForkListener  Listener
@@ -30,16 +38,14 @@ func NewForkingDV5Listener(logger *zap.Logger, preFork, postFork Listener, itera
 	}
 }
 
-// Before the fork, returns the result of a Lookup in both pre and post-fork services.
-// After the fork, returns only the result from the post-fork service.
+// Lookup returns the combined result of a lookup in both listeners.
 func (l *forkingDV5Listener) Lookup(id enode.ID) []*enode.Node {
 	nodes := l.postForkListener.Lookup(id)
 	nodes = append(nodes, l.preForkListener.Lookup(id)...)
 	return nodes
 }
 
-// Before the fork, returns an iterator for both pre and post-fork services.
-// After the fork, returns only the iterator from the post-fork service.
+// RandomNodes returns an iterator that draws fairly from both listeners.
 func (l *forkingDV5Listener) RandomNodes() enode.Iterator {
 	fairMix := enode.NewFairMix(l.iteratorTimeout)
 	fairMix.AddSource(&annotatedIterator{l.postForkListener.RandomNodes(), "post"})
@@ -47,16 +53,15 @@ func (l *forkingDV5Listener) RandomNodes() enode.Iterator {
 	return fairMix
 }
 
-// Before the fork, returns all nodes from the pre and post-fork listeners.
-// After the fork, returns only the result from the post-fork service.
+// AllNodes returns the nodes held by both listeners.
 func (l *forkingDV5Listener) AllNodes() []*enode.Node {
 	enodes := l.postForkListener.AllNodes()
 	enodes = append(enodes, l.preForkListener.AllNodes()...)
 	return enodes
 }
 
-// Sends a ping in the post-fork service.
-// Before the fork, it also tries to ping with the pre-fork service in case of error.
+// Ping tries the post-fork listener first, falling back to the pre-fork one so
+// that nodes reachable only on the default protocol ID still answer.
 func (l *forkingDV5Listener) Ping(node *enode.Node) (*v5wire.Pong, error) {
 	pong, err := l.postForkListener.Ping(node)
 	if err != nil {

--- a/network/discovery/observability.go
+++ b/network/discovery/observability.go
@@ -59,7 +59,17 @@ var (
 			observability.InstrumentName(observabilityNamespace, "peers.accepted"),
 			metric.WithUnit("{peer}"),
 			metric.WithDescription("total number of peers accepted during discovery")))
+
+	unhandledPacketsDroppedCounter = metrics.New(
+		meter.Int64Counter(
+			observability.InstrumentName(observabilityNamespace, "unhandled_packets.dropped"),
+			metric.WithUnit("{packet}"),
+			metric.WithDescription("total number of packets forwarded to the pre-fork listener that were dropped because its buffer was full")))
 )
+
+func recordUnhandledPacketDropped(ctx context.Context) {
+	unhandledPacketsDroppedCounter.Add(ctx, 1)
+}
 
 func recordPeerSkipped(ctx context.Context, reason skipReason) {
 	peerRejectionsCounter.Add(ctx, 1, metric.WithAttributes(peerSkipReasonAttribute(reason)))

--- a/network/discovery/service_test.go
+++ b/network/discovery/service_test.go
@@ -53,6 +53,12 @@ func TestDiscV5Service_Close(t *testing.T) {
 
 	err := dvs.Close()
 	assert.NoError(t, err)
+
+	// Callers above don't guard against closing twice, and the second pass
+	// would panic closing sharedConn.Unhandled again.
+	assert.NotPanics(t, func() {
+		assert.NoError(t, dvs.Close())
+	})
 }
 
 func TestDiscV5Service_RegisterSubnets(t *testing.T) {

--- a/network/discovery/service_test.go
+++ b/network/discovery/service_test.go
@@ -54,8 +54,8 @@ func TestDiscV5Service_Close(t *testing.T) {
 	err := dvs.Close()
 	assert.NoError(t, err)
 
-	// Callers above don't guard against closing twice, and the second pass
-	// would panic closing sharedConn.Unhandled again.
+	// A repeat close would panic re-closing sharedConn.Unhandled; Close guards
+	// against that. The production caller closes once, but tests reach it directly.
 	assert.NotPanics(t, func() {
 		assert.NoError(t, dvs.Close())
 	})
@@ -103,7 +103,7 @@ func (p *producingListener) Close() {
 // above cannot catch, having no live producer.
 func TestDiscV5Service_CloseStopsProducerBeforeClosingUnhandled(t *testing.T) {
 	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
-	sharedConn := NewSharedUDPConn(context.Background(), zap.NewNop(), nil, unhandled)
+	sharedConn := NewSharedUDPConn(t.Context(), zap.NewNop(), nil, unhandled)
 	producer := newProducingListener(unhandled)
 
 	dvs := &DiscV5Service{

--- a/network/discovery/service_test.go
+++ b/network/discovery/service_test.go
@@ -61,6 +61,66 @@ func TestDiscV5Service_Close(t *testing.T) {
 	})
 }
 
+// producingListener stands in for the post-fork discv5 listener in a close-order
+// test: it forwards packets into unhandled until Close is called, and Close
+// blocks until that has stopped — the same guarantee go-ethereum's UDPv5.Close
+// gives (it joins its goroutines before returning). Only Close is exercised.
+type producingListener struct {
+	Listener
+	unhandled chan<- discover.ReadPacket
+	stop      chan struct{}
+	done      chan struct{}
+}
+
+func newProducingListener(unhandled chan<- discover.ReadPacket) *producingListener {
+	p := &producingListener{
+		unhandled: unhandled,
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	go func() {
+		defer close(p.done)
+		for {
+			select {
+			case <-p.stop:
+				return
+			case p.unhandled <- discover.ReadPacket{Data: []byte{0}}:
+			}
+		}
+	}()
+	return p
+}
+
+func (p *producingListener) Close() {
+	close(p.stop)
+	<-p.done
+}
+
+// TestDiscV5Service_CloseStopsProducerBeforeClosingUnhandled pins the shutdown
+// order: close() must stop the listeners (the producers into Unhandled) before
+// closing Unhandled. If it ever reverts to closing Unhandled first, the still-live
+// producer panics with "send on closed channel" — which the idempotency test
+// above cannot catch, having no live producer.
+func TestDiscV5Service_CloseStopsProducerBeforeClosingUnhandled(t *testing.T) {
+	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
+	sharedConn := NewSharedUDPConn(context.Background(), zap.NewNop(), nil, unhandled)
+	producer := newProducingListener(unhandled)
+
+	dvs := &DiscV5Service{
+		dv5Listener: producer,
+		sharedConn:  sharedConn,
+		cancel:      func() {},
+	}
+
+	// Let the producer get going so a wrong-order close would very likely catch
+	// it mid-send.
+	time.Sleep(20 * time.Millisecond)
+
+	assert.NotPanics(t, func() {
+		assert.NoError(t, dvs.Close())
+	})
+}
+
 func TestDiscV5Service_RegisterSubnets(t *testing.T) {
 	dvs := testingDiscovery(t)
 

--- a/network/discovery/shared_conn.go
+++ b/network/discovery/shared_conn.go
@@ -12,8 +12,8 @@ import (
 
 const (
 	// unhandledChanSize is the handoff capacity between go-ethereum's forwarding
-	// send and drain. It can stay small because drain is always receptive; the
-	// queue that actually absorbs bursts is unhandledBufferSize.
+	// send and drain. It stays small because drain is always receptive; bursts
+	// are absorbed by unhandledBufferSize instead.
 	// Size taken from https://github.com/ethereum/go-ethereum/blob/v1.13.5/p2p/server.go#L551
 	unhandledChanSize = 100
 
@@ -24,19 +24,18 @@ const (
 
 // SharedUDPConn implements a shared connection: writes go to the underlying
 // socket, and reads return the packets the primary listener could not decode
-// and forwarded to Unhandled, less any shed under load.
+// and forwarded to Unhandled, minus any dropped under load.
 // Originally copied from https://github.com/ethereum/go-ethereum/blob/v1.14.8/p2p/server.go#L435
 //
-// Unlike upstream, reads are served from an internal buffer filled by drain.
-// That decoupling is load-bearing: go-ethereum forwards undecodable packets to
-// Unhandled with a blocking send and no default case (v5_udp.go, handlePacket),
-// on the post-fork listener's dispatch goroutine — which re-arms its reader only
-// after handlePacket returns. Serving reads straight off Unhandled, as the
-// pre-fork listener does one packet per dispatch cycle, therefore let a burst of
-// undecodable packets (scan noise, stray discv4, a deliberate flood) stall the
-// post-fork listener until it stopped draining the real UDP socket and the
-// kernel began dropping valid discv5 traffic. drain always accepts and discards
-// on overflow, bounding and counting that back-pressure instead.
+// Unlike upstream, reads are served from an internal buffer filled by drain,
+// not from Unhandled directly. That decoupling is load-bearing: go-ethereum
+// forwards undecodable packets with a blocking send and no default case
+// (v5_udp.go, handlePacket) on the post-fork listener's dispatch goroutine,
+// which re-arms its socket read only after handlePacket returns. Serving reads
+// straight off Unhandled — one packet per dispatch cycle — let a burst of junk
+// (scan noise, stray discv4, a flood) stall that listener until it stopped
+// draining the socket, and the kernel dropped valid discv5 traffic. drain
+// always accepts, dropping and counting on overflow instead.
 type SharedUDPConn struct {
 	*net.UDPConn
 	Unhandled chan discover.ReadPacket
@@ -66,14 +65,13 @@ func NewSharedUDPConn(ctx context.Context, conn *net.UDPConn, unhandled chan dis
 }
 
 // drain moves packets from Unhandled into the internal buffer, discarding them
-// once it is full. It stays receptive for the whole lifetime of the producer so
-// the forwarding send in go-ethereum never blocks for longer than it takes to
-// hand the packet over.
+// when it is full. It stays receptive for the producer's whole lifetime, so
+// go-ethereum's forwarding send never blocks longer than the handoff.
 //
 // ctx carries the metric context only — it is deliberately not a stop signal.
 // Draining must outlive cancellation: DiscV5Service.Close cancels before it
-// joins the producer, so stopping here on ctx.Done would let the post-fork
-// listener wedge on a full channel, or panic sending to a closed one. drain
+// joins the producer, so stopping on ctx.Done here would let the post-fork
+// listener wedge on a full channel or panic sending to a closed one. drain
 // stops only when Unhandled is closed, which its owner does after that join.
 func (s *SharedUDPConn) drain(ctx context.Context) {
 	defer s.drained.Done()

--- a/network/discovery/shared_conn.go
+++ b/network/discovery/shared_conn.go
@@ -60,6 +60,12 @@ func NewSharedUDPConn(ctx context.Context, conn *net.UDPConn, unhandled chan dis
 // once it is full. It stays receptive for the whole lifetime of the producer so
 // the forwarding send in go-ethereum never blocks for longer than it takes to
 // hand the packet over.
+//
+// ctx carries the metric context only — it is deliberately not a stop signal.
+// Draining must outlive cancellation: DiscV5Service.Close cancels before it
+// joins the producer, so stopping here on ctx.Done would let the post-fork
+// listener wedge on a full channel, or panic sending to a closed one. drain
+// stops only when Unhandled is closed, which its owner does after that join.
 func (s *SharedUDPConn) drain(ctx context.Context) {
 	defer s.drained.Done()
 	for packet := range s.Unhandled {

--- a/network/discovery/shared_conn.go
+++ b/network/discovery/shared_conn.go
@@ -6,8 +6,10 @@ import (
 	"net/netip"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/discover"
+	"go.uber.org/zap"
 )
 
 const (
@@ -20,6 +22,10 @@ const (
 	// unhandledBufferSize bounds how many forwarded packets are held for the
 	// pre-fork listener before drain starts discarding them.
 	unhandledBufferSize = 1024
+
+	// dropWarnInterval rate-limits drain's "buffer full" warning so a sustained
+	// flood produces a periodic heartbeat rather than a line per dropped packet.
+	dropWarnInterval = time.Minute
 )
 
 // SharedUDPConn implements a shared connection: writes go to the underlying
@@ -35,16 +41,19 @@ const (
 // straight off Unhandled — one packet per dispatch cycle — let a burst of junk
 // (scan noise, stray discv4, a flood) stall that listener until it stopped
 // draining the socket, and the kernel dropped valid discv5 traffic. drain
-// always accepts, dropping and counting on overflow instead.
+// always accepts, evicting the oldest buffered packet on overflow — counted and
+// warned — so the freshest survives instead.
 type SharedUDPConn struct {
 	*net.UDPConn
 	Unhandled chan discover.ReadPacket
 
-	buffered   chan discover.ReadPacket
-	readerDone chan struct{}
-	closeOnce  sync.Once
-	drained    sync.WaitGroup
-	dropped    atomic.Uint64
+	logger       *zap.Logger
+	buffered     chan discover.ReadPacket
+	readerDone   chan struct{}
+	closeOnce    sync.Once
+	drained      sync.WaitGroup
+	dropped      atomic.Uint64
+	lastDropWarn time.Time // touched only by drain
 }
 
 // NewSharedUDPConn returns a SharedUDPConn and starts draining unhandled.
@@ -52,10 +61,11 @@ type SharedUDPConn struct {
 // Ownership of unhandled stays with the caller: drain runs until unhandled is
 // closed, which must not happen until the listener producing into it has fully
 // stopped. Closing it earlier panics that producer mid-send.
-func NewSharedUDPConn(ctx context.Context, conn *net.UDPConn, unhandled chan discover.ReadPacket) *SharedUDPConn {
+func NewSharedUDPConn(ctx context.Context, logger *zap.Logger, conn *net.UDPConn, unhandled chan discover.ReadPacket) *SharedUDPConn {
 	s := &SharedUDPConn{
 		UDPConn:    conn,
 		Unhandled:  unhandled,
+		logger:     logger,
 		buffered:   make(chan discover.ReadPacket, unhandledBufferSize),
 		readerDone: make(chan struct{}),
 	}
@@ -64,9 +74,10 @@ func NewSharedUDPConn(ctx context.Context, conn *net.UDPConn, unhandled chan dis
 	return s
 }
 
-// drain moves packets from Unhandled into the internal buffer, discarding them
-// when it is full. It stays receptive for the producer's whole lifetime, so
-// go-ethereum's forwarding send never blocks longer than the handoff.
+// drain moves packets from Unhandled into the internal buffer, evicting the
+// oldest to make room when it is full. It stays receptive for the producer's
+// whole lifetime, so go-ethereum's forwarding send never blocks longer than the
+// handoff.
 //
 // ctx carries the metric context only — it is deliberately not a stop signal.
 // Draining must outlive cancellation: DiscV5Service.Close cancels before it
@@ -76,13 +87,46 @@ func NewSharedUDPConn(ctx context.Context, conn *net.UDPConn, unhandled chan dis
 func (s *SharedUDPConn) drain(ctx context.Context) {
 	defer s.drained.Done()
 	for packet := range s.Unhandled {
+		if !s.bufferPacket(packet) {
+			continue
+		}
+		total := s.dropped.Add(1)
+		recordUnhandledPacketDropped(ctx)
+		s.warnDropping(total)
+	}
+}
+
+// bufferPacket enqueues packet for the reader. When the buffer is full it evicts
+// the oldest packet so the freshest one wins — a real ping response must not be
+// starved by a backlog of junk during a flood. It reports whether a packet was
+// dropped to make room.
+func (s *SharedUDPConn) bufferPacket(packet discover.ReadPacket) (dropped bool) {
+	for {
 		select {
 		case s.buffered <- packet:
+			return dropped
 		default:
-			s.dropped.Add(1)
-			recordUnhandledPacketDropped(ctx)
+		}
+		// Full: evict the oldest and retry. A concurrent read may free a slot
+		// first, in which case nothing is dropped.
+		select {
+		case <-s.buffered:
+			dropped = true
+		default:
 		}
 	}
+}
+
+// warnDropping emits a rate-limited warning while drain is shedding, so an
+// operator watching pre-fork discovery degrade has a log signal, not just the
+// drop counter. Called only from drain, so lastDropWarn needs no locking.
+func (s *SharedUDPConn) warnDropping(total uint64) {
+	if time.Since(s.lastDropWarn) < dropWarnInterval {
+		return
+	}
+	s.lastDropWarn = time.Now()
+	s.logger.Warn("discv5 unhandled-packet buffer full; dropping forwarded packets",
+		zap.Uint64("dropped_total", total))
 }
 
 // Dropped reports how many forwarded packets were discarded due to a full buffer.

--- a/network/discovery/shared_conn.go
+++ b/network/discovery/shared_conn.go
@@ -10,13 +10,22 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/discover"
 )
 
-// unhandledBufferSize bounds how many forwarded packets are held for the
-// pre-fork listener before drain starts discarding them.
-const unhandledBufferSize = 1024
+const (
+	// unhandledChanSize is the handoff capacity between go-ethereum's forwarding
+	// send and drain. It can stay small because drain is always receptive; the
+	// queue that actually absorbs bursts is unhandledBufferSize.
+	// Size taken from https://github.com/ethereum/go-ethereum/blob/v1.13.5/p2p/server.go#L551
+	unhandledChanSize = 100
 
-// SharedUDPConn implements a shared connection. Write sends messages to the underlying connection while read returns
-// messages that were found unprocessable and sent to the unhandled channel by the primary listener.
-// It's copied from https://github.com/ethereum/go-ethereum/blob/v1.14.8/p2p/server.go#L435
+	// unhandledBufferSize bounds how many forwarded packets are held for the
+	// pre-fork listener before drain starts discarding them.
+	unhandledBufferSize = 1024
+)
+
+// SharedUDPConn implements a shared connection: writes go to the underlying
+// socket, and reads return the packets the primary listener could not decode
+// and forwarded to Unhandled, less any shed under load.
+// Originally copied from https://github.com/ethereum/go-ethereum/blob/v1.14.8/p2p/server.go#L435
 //
 // Unlike upstream, reads are served from an internal buffer filled by drain.
 // That decoupling is load-bearing: go-ethereum forwards undecodable packets to

--- a/network/discovery/shared_conn.go
+++ b/network/discovery/shared_conn.go
@@ -16,7 +16,7 @@ const (
 	// unhandledChanSize is the handoff capacity between go-ethereum's forwarding
 	// send and drain. It stays small because drain is always receptive; bursts
 	// are absorbed by unhandledBufferSize instead.
-	// Size taken from https://github.com/ethereum/go-ethereum/blob/v1.13.5/p2p/server.go#L551
+	// Size taken from https://github.com/ethereum/go-ethereum/blob/v1.16.4/p2p/server.go#L465
 	unhandledChanSize = 100
 
 	// unhandledBufferSize bounds how many forwarded packets are held for the
@@ -31,7 +31,7 @@ const (
 // SharedUDPConn implements a shared connection: writes go to the underlying
 // socket, and reads return the packets the primary listener could not decode
 // and forwarded to Unhandled, minus any dropped under load.
-// Originally copied from https://github.com/ethereum/go-ethereum/blob/v1.14.8/p2p/server.go#L435
+// Adapted from go-ethereum's sharedUDPConn: https://github.com/ethereum/go-ethereum/blob/v1.16.4/p2p/server.go#L335
 //
 // Unlike upstream, reads are served from an internal buffer filled by drain,
 // not from Unhandled directly. That decoupling is load-bearing: go-ethereum

--- a/network/discovery/shared_conn.go
+++ b/network/discovery/shared_conn.go
@@ -1,33 +1,118 @@
 package discovery
 
 import (
-	"errors"
+	"context"
 	"net"
 	"net/netip"
+	"sync"
+	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/p2p/discover"
 )
 
+// unhandledBufferSize bounds how many forwarded packets are held for the
+// pre-fork listener before drain starts discarding them.
+const unhandledBufferSize = 1024
+
 // SharedUDPConn implements a shared connection. Write sends messages to the underlying connection while read returns
 // messages that were found unprocessable and sent to the unhandled channel by the primary listener.
 // It's copied from https://github.com/ethereum/go-ethereum/blob/v1.14.8/p2p/server.go#L435
+//
+// Unlike upstream, reads are served from an internal buffer filled by drain.
+// That decoupling is load-bearing: go-ethereum forwards undecodable packets to
+// Unhandled with a blocking send and no default case (v5_udp.go, handlePacket),
+// on the post-fork listener's dispatch goroutine — which re-arms its reader only
+// after handlePacket returns. Serving reads straight off Unhandled, as the
+// pre-fork listener does one packet per dispatch cycle, therefore let a burst of
+// undecodable packets (scan noise, stray discv4, a deliberate flood) stall the
+// post-fork listener until it stopped draining the real UDP socket and the
+// kernel began dropping valid discv5 traffic. drain always accepts and discards
+// on overflow, bounding and counting that back-pressure instead.
 type SharedUDPConn struct {
 	*net.UDPConn
 	Unhandled chan discover.ReadPacket
+
+	buffered   chan discover.ReadPacket
+	readerDone chan struct{}
+	closeOnce  sync.Once
+	drained    sync.WaitGroup
+	dropped    atomic.Uint64
+}
+
+// NewSharedUDPConn returns a SharedUDPConn and starts draining unhandled.
+//
+// Ownership of unhandled stays with the caller: drain runs until unhandled is
+// closed, which must not happen until the listener producing into it has fully
+// stopped. Closing it earlier panics that producer mid-send.
+func NewSharedUDPConn(ctx context.Context, conn *net.UDPConn, unhandled chan discover.ReadPacket) *SharedUDPConn {
+	s := &SharedUDPConn{
+		UDPConn:    conn,
+		Unhandled:  unhandled,
+		buffered:   make(chan discover.ReadPacket, unhandledBufferSize),
+		readerDone: make(chan struct{}),
+	}
+	s.drained.Add(1)
+	go s.drain(ctx)
+	return s
+}
+
+// drain moves packets from Unhandled into the internal buffer, discarding them
+// once it is full. It stays receptive for the whole lifetime of the producer so
+// the forwarding send in go-ethereum never blocks for longer than it takes to
+// hand the packet over.
+func (s *SharedUDPConn) drain(ctx context.Context) {
+	defer s.drained.Done()
+	for packet := range s.Unhandled {
+		select {
+		case s.buffered <- packet:
+		default:
+			s.dropped.Add(1)
+			recordUnhandledPacketDropped(ctx)
+		}
+	}
+}
+
+// Dropped reports how many forwarded packets were discarded due to a full buffer.
+func (s *SharedUDPConn) Dropped() uint64 {
+	return s.dropped.Load()
 }
 
 // ReadFromUDPAddrPort implements discover.UDPConn
 func (s *SharedUDPConn) ReadFromUDPAddrPort(b []byte) (n int, addr netip.AddrPort, err error) {
-	packet, ok := <-s.Unhandled
-	if !ok {
-		return 0, netip.AddrPort{}, errors.New("connection was closed")
+	// Check for close on its own first: a single select over both cases picks
+	// randomly when both are ready, so a buffer that stays non-empty could
+	// starve the close signal and leave go-ethereum's readLoop running.
+	select {
+	case <-s.readerDone:
+		return 0, netip.AddrPort{}, net.ErrClosed
+	default:
 	}
-	l := min(len(packet.Data), len(b))
-	copy(b[:l], packet.Data[:l])
-	return l, packet.Addr, nil
+
+	select {
+	case <-s.readerDone:
+		return 0, netip.AddrPort{}, net.ErrClosed
+	case packet := <-s.buffered:
+		l := min(len(packet.Data), len(b))
+		copy(b[:l], packet.Data[:l])
+		return l, packet.Addr, nil
+	}
 }
 
-// Close implements discover.UDPConn
+// Close implements discover.UDPConn.
+//
+// It releases the reader without touching the underlying socket, which is owned
+// by the post-fork listener, and without closing Unhandled, which that listener
+// is still writing to. Draining continues so the producer cannot wedge while it
+// shuts down.
 func (s *SharedUDPConn) Close() error {
+	s.closeOnce.Do(func() {
+		close(s.readerDone)
+	})
 	return nil
+}
+
+// WaitDrained blocks until drain has exited, which happens once the owner of
+// Unhandled closes it.
+func (s *SharedUDPConn) WaitDrained() {
+	s.drained.Wait()
 }

--- a/network/discovery/shared_conn.go
+++ b/network/discovery/shared_conn.go
@@ -42,7 +42,7 @@ const (
 // (scan noise, stray discv4, a flood) stall that listener until it stopped
 // draining the socket, and the kernel dropped valid discv5 traffic. drain
 // always accepts, evicting the oldest buffered packet on overflow — counted and
-// warned — so the freshest survives instead.
+// warned — so the newest is kept rather than dropped.
 type SharedUDPConn struct {
 	*net.UDPConn
 	Unhandled chan discover.ReadPacket
@@ -96,10 +96,16 @@ func (s *SharedUDPConn) drain(ctx context.Context) {
 	}
 }
 
-// bufferPacket enqueues packet for the reader. When the buffer is full it evicts
-// the oldest packet so the freshest one wins — a real ping response must not be
-// starved by a backlog of junk during a flood. It reports whether a packet was
-// dropped to make room.
+// bufferPacket enqueues packet for the reader, evicting the oldest to make room
+// when the buffer is full so the newcomer is kept rather than tail-dropped. It
+// reports whether a packet was dropped.
+//
+// This bounds staleness; it does not guarantee a fresh packet is read promptly.
+// Reads are FIFO (ReadFromUDPAddrPort), so a retained ping response can still sit
+// behind up to unhandledBufferSize-1 older packets, and under a sustained flood a
+// persistently-full buffer can outlast geth's V5RespTimeout regardless of depth.
+// The wedge fix is the non-blocking send, not this buffer; evicting the oldest
+// only makes overflow strictly no worse than dropping the newcomer.
 func (s *SharedUDPConn) bufferPacket(packet discover.ReadPacket) (dropped bool) {
 	for {
 		select {
@@ -107,8 +113,11 @@ func (s *SharedUDPConn) bufferPacket(packet discover.ReadPacket) (dropped bool) 
 			return dropped
 		default:
 		}
-		// Full: evict the oldest and retry. A concurrent read may free a slot
-		// first, in which case nothing is dropped.
+		// Full at the send: evict the oldest, then retry. The evict is
+		// unconditional while anything is buffered, so the newcomer displaces the
+		// oldest even if a concurrent read just freed a slot. dropped stays false
+		// only when the buffer was emptied meanwhile (evict's default fires) —
+		// not reachable under the flood this guards.
 		select {
 		case <-s.buffered:
 			dropped = true

--- a/network/discovery/shared_conn_test.go
+++ b/network/discovery/shared_conn_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func testPacket(b byte) discover.ReadPacket {
@@ -43,7 +44,7 @@ func forwardBlocking(unhandled chan discover.ReadPacket, n int, sent *atomic.Int
 // which halted the post-fork listener and stopped the UDP socket being drained.
 func TestSharedUDPConn_ForwardingNeverBlocks(t *testing.T) {
 	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
-	conn := NewSharedUDPConn(context.Background(), nil, unhandled)
+	conn := NewSharedUDPConn(context.Background(), zap.NewNop(), nil, unhandled)
 
 	// Well past unhandled's capacity and the internal buffer combined.
 	const total = unhandledChanSize + unhandledBufferSize + 5000
@@ -73,7 +74,7 @@ func TestSharedUDPConn_ForwardingNeverBlocks(t *testing.T) {
 // producer forwards is what the pre-fork listener reads.
 func TestSharedUDPConn_DeliversPacketsToReader(t *testing.T) {
 	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
-	conn := NewSharedUDPConn(context.Background(), nil, unhandled)
+	conn := NewSharedUDPConn(context.Background(), zap.NewNop(), nil, unhandled)
 	defer func() {
 		close(unhandled)
 		conn.WaitDrained()
@@ -98,7 +99,7 @@ func TestSharedUDPConn_DeliversPacketsToReader(t *testing.T) {
 // TestSharedUDPConn_TruncatesOversizedPacket pins the existing copy semantics.
 func TestSharedUDPConn_TruncatesOversizedPacket(t *testing.T) {
 	unhandled := make(chan discover.ReadPacket, 1)
-	conn := NewSharedUDPConn(context.Background(), nil, unhandled)
+	conn := NewSharedUDPConn(context.Background(), zap.NewNop(), nil, unhandled)
 	defer func() {
 		close(unhandled)
 		conn.WaitDrained()
@@ -120,7 +121,7 @@ func TestSharedUDPConn_TruncatesOversizedPacket(t *testing.T) {
 // listener shut down without closing Unhandled out from under its producer.
 func TestSharedUDPConn_CloseReleasesBlockedReader(t *testing.T) {
 	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
-	conn := NewSharedUDPConn(context.Background(), nil, unhandled)
+	conn := NewSharedUDPConn(context.Background(), zap.NewNop(), nil, unhandled)
 
 	readErr := make(chan error, 1)
 	go func() {
@@ -284,7 +285,7 @@ func TestInitDiscV5Listener_CleansUpOnError(t *testing.T) {
 // with "send on closed channel".
 func TestSharedUDPConn_DrainsWhileClosing(t *testing.T) {
 	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
-	conn := NewSharedUDPConn(context.Background(), nil, unhandled)
+	conn := NewSharedUDPConn(context.Background(), zap.NewNop(), nil, unhandled)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -312,4 +313,38 @@ func TestSharedUDPConn_DrainsWhileClosing(t *testing.T) {
 
 	close(unhandled)
 	conn.WaitDrained()
+}
+
+// TestSharedUDPConn_DropsOldestWhenFull verifies overflow evicts the oldest
+// buffered packet, so the freshest packets survive a flood — a real ping
+// response must not be starved by a stale backlog. Tail-dropping the newcomer
+// would keep the oldest instead and fail this test.
+func TestSharedUDPConn_DropsOldestWhenFull(t *testing.T) {
+	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
+	conn := NewSharedUDPConn(context.Background(), zap.NewNop(), nil, unhandled)
+
+	// Tag each packet with a unique port so we can tell which survived, and send
+	// more than the buffer holds. With no reader, drain fills the buffer and then
+	// evicts oldest-first.
+	const overflow = 50
+	const total = unhandledBufferSize + overflow
+	for i := 0; i < total; i++ {
+		unhandled <- discover.ReadPacket{
+			Data: []byte{0},
+			Addr: netip.AddrPortFrom(netip.MustParseAddr("1.2.3.4"), uint16(i)),
+		}
+	}
+	close(unhandled)
+	conn.WaitDrained()
+
+	require.EqualValues(t, overflow, conn.Dropped(), "the oldest `overflow` packets should have been dropped")
+
+	// The buffer should hold exactly the newest unhandledBufferSize packets, in
+	// order: ports overflow..total-1.
+	buf := make([]byte, 1500)
+	for want := overflow; want < total; want++ {
+		_, addr, err := conn.ReadFromUDPAddrPort(buf)
+		require.NoError(t, err)
+		require.EqualValues(t, want, addr.Port(), "freshest packets should survive, in order")
+	}
 }

--- a/network/discovery/shared_conn_test.go
+++ b/network/discovery/shared_conn_test.go
@@ -1,0 +1,180 @@
+package discovery
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/stretchr/testify/require"
+)
+
+func testPacket(b byte) discover.ReadPacket {
+	return discover.ReadPacket{
+		Data: []byte{b},
+		Addr: netip.MustParseAddrPort("1.2.3.4:30303"),
+	}
+}
+
+// forwardBlocking mimics how go-ethereum hands undecodable packets to the
+// pre-fork listener: a bare blocking send with no default case and no context
+// check (p2p/discover/v5_udp.go, handlePacket). It runs on the post-fork
+// listener's dispatch goroutine, so anything that blocks here stops that
+// listener from reading the real UDP socket.
+func forwardBlocking(unhandled chan discover.ReadPacket, n int, sent *atomic.Int64) {
+	for i := 0; i < n; i++ {
+		unhandled <- testPacket(byte(i))
+		sent.Add(1)
+	}
+}
+
+// TestSharedUDPConn_ForwardingNeverBlocks is the regression test for the wedge:
+// with no reader consuming at all, a producer must still be able to forward far
+// more packets than any buffer holds. Tying Unhandled directly to the pre-fork
+// listener's read path made this block once ~100 packets were in flight, which
+// halted the post-fork listener and stopped the UDP socket being drained.
+func TestSharedUDPConn_ForwardingNeverBlocks(t *testing.T) {
+	unhandled := make(chan discover.ReadPacket, 100)
+	conn := NewSharedUDPConn(context.Background(), nil, unhandled)
+
+	// Well past unhandled's capacity and the internal buffer combined.
+	const total = 100 + unhandledBufferSize + 5000
+
+	var sent atomic.Int64
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		forwardBlocking(unhandled, total, &sent)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("forwarding blocked after %d/%d packets: the post-fork listener "+
+			"would be stalled here and the UDP socket left undrained", sent.Load(), total)
+	}
+
+	require.EqualValues(t, total, sent.Load())
+	require.Positive(t, conn.Dropped(), "overflow should be dropped and counted, not blocked on")
+
+	close(unhandled)
+	conn.WaitDrained()
+}
+
+// TestSharedUDPConn_DeliversPacketsToReader covers the normal path: what the
+// producer forwards is what the pre-fork listener reads.
+func TestSharedUDPConn_DeliversPacketsToReader(t *testing.T) {
+	unhandled := make(chan discover.ReadPacket, 100)
+	conn := NewSharedUDPConn(context.Background(), nil, unhandled)
+	defer func() {
+		close(unhandled)
+		conn.WaitDrained()
+	}()
+
+	for i := 0; i < 10; i++ {
+		unhandled <- testPacket(byte(i))
+	}
+
+	buf := make([]byte, 1500)
+	for i := 0; i < 10; i++ {
+		n, addr, err := conn.ReadFromUDPAddrPort(buf)
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+		require.EqualValues(t, i, buf[0])
+		require.Equal(t, netip.MustParseAddrPort("1.2.3.4:30303"), addr)
+	}
+
+	require.Zero(t, conn.Dropped())
+}
+
+// TestSharedUDPConn_TruncatesOversizedPacket pins the existing copy semantics.
+func TestSharedUDPConn_TruncatesOversizedPacket(t *testing.T) {
+	unhandled := make(chan discover.ReadPacket, 1)
+	conn := NewSharedUDPConn(context.Background(), nil, unhandled)
+	defer func() {
+		close(unhandled)
+		conn.WaitDrained()
+	}()
+
+	unhandled <- discover.ReadPacket{
+		Data: []byte{1, 2, 3, 4, 5},
+		Addr: netip.MustParseAddrPort("1.2.3.4:30303"),
+	}
+
+	buf := make([]byte, 2)
+	n, _, err := conn.ReadFromUDPAddrPort(buf)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+	require.Equal(t, []byte{1, 2}, buf)
+}
+
+// TestSharedUDPConn_CloseReleasesBlockedReader is what lets the pre-fork
+// listener shut down without closing Unhandled out from under its producer.
+func TestSharedUDPConn_CloseReleasesBlockedReader(t *testing.T) {
+	unhandled := make(chan discover.ReadPacket, 100)
+	conn := NewSharedUDPConn(context.Background(), nil, unhandled)
+
+	readErr := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1500)
+		_, _, err := conn.ReadFromUDPAddrPort(buf)
+		readErr <- err
+	}()
+
+	// Let the reader park on the empty buffer.
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, conn.Close())
+
+	select {
+	case err := <-readErr:
+		// Must be a permanent error so go-ethereum's readLoop exits instead of retrying.
+		require.ErrorIs(t, err, net.ErrClosed)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not release the blocked reader; listener shutdown would hang")
+	}
+
+	require.NoError(t, conn.Close(), "Close must be idempotent")
+
+	close(unhandled)
+	conn.WaitDrained()
+}
+
+// TestSharedUDPConn_DrainsWhileClosing guards the shutdown ordering: the
+// producer keeps forwarding while the reader shuts down, and must not block or
+// panic. Previously Close() closed Unhandled, so an in-flight send panicked
+// with "send on closed channel".
+func TestSharedUDPConn_DrainsWhileClosing(t *testing.T) {
+	unhandled := make(chan discover.ReadPacket, 100)
+	conn := NewSharedUDPConn(context.Background(), nil, unhandled)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var sent atomic.Int64
+	go func() {
+		defer wg.Done()
+		forwardBlocking(unhandled, 5000, &sent)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, conn.Close())
+
+	waited := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waited)
+	}()
+
+	select {
+	case <-waited:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("producer blocked during shutdown after %d packets", sent.Load())
+	}
+	require.EqualValues(t, 5000, sent.Load())
+
+	close(unhandled)
+	conn.WaitDrained()
+}

--- a/network/discovery/shared_conn_test.go
+++ b/network/discovery/shared_conn_test.go
@@ -44,7 +44,7 @@ func forwardBlocking(unhandled chan discover.ReadPacket, n int, sent *atomic.Int
 // which halted the post-fork listener and stopped the UDP socket being drained.
 func TestSharedUDPConn_ForwardingNeverBlocks(t *testing.T) {
 	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
-	conn := NewSharedUDPConn(context.Background(), zap.NewNop(), nil, unhandled)
+	conn := NewSharedUDPConn(t.Context(), zap.NewNop(), nil, unhandled)
 
 	// Well past unhandled's capacity and the internal buffer combined.
 	const total = unhandledChanSize + unhandledBufferSize + 5000
@@ -70,11 +70,44 @@ func TestSharedUDPConn_ForwardingNeverBlocks(t *testing.T) {
 	conn.WaitDrained()
 }
 
+// TestSharedUDPConn_DrainsAfterCancel pins the invariant documented on drain:
+// ctx is a metric context, not a stop signal. DiscV5Service.Close cancels before
+// it joins the producer, so a drain that honoured cancellation would let the
+// post-fork listener park in its unescapable forwarding send — deadlocking
+// shutdown in UDPv5.Close's wg.Wait, not just stalling discovery. It deliberately
+// keeps context.Background(): the whole point is a ctx cancelled before the conn
+// is built, which t.Context() (cancelled only at cleanup) cannot express.
+func TestSharedUDPConn_DrainsAfterCancel(t *testing.T) {
+	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	conn := NewSharedUDPConn(ctx, zap.NewNop(), nil, unhandled)
+
+	const total = unhandledChanSize + unhandledBufferSize + 5000
+	var sent atomic.Int64
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		forwardBlocking(unhandled, total, &sent)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("forwarding blocked after %d/%d packets with a cancelled ctx: "+
+			"drain must outlive cancellation or Close deadlocks joining the producer",
+			sent.Load(), total)
+	}
+
+	close(unhandled)
+	conn.WaitDrained()
+}
+
 // TestSharedUDPConn_DeliversPacketsToReader covers the normal path: what the
 // producer forwards is what the pre-fork listener reads.
 func TestSharedUDPConn_DeliversPacketsToReader(t *testing.T) {
 	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
-	conn := NewSharedUDPConn(context.Background(), zap.NewNop(), nil, unhandled)
+	conn := NewSharedUDPConn(t.Context(), zap.NewNop(), nil, unhandled)
 	defer func() {
 		close(unhandled)
 		conn.WaitDrained()
@@ -99,7 +132,7 @@ func TestSharedUDPConn_DeliversPacketsToReader(t *testing.T) {
 // TestSharedUDPConn_TruncatesOversizedPacket pins the existing copy semantics.
 func TestSharedUDPConn_TruncatesOversizedPacket(t *testing.T) {
 	unhandled := make(chan discover.ReadPacket, 1)
-	conn := NewSharedUDPConn(context.Background(), zap.NewNop(), nil, unhandled)
+	conn := NewSharedUDPConn(t.Context(), zap.NewNop(), nil, unhandled)
 	defer func() {
 		close(unhandled)
 		conn.WaitDrained()
@@ -121,7 +154,7 @@ func TestSharedUDPConn_TruncatesOversizedPacket(t *testing.T) {
 // listener shut down without closing Unhandled out from under its producer.
 func TestSharedUDPConn_CloseReleasesBlockedReader(t *testing.T) {
 	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
-	conn := NewSharedUDPConn(context.Background(), zap.NewNop(), nil, unhandled)
+	conn := NewSharedUDPConn(t.Context(), zap.NewNop(), nil, unhandled)
 
 	readErr := make(chan error, 1)
 	go func() {
@@ -285,7 +318,7 @@ func TestInitDiscV5Listener_CleansUpOnError(t *testing.T) {
 // with "send on closed channel".
 func TestSharedUDPConn_DrainsWhileClosing(t *testing.T) {
 	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
-	conn := NewSharedUDPConn(context.Background(), zap.NewNop(), nil, unhandled)
+	conn := NewSharedUDPConn(t.Context(), zap.NewNop(), nil, unhandled)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -316,12 +349,11 @@ func TestSharedUDPConn_DrainsWhileClosing(t *testing.T) {
 }
 
 // TestSharedUDPConn_DropsOldestWhenFull verifies overflow evicts the oldest
-// buffered packet, so the freshest packets survive a flood — a real ping
-// response must not be starved by a stale backlog. Tail-dropping the newcomer
-// would keep the oldest instead and fail this test.
+// buffered packet, so the newest are the ones retained rather than tail-dropped.
+// Tail-dropping the newcomer would keep the oldest instead and fail this test.
 func TestSharedUDPConn_DropsOldestWhenFull(t *testing.T) {
 	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
-	conn := NewSharedUDPConn(context.Background(), zap.NewNop(), nil, unhandled)
+	conn := NewSharedUDPConn(t.Context(), zap.NewNop(), nil, unhandled)
 
 	// Tag each packet with a unique port so we can tell which survived, and send
 	// more than the buffer holds. With no reader, drain fills the buffer and then
@@ -345,6 +377,6 @@ func TestSharedUDPConn_DropsOldestWhenFull(t *testing.T) {
 	for want := overflow; want < total; want++ {
 		_, addr, err := conn.ReadFromUDPAddrPort(buf)
 		require.NoError(t, err)
-		require.EqualValues(t, want, addr.Port(), "freshest packets should survive, in order")
+		require.EqualValues(t, want, addr.Port(), "the newest packets should be retained, in order")
 	}
 }

--- a/network/discovery/shared_conn_test.go
+++ b/network/discovery/shared_conn_test.go
@@ -143,6 +143,54 @@ func TestSharedUDPConn_CloseReleasesBlockedReader(t *testing.T) {
 	conn.WaitDrained()
 }
 
+// TestInitDiscV5Listener_CleansUpOnError covers the half-built service: when
+// setup fails after the drain goroutine has started, the caller discards the
+// service without ever calling Close, so init has to unwind its own resources.
+func TestInitDiscV5Listener_CleansUpOnError(t *testing.T) {
+	opts := testingDiscoveryOptions(t, testNetConfig.SSV)
+	// A malformed bootnode fails ENR parsing in DiscV5Cfg, which is the first
+	// error return after the drain goroutine is running.
+	opts.DiscV5Opts.Bootnodes = []string{"enr:-not-a-valid-record"}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	dvs := &DiscV5Service{
+		logger:    testLogger,
+		ctx:       ctx,
+		cancel:    cancel,
+		ssvConfig: testNetConfig.SSV,
+		subnets:   opts.DiscV5Opts.Subnets,
+	}
+
+	// Reaching the assertions at all already proves drain exited: the cleanup
+	// closes Unhandled and waits for it, so a drain that never stopped would
+	// hang here instead of returning.
+	require.Error(t, dvs.initDiscV5Listener(opts))
+	require.Nil(t, dvs.sharedConn, "sharedConn should be released on the error path")
+	require.Nil(t, dvs.conn, "udp socket should be released on the error path")
+
+	// The socket is the resource that actually bites, so prove it was freed
+	// rather than trusting the nil-ing: rebinding the same port only succeeds
+	// if the failed attempt released it.
+	good := testingDiscoveryOptions(t, testNetConfig.SSV)
+	good.DiscV5Opts.Port = opts.DiscV5Opts.Port
+	good.DiscV5Opts.TCPPort = opts.DiscV5Opts.TCPPort
+
+	dvs2 := &DiscV5Service{
+		logger:    testLogger,
+		ctx:       ctx,
+		cancel:    cancel,
+		ssvConfig: testNetConfig.SSV,
+		subnets:   good.DiscV5Opts.Subnets,
+	}
+	require.NoError(t, dvs2.initDiscV5Listener(good), "port still held: the failed attempt leaked its socket")
+	t.Cleanup(func() {
+		dvs2.dv5Listener.Close()
+		close(dvs2.sharedConn.Unhandled)
+		dvs2.sharedConn.WaitDrained()
+	})
+}
+
 // TestSharedUDPConn_DrainsWhileClosing guards the shutdown ordering: the
 // producer keeps forwarding while the reader shuts down, and must not block or
 // panic. Previously Close() closed Unhandled, so an in-flight send panicked

--- a/network/discovery/shared_conn_test.go
+++ b/network/discovery/shared_conn_test.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/netip"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/stretchr/testify/require"
 )
 
@@ -145,6 +147,18 @@ func TestSharedUDPConn_CloseReleasesBlockedReader(t *testing.T) {
 	conn.WaitDrained()
 }
 
+// closeRecordingListener wraps a Listener and records whether Close was called,
+// so a test can assert that error-path cleanup tore the wrapped listener down.
+type closeRecordingListener struct {
+	Listener
+	closed *atomic.Bool
+}
+
+func (l closeRecordingListener) Close() {
+	l.closed.Store(true)
+	l.Listener.Close()
+}
+
 // TestInitDiscV5Listener_CleansUpOnError covers the half-built service: setup
 // can fail at several points after resources are live, and the caller discards
 // the service without ever calling Close, so init has to unwind its own.
@@ -163,6 +177,9 @@ func TestInitDiscV5Listener_CleansUpOnError(t *testing.T) {
 		name string
 		// break the options so init fails at a specific point
 		breakSetup func(t *testing.T, o *Options)
+		// or break listener creation itself, to fail after resources are live;
+		// returns an assertion to run once init has failed and unwound
+		breakListener func(t *testing.T) (assertCleanedUp func(t *testing.T))
 	}{
 		{
 			// Fails in DiscV5Cfg, once the drain goroutine is already running.
@@ -181,6 +198,43 @@ func TestInitDiscV5Listener_CleansUpOnError(t *testing.T) {
 				o.DiscV5Opts.StoragePath = filepath.Join(blocker, "enode")
 			},
 		},
+		{
+			// Fails creating the pre-fork listener while the post-fork one is
+			// already up, so cleanup must tear that listener (and its socket)
+			// down — we wrap it to assert it was actually closed.
+			//
+			// Swaps the package-level listenV5, so the test must stay non-parallel.
+			name: "pre-fork listener creation fails",
+			breakListener: func(t *testing.T) func(t *testing.T) {
+				var postForkClosed atomic.Bool
+				orig := listenV5
+				var calls int
+				listenV5 = func(conn discover.UDPConn, ln *enode.LocalNode, cfg discover.Config) (Listener, error) {
+					// init creates the post-fork listener first, then the
+					// pre-fork one; fail the pre-fork and observe the post-fork.
+					calls++
+					switch calls {
+					case 1:
+						lis, err := orig(conn, ln, cfg)
+						if err != nil {
+							return nil, err
+						}
+						return closeRecordingListener{Listener: lis, closed: &postForkClosed}, nil
+					case 2:
+						return nil, errors.New("forced pre-fork listener failure")
+					default:
+						// Later inits (the good rebind below) behave normally.
+						return orig(conn, ln, cfg)
+					}
+				}
+				t.Cleanup(func() { listenV5 = orig })
+
+				return func(t *testing.T) {
+					require.True(t, postForkClosed.Load(),
+						"cleanup must close the post-fork listener when the pre-fork listener fails")
+				}
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -189,7 +243,13 @@ func TestInitDiscV5Listener_CleansUpOnError(t *testing.T) {
 			defer cancel()
 
 			opts := testingDiscoveryOptions(t, testNetConfig.SSV)
-			tc.breakSetup(t, opts)
+			if tc.breakSetup != nil {
+				tc.breakSetup(t, opts)
+			}
+			var assertCleanedUp func(t *testing.T)
+			if tc.breakListener != nil {
+				assertCleanedUp = tc.breakListener(t)
+			}
 
 			dvs := newService(ctx, cancel, opts)
 			// Returning at all already proves drain exited where one was started:
@@ -198,6 +258,9 @@ func TestInitDiscV5Listener_CleansUpOnError(t *testing.T) {
 			require.Error(t, dvs.initDiscV5Listener(opts))
 			require.Nil(t, dvs.sharedConn, "sharedConn should be released on the error path")
 			require.Nil(t, dvs.conn, "udp socket should be released on the error path")
+			if assertCleanedUp != nil {
+				assertCleanedUp(t)
+			}
 
 			// The socket is the resource that actually bites, so prove it was
 			// freed rather than trusting the nil-ing: rebinding the same port
@@ -209,9 +272,7 @@ func TestInitDiscV5Listener_CleansUpOnError(t *testing.T) {
 			dvs2 := newService(ctx, cancel, good)
 			require.NoError(t, dvs2.initDiscV5Listener(good), "port still held: the failed attempt leaked its socket")
 			t.Cleanup(func() {
-				dvs2.dv5Listener.Close()
-				close(dvs2.sharedConn.Unhandled)
-				dvs2.sharedConn.WaitDrained()
+				require.NoError(t, dvs2.Close())
 			})
 		})
 	}

--- a/network/discovery/shared_conn_test.go
+++ b/network/discovery/shared_conn_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net"
 	"net/netip"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -35,14 +37,14 @@ func forwardBlocking(unhandled chan discover.ReadPacket, n int, sent *atomic.Int
 // TestSharedUDPConn_ForwardingNeverBlocks is the regression test for the wedge:
 // with no reader consuming at all, a producer must still be able to forward far
 // more packets than any buffer holds. Tying Unhandled directly to the pre-fork
-// listener's read path made this block once ~100 packets were in flight, which
-// halted the post-fork listener and stopped the UDP socket being drained.
+// listener's read path made this block at unhandledChanSize packets in flight,
+// which halted the post-fork listener and stopped the UDP socket being drained.
 func TestSharedUDPConn_ForwardingNeverBlocks(t *testing.T) {
-	unhandled := make(chan discover.ReadPacket, 100)
+	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
 	conn := NewSharedUDPConn(context.Background(), nil, unhandled)
 
 	// Well past unhandled's capacity and the internal buffer combined.
-	const total = 100 + unhandledBufferSize + 5000
+	const total = unhandledChanSize + unhandledBufferSize + 5000
 
 	var sent atomic.Int64
 	done := make(chan struct{})
@@ -68,7 +70,7 @@ func TestSharedUDPConn_ForwardingNeverBlocks(t *testing.T) {
 // TestSharedUDPConn_DeliversPacketsToReader covers the normal path: what the
 // producer forwards is what the pre-fork listener reads.
 func TestSharedUDPConn_DeliversPacketsToReader(t *testing.T) {
-	unhandled := make(chan discover.ReadPacket, 100)
+	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
 	conn := NewSharedUDPConn(context.Background(), nil, unhandled)
 	defer func() {
 		close(unhandled)
@@ -115,7 +117,7 @@ func TestSharedUDPConn_TruncatesOversizedPacket(t *testing.T) {
 // TestSharedUDPConn_CloseReleasesBlockedReader is what lets the pre-fork
 // listener shut down without closing Unhandled out from under its producer.
 func TestSharedUDPConn_CloseReleasesBlockedReader(t *testing.T) {
-	unhandled := make(chan discover.ReadPacket, 100)
+	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
 	conn := NewSharedUDPConn(context.Background(), nil, unhandled)
 
 	readErr := make(chan error, 1)
@@ -143,52 +145,76 @@ func TestSharedUDPConn_CloseReleasesBlockedReader(t *testing.T) {
 	conn.WaitDrained()
 }
 
-// TestInitDiscV5Listener_CleansUpOnError covers the half-built service: when
-// setup fails after the drain goroutine has started, the caller discards the
-// service without ever calling Close, so init has to unwind its own resources.
+// TestInitDiscV5Listener_CleansUpOnError covers the half-built service: setup
+// can fail at several points after resources are live, and the caller discards
+// the service without ever calling Close, so init has to unwind its own.
 func TestInitDiscV5Listener_CleansUpOnError(t *testing.T) {
-	opts := testingDiscoveryOptions(t, testNetConfig.SSV)
-	// A malformed bootnode fails ENR parsing in DiscV5Cfg, which is the first
-	// error return after the drain goroutine is running.
-	opts.DiscV5Opts.Bootnodes = []string{"enr:-not-a-valid-record"}
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	dvs := &DiscV5Service{
-		logger:    testLogger,
-		ctx:       ctx,
-		cancel:    cancel,
-		ssvConfig: testNetConfig.SSV,
-		subnets:   opts.DiscV5Opts.Subnets,
+	newService := func(ctx context.Context, cancel context.CancelFunc, opts *Options) *DiscV5Service {
+		return &DiscV5Service{
+			logger:    testLogger,
+			ctx:       ctx,
+			cancel:    cancel,
+			ssvConfig: testNetConfig.SSV,
+			subnets:   opts.DiscV5Opts.Subnets,
+		}
 	}
 
-	// Reaching the assertions at all already proves drain exited: the cleanup
-	// closes Unhandled and waits for it, so a drain that never stopped would
-	// hang here instead of returning.
-	require.Error(t, dvs.initDiscV5Listener(opts))
-	require.Nil(t, dvs.sharedConn, "sharedConn should be released on the error path")
-	require.Nil(t, dvs.conn, "udp socket should be released on the error path")
-
-	// The socket is the resource that actually bites, so prove it was freed
-	// rather than trusting the nil-ing: rebinding the same port only succeeds
-	// if the failed attempt released it.
-	good := testingDiscoveryOptions(t, testNetConfig.SSV)
-	good.DiscV5Opts.Port = opts.DiscV5Opts.Port
-	good.DiscV5Opts.TCPPort = opts.DiscV5Opts.TCPPort
-
-	dvs2 := &DiscV5Service{
-		logger:    testLogger,
-		ctx:       ctx,
-		cancel:    cancel,
-		ssvConfig: testNetConfig.SSV,
-		subnets:   good.DiscV5Opts.Subnets,
+	cases := []struct {
+		name string
+		// break the options so init fails at a specific point
+		breakSetup func(t *testing.T, o *Options)
+	}{
+		{
+			// Fails in DiscV5Cfg, once the drain goroutine is already running.
+			name: "malformed bootnode",
+			breakSetup: func(t *testing.T, o *Options) {
+				o.DiscV5Opts.Bootnodes = []string{"enr:-not-a-valid-record"}
+			},
+		},
+		{
+			// Fails in createLocalNode, after the socket is bound but before
+			// SharedUDPConn exists — so only the socket needs releasing.
+			name: "unusable storage path",
+			breakSetup: func(t *testing.T, o *Options) {
+				blocker := filepath.Join(t.TempDir(), "not-a-dir")
+				require.NoError(t, os.WriteFile(blocker, nil, 0o600))
+				o.DiscV5Opts.StoragePath = filepath.Join(blocker, "enode")
+			},
+		},
 	}
-	require.NoError(t, dvs2.initDiscV5Listener(good), "port still held: the failed attempt leaked its socket")
-	t.Cleanup(func() {
-		dvs2.dv5Listener.Close()
-		close(dvs2.sharedConn.Unhandled)
-		dvs2.sharedConn.WaitDrained()
-	})
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			opts := testingDiscoveryOptions(t, testNetConfig.SSV)
+			tc.breakSetup(t, opts)
+
+			dvs := newService(ctx, cancel, opts)
+			// Returning at all already proves drain exited where one was started:
+			// the cleanup closes Unhandled and waits on it, so a drain that never
+			// stopped would hang here.
+			require.Error(t, dvs.initDiscV5Listener(opts))
+			require.Nil(t, dvs.sharedConn, "sharedConn should be released on the error path")
+			require.Nil(t, dvs.conn, "udp socket should be released on the error path")
+
+			// The socket is the resource that actually bites, so prove it was
+			// freed rather than trusting the nil-ing: rebinding the same port
+			// only succeeds if the failed attempt released it.
+			good := testingDiscoveryOptions(t, testNetConfig.SSV)
+			good.DiscV5Opts.Port = opts.DiscV5Opts.Port
+			good.DiscV5Opts.TCPPort = opts.DiscV5Opts.TCPPort
+
+			dvs2 := newService(ctx, cancel, good)
+			require.NoError(t, dvs2.initDiscV5Listener(good), "port still held: the failed attempt leaked its socket")
+			t.Cleanup(func() {
+				dvs2.dv5Listener.Close()
+				close(dvs2.sharedConn.Unhandled)
+				dvs2.sharedConn.WaitDrained()
+			})
+		})
+	}
 }
 
 // TestSharedUDPConn_DrainsWhileClosing guards the shutdown ordering: the
@@ -196,7 +222,7 @@ func TestInitDiscV5Listener_CleansUpOnError(t *testing.T) {
 // panic. Previously Close() closed Unhandled, so an in-flight send panicked
 // with "send on closed channel".
 func TestSharedUDPConn_DrainsWhileClosing(t *testing.T) {
-	unhandled := make(chan discover.ReadPacket, 100)
+	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
 	conn := NewSharedUDPConn(context.Background(), nil, unhandled)
 
 	var wg sync.WaitGroup

--- a/network/discovery/shared_conn_test.go
+++ b/network/discovery/shared_conn_test.go
@@ -72,11 +72,11 @@ func TestSharedUDPConn_ForwardingNeverBlocks(t *testing.T) {
 
 // TestSharedUDPConn_DrainsAfterCancel pins the invariant documented on drain:
 // ctx is a metric context, not a stop signal. DiscV5Service.Close cancels before
-// it joins the producer, so a drain that honoured cancellation would let the
+// it joins the producer, so a drain that honored cancellation would let the
 // post-fork listener park in its unescapable forwarding send — deadlocking
 // shutdown in UDPv5.Close's wg.Wait, not just stalling discovery. It deliberately
-// keeps context.Background(): the whole point is a ctx cancelled before the conn
-// is built, which t.Context() (cancelled only at cleanup) cannot express.
+// keeps context.Background(): the whole point is a ctx canceled before the conn
+// is built, which t.Context() (canceled only at cleanup) cannot express.
 func TestSharedUDPConn_DrainsAfterCancel(t *testing.T) {
 	unhandled := make(chan discover.ReadPacket, unhandledChanSize)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -94,7 +94,7 @@ func TestSharedUDPConn_DrainsAfterCancel(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(10 * time.Second):
-		t.Fatalf("forwarding blocked after %d/%d packets with a cancelled ctx: "+
+		t.Fatalf("forwarding blocked after %d/%d packets with a canceled ctx: "+
 			"drain must outlive cancellation or Close deadlocks joining the producer",
 			sent.Load(), total)
 	}


### PR DESCRIPTION
## Problem

Undecodable discv5 packets could wedge discovery. go-ethereum's post-fork listener forwards packets it can't decode to an `Unhandled` channel with a **blocking send** (`p2p/discover/v5_udp.go`, `handlePacket`), on the same goroutine that drives its UDP reader. The old `SharedUDPConn` served the pre-fork listener's reads directly off that channel, so a burst of junk — scan noise, stray discv4, a deliberate flood — could fill it, block the send, and stall the post-fork listener, which then stopped draining the real socket and the kernel dropped valid discv5 traffic.

## Fix

`SharedUDPConn` now runs an always-receptive `drain` goroutine that moves packets from `Unhandled` into an internal buffer, dropping and counting on overflow instead of blocking. The forwarding send never blocks beyond the handoff, so the socket keeps draining under any load. Reads are served from the buffer.

- `unhandledChanSize` (100) — handoff channel; small because `drain` is always receptive.
- `unhandledBufferSize` (1024) — burst-absorption buffer; overflow is a counted drop, not a stall.

Shutdown is ordered to neither wedge nor panic: stop the producer, close `Unhandled`, `WaitDrained`, then close the socket. `Close` is idempotent (`sync.Once`) — a double close of `Unhandled` would otherwise panic.

## Changes

- `shared_conn.go` — `drain` + buffer, idempotent `Close`, `WaitDrained`, `Dropped`.
- `dv5_service.go` — ordered/idempotent `Close`; error-path cleanup in `initDiscV5Listener`; wire up `NewSharedUDPConn`.
- `observability.go` — new counter `ssv.p2p.discovery.unhandled_packets.dropped`.
- `forking_dv5_listener.go` — corrected stale fork comments (no behaviour change).
- `shared_conn_test.go` / `service_test.go` — regression + cleanup tests: wedge, drain-while-closing, blocked-reader release, init cleanup (rebinds the port to prove the socket was freed), double `Close`.

## Notes

- **`initDiscV5Listener` cleanup (review).** The drain goroutine started before four error returns that leave `dv5Listener` nil, so the caller dropped the half-built service without `Close` — leaking the goroutine/socket (and post-fork listener on the last two paths). Now unwound in `Close` order. Never accumulated in practice: `Setup()` failure hits `logger.Fatal`.
- **`drain`'s ctx is metric-only, by design.** `Close` cancels before joining the producer, so stopping `drain` on ctx would reintroduce the wedge/panic.
- **Buffer stays 1024; pre-fork listener stays.** Measured, not assumed — over 6h, `sum by (ssv_fork) (rate(ssv_p2p_discovery_iterations_total[6h]))`:

  | cluster | post | pre |
  |---|---|---|
  | production-ovh (mainnet + hoodi) | 121.2/s | **121.2/s** |
  | stage | 1060.1/s | 104.6/s |
  | production | 38.5/s | 0.04/s |

  The pre-fork listener is live with a populated routing table and is the only path to nodes on the default protocol ID, so removing it risks cutting them off. Caveat: `ssv.fork` is attributed only on the iterations counter, not `peers.accepted`, so the data can't yet show whether any *accepted* peer needed it — that attribution is what would make removal decidable.
