### PR TITLE
network/discovery: accept NextDomainType in checkPeer for cross-client compatibility

### DIFF
--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -16,6 +16,8 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/peers"
 	"github.com/ssvlabs/ssv/network/records"
@@ -266,19 +268,26 @@ func (dvs *DiscV5Service) checkPeer(ctx context.Context, e PeerEvent) error {
 		return newPeerSkipError(skipReasonNotSSV, errors.New("node is not an SSV node"))
 	}
 
-	// Get the peer's domain type, skipping if it mismatches ours.
-	// Discovery filtering intentionally stays on the static current domain: it's symmetric
-	// within a converged fleet, and real fork enforcement happens in the fork-aware handshake
-	// filter and per-slot message validation, not here.
+	// Get the peer's domain type, skipping unless it matches our current or next domain.
+	// We advertise the static current domain in our main ENR key, but fork-aware clients
+	// (e.g. Anchor) advertise the active domain, which becomes the next domain after a fork —
+	// so a strict match against the current domain would reject them forever. Real fork
+	// enforcement happens in the fork-aware handshake filter and per-slot message validation,
+	// not here.
 	peerDiscoveriesCounter.Add(ctx, 1)
 	nodeDomainType, err := records.GetDomainTypeEntry(e.Node.Record(), records.KeyDomainType)
 	if err != nil {
 		recordPeerSkipped(ctx, skipReasonInvalidDomainType)
 		return newPeerSkipError(skipReasonInvalidDomainType, fmt.Errorf("could not read domain type: %w", err))
 	}
-	if dvs.ssvConfig.DomainType != nodeDomainType {
+	// Only accept NextDomainType when it's set: config parsing defaults it to DomainType,
+	// but a zero value must not make us accept peers advertising an all-zero domain.
+	domainMatches := nodeDomainType == dvs.ssvConfig.DomainType ||
+		(dvs.ssvConfig.NextDomainType != (spectypes.DomainType{}) &&
+			nodeDomainType == dvs.ssvConfig.NextDomainType)
+	if !domainMatches {
 		recordPeerSkipped(ctx, skipReasonDomainTypeMismatch)
-		return newPeerSkipError(skipReasonDomainTypeMismatch, fmt.Errorf("domain type %x doesn't match %x", nodeDomainType, dvs.ssvConfig.DomainType))
+		return newPeerSkipError(skipReasonDomainTypeMismatch, fmt.Errorf("domain type %x matches neither %x nor %x", nodeDomainType, dvs.ssvConfig.DomainType, dvs.ssvConfig.NextDomainType))
 	}
 
 	// Get the peer's subnets, skipping if it has none.
@@ -493,8 +502,8 @@ func (dvs *DiscV5Service) PublishENR() {
 		return
 	}
 	// KeyNextDomainType carries the real upcoming domain (not the current one) so that
-	// fork-aware (boole-style) binaries and future dynamic domain flips can rely on it,
-	// even though our own peer filter only ever compares against the static current domain.
+	// fork-aware (boole-style) binaries and future dynamic domain flips can rely on it;
+	// our own discovery filter accepts peers advertising either the current or next domain.
 	err = records.SetDomainTypeEntry(dvs.dv5Listener.LocalNode(), records.KeyNextDomainType, dvs.ssvConfig.NextDomainType)
 	if err != nil {
 		dvs.logger.Error("could not set next domain type", zap.Error(err))

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -283,14 +283,14 @@ func (dvs *DiscV5Service) checkPeer(ctx context.Context, e PeerEvent) error {
 	// Only accept NextDomainType when it's set to a distinct value: config parsing defaults
 	// it to DomainType, and a zero value must not make us accept peers advertising an
 	// all-zero domain.
-	nextDomainAccepted := dvs.ssvConfig.NextDomainType != (spectypes.DomainType{}) &&
+	hasDistinctNextDomain := dvs.ssvConfig.NextDomainType != (spectypes.DomainType{}) &&
 		dvs.ssvConfig.NextDomainType != dvs.ssvConfig.DomainType
 	matchesDomain := nodeDomainType == dvs.ssvConfig.DomainType
-	matchesNextDomain := nextDomainAccepted && nodeDomainType == dvs.ssvConfig.NextDomainType
+	matchesNextDomain := hasDistinctNextDomain && nodeDomainType == dvs.ssvConfig.NextDomainType
 	if !matchesDomain && !matchesNextDomain {
 		recordPeerSkipped(ctx, skipReasonDomainTypeMismatch)
 		var err error
-		if nextDomainAccepted {
+		if hasDistinctNextDomain {
 			err = fmt.Errorf("domain type %x matches neither %x nor %x", nodeDomainType, dvs.ssvConfig.DomainType, dvs.ssvConfig.NextDomainType)
 		} else {
 			err = fmt.Errorf("domain type %x does not match %x", nodeDomainType, dvs.ssvConfig.DomainType)

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -289,9 +289,11 @@ func (dvs *DiscV5Service) checkPeer(ctx context.Context, e PeerEvent) error {
 	matchesNextDomain := nextDomainAccepted && nodeDomainType == dvs.ssvConfig.NextDomainType
 	if !matchesDomain && !matchesNextDomain {
 		recordPeerSkipped(ctx, skipReasonDomainTypeMismatch)
-		err := fmt.Errorf("domain type %x does not match %x", nodeDomainType, dvs.ssvConfig.DomainType)
+		var err error
 		if nextDomainAccepted {
 			err = fmt.Errorf("domain type %x matches neither %x nor %x", nodeDomainType, dvs.ssvConfig.DomainType, dvs.ssvConfig.NextDomainType)
+		} else {
+			err = fmt.Errorf("domain type %x does not match %x", nodeDomainType, dvs.ssvConfig.DomainType)
 		}
 		return newPeerSkipError(skipReasonDomainTypeMismatch, err)
 	}

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -280,14 +280,20 @@ func (dvs *DiscV5Service) checkPeer(ctx context.Context, e PeerEvent) error {
 		recordPeerSkipped(ctx, skipReasonInvalidDomainType)
 		return newPeerSkipError(skipReasonInvalidDomainType, fmt.Errorf("could not read domain type: %w", err))
 	}
-	// Only accept NextDomainType when it's set: config parsing defaults it to DomainType,
-	// but a zero value must not make us accept peers advertising an all-zero domain.
-	domainMatches := nodeDomainType == dvs.ssvConfig.DomainType ||
-		(dvs.ssvConfig.NextDomainType != (spectypes.DomainType{}) &&
-			nodeDomainType == dvs.ssvConfig.NextDomainType)
-	if !domainMatches {
+	// Only accept NextDomainType when it's set to a distinct value: config parsing defaults
+	// it to DomainType, and a zero value must not make us accept peers advertising an
+	// all-zero domain.
+	nextDomainAccepted := dvs.ssvConfig.NextDomainType != (spectypes.DomainType{}) &&
+		dvs.ssvConfig.NextDomainType != dvs.ssvConfig.DomainType
+	matchesDomain := nodeDomainType == dvs.ssvConfig.DomainType
+	matchesNextDomain := nextDomainAccepted && nodeDomainType == dvs.ssvConfig.NextDomainType
+	if !matchesDomain && !matchesNextDomain {
 		recordPeerSkipped(ctx, skipReasonDomainTypeMismatch)
-		return newPeerSkipError(skipReasonDomainTypeMismatch, fmt.Errorf("domain type %x matches neither %x nor %x", nodeDomainType, dvs.ssvConfig.DomainType, dvs.ssvConfig.NextDomainType))
+		err := fmt.Errorf("domain type %x does not match %x", nodeDomainType, dvs.ssvConfig.DomainType)
+		if nextDomainAccepted {
+			err = fmt.Errorf("domain type %x matches neither %x nor %x", nodeDomainType, dvs.ssvConfig.DomainType, dvs.ssvConfig.NextDomainType)
+		}
+		return newPeerSkipError(skipReasonDomainTypeMismatch, err)
 	}
 
 	// Get the peer's subnets, skipping if it has none.

--- a/network/discovery/dv5_service_test.go
+++ b/network/discovery/dv5_service_test.go
@@ -220,44 +220,76 @@ func TestCheckPeer(t *testing.T) {
 	}
 }
 
-// TestCheckPeer_ZeroNextDomainType verifies the zero-value guard: when NextDomainType is
-// unset (zero, as in configs built from struct literals), a peer advertising an all-zero
-// domain type must still be rejected rather than matching the zero NextDomainType.
-func TestCheckPeer_ZeroNextDomainType(t *testing.T) {
-	ctx := t.Context()
-	logger := zap.NewNop()
-	mySubnets := mockSubnets(1, 2, 3)
-
-	priv, err := utils.ECDSAPrivateKey(logger, "")
-	require.NoError(t, err)
-
-	localNode, err := records.CreateLocalNode(priv, t.TempDir(), net.ParseIP("127.0.0.1"), 12000, 13000)
-	require.NoError(t, err)
-	localNode.Set(enr.WithEntry("ssv", true))
-	require.NoError(t, records.SetDomainTypeEntry(localNode, records.KeyDomainType, spectypes.DomainType{}))
-	require.NoError(t, records.SetSubnetsEntry(localNode, mySubnets))
-
-	addrInfo, err := ToPeer(localNode.Node())
-	require.NoError(t, err)
-
-	dvs := &DiscV5Service{
-		ctx:        ctx,
-		conns:      &mock.MockConnectionIndex{},
-		subnetsIdx: peers.NewSubnetsIndex(),
-		ssvConfig: &networkconfig.SSV{
-			DomainType: spectypes.DomainType{0x1, 0x2, 0x3, 0x4},
-			// NextDomainType intentionally left zero.
+// TestCheckPeer_NoDistinctNextDomain verifies strict single-domain matching when no
+// distinct next domain is accepted: with NextDomainType unset (zero, as in configs built
+// from struct literals) or equal to DomainType (the config-parse default), mismatched
+// peer domains must be rejected with the single-domain error. In particular, an all-zero
+// peer domain must not match the zero NextDomainType.
+func TestCheckPeer_NoDistinctNextDomain(t *testing.T) {
+	tests := []struct {
+		name           string
+		nextDomainType spectypes.DomainType
+		peerDomainType spectypes.DomainType
+		expectedError  string
+	}{
+		{
+			name:           "zero next domain, zero peer domain",
+			nextDomainType: spectypes.DomainType{},
+			peerDomainType: spectypes.DomainType{},
+			expectedError:  "domain type 00000000 does not match 01020304",
 		},
-		subnets:             mySubnets,
-		discoveredPeersPool: ttl.New[peer.ID, DiscoveredPeer](ctx, time.Hour, time.Hour),
-		trimmedRecently:     ttl.New[peer.ID, struct{}](ctx, time.Hour, time.Hour),
+		{
+			name:           "zero next domain, mismatched peer domain",
+			nextDomainType: spectypes.DomainType{},
+			peerDomainType: spectypes.DomainType{0x1, 0x2, 0x3, 0x5},
+			expectedError:  "domain type 01020305 does not match 01020304",
+		},
+		{
+			name:           "next domain equals current domain, mismatched peer domain",
+			nextDomainType: spectypes.DomainType{0x1, 0x2, 0x3, 0x4},
+			peerDomainType: spectypes.DomainType{0x1, 0x2, 0x3, 0x5},
+			expectedError:  "domain type 01020305 does not match 01020304",
+		},
 	}
 
-	err = dvs.checkPeer(context.TODO(), PeerEvent{
-		AddrInfo: *addrInfo,
-		Node:     localNode.Node(),
-	})
-	require.ErrorContains(t, err, "domain type 00000000 does not match 01020304")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
+			logger := zap.NewNop()
+			mySubnets := mockSubnets(1, 2, 3)
+
+			priv, err := utils.ECDSAPrivateKey(logger, "")
+			require.NoError(t, err)
+
+			localNode, err := records.CreateLocalNode(priv, t.TempDir(), net.ParseIP("127.0.0.1"), 12000, 13000)
+			require.NoError(t, err)
+			localNode.Set(enr.WithEntry("ssv", true))
+			require.NoError(t, records.SetDomainTypeEntry(localNode, records.KeyDomainType, test.peerDomainType))
+			require.NoError(t, records.SetSubnetsEntry(localNode, mySubnets))
+
+			addrInfo, err := ToPeer(localNode.Node())
+			require.NoError(t, err)
+
+			dvs := &DiscV5Service{
+				ctx:        ctx,
+				conns:      &mock.MockConnectionIndex{},
+				subnetsIdx: peers.NewSubnetsIndex(),
+				ssvConfig: &networkconfig.SSV{
+					DomainType:     spectypes.DomainType{0x1, 0x2, 0x3, 0x4},
+					NextDomainType: test.nextDomainType,
+				},
+				subnets:             mySubnets,
+				discoveredPeersPool: ttl.New[peer.ID, DiscoveredPeer](ctx, time.Hour, time.Hour),
+				trimmedRecently:     ttl.New[peer.ID, struct{}](ctx, time.Hour, time.Hour),
+			}
+
+			err = dvs.checkPeer(context.TODO(), PeerEvent{
+				AddrInfo: *addrInfo,
+				Node:     localNode.Node(),
+			})
+			require.ErrorContains(t, err, test.expectedError)
+		})
+	}
 }
 
 func TestCheckPeer_UpdatesSubnetsIndexBeforeConnectionFilters(t *testing.T) {

--- a/network/discovery/dv5_service_test.go
+++ b/network/discovery/dv5_service_test.go
@@ -49,7 +49,19 @@ func TestCheckPeer(t *testing.T) {
 				name:          "domain type mismatch",
 				domainType:    &spectypes.DomainType{0x1, 0x2, 0x3, 0x5},
 				subnets:       mySubnets,
-				expectedError: errors.New("domain type 01020305 doesn't match 01020304"),
+				expectedError: errors.New("domain type 01020305 matches neither 01020304 nor 01020306"),
+			},
+			{
+				name:          "matches next domain type",
+				domainType:    &spectypes.DomainType{0x1, 0x2, 0x3, 0x6},
+				subnets:       mySubnets,
+				expectedError: nil,
+			},
+			{
+				name:          "unrelated domain type",
+				domainType:    &spectypes.DomainType{0x0, 0x0, 0x5, 0x3},
+				subnets:       mySubnets,
+				expectedError: errors.New("domain type 00000503 matches neither 01020304 nor 01020306"),
 			},
 			{
 				name:           "missing subnets",
@@ -121,7 +133,8 @@ func TestCheckPeer(t *testing.T) {
 	)
 
 	var checkPeerTestSSVConfig = &networkconfig.SSV{
-		DomainType: spectypes.DomainType{0x1, 0x2, 0x3, 0x4},
+		DomainType:     spectypes.DomainType{0x1, 0x2, 0x3, 0x4},
+		NextDomainType: spectypes.DomainType{0x1, 0x2, 0x3, 0x6},
 	}
 
 	// Create the LocalNode instances for the tests.
@@ -205,6 +218,46 @@ func TestCheckPeer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCheckPeer_ZeroNextDomainType verifies the zero-value guard: when NextDomainType is
+// unset (zero, as in configs built from struct literals), a peer advertising an all-zero
+// domain type must still be rejected rather than matching the zero NextDomainType.
+func TestCheckPeer_ZeroNextDomainType(t *testing.T) {
+	ctx := t.Context()
+	logger := zap.NewNop()
+	mySubnets := mockSubnets(1, 2, 3)
+
+	priv, err := utils.ECDSAPrivateKey(logger, "")
+	require.NoError(t, err)
+
+	localNode, err := records.CreateLocalNode(priv, t.TempDir(), net.ParseIP("127.0.0.1"), 12000, 13000)
+	require.NoError(t, err)
+	localNode.Set(enr.WithEntry("ssv", true))
+	require.NoError(t, records.SetDomainTypeEntry(localNode, records.KeyDomainType, spectypes.DomainType{}))
+	require.NoError(t, records.SetSubnetsEntry(localNode, mySubnets))
+
+	addrInfo, err := ToPeer(localNode.Node())
+	require.NoError(t, err)
+
+	dvs := &DiscV5Service{
+		ctx:        ctx,
+		conns:      &mock.MockConnectionIndex{},
+		subnetsIdx: peers.NewSubnetsIndex(),
+		ssvConfig: &networkconfig.SSV{
+			DomainType: spectypes.DomainType{0x1, 0x2, 0x3, 0x4},
+			// NextDomainType intentionally left zero.
+		},
+		subnets:             mySubnets,
+		discoveredPeersPool: ttl.New[peer.ID, DiscoveredPeer](ctx, time.Hour, time.Hour),
+		trimmedRecently:     ttl.New[peer.ID, struct{}](ctx, time.Hour, time.Hour),
+	}
+
+	err = dvs.checkPeer(context.TODO(), PeerEvent{
+		AddrInfo: *addrInfo,
+		Node:     localNode.Node(),
+	})
+	require.ErrorContains(t, err, "domain type 00000000 matches neither 01020304 nor 00000000")
 }
 
 func TestCheckPeer_UpdatesSubnetsIndexBeforeConnectionFilters(t *testing.T) {

--- a/network/discovery/dv5_service_test.go
+++ b/network/discovery/dv5_service_test.go
@@ -257,7 +257,7 @@ func TestCheckPeer_ZeroNextDomainType(t *testing.T) {
 		AddrInfo: *addrInfo,
 		Node:     localNode.Node(),
 	})
-	require.ErrorContains(t, err, "domain type 00000000 matches neither 01020304 nor 00000000")
+	require.ErrorContains(t, err, "domain type 00000000 does not match 01020304")
 }
 
 func TestCheckPeer_UpdatesSubnetsIndexBeforeConnectionFilters(t *testing.T) {

--- a/network/discovery/service_test.go
+++ b/network/discovery/service_test.go
@@ -272,13 +272,18 @@ func TestDiscV5Service_checkPeer(t *testing.T) {
 	err = dvs.checkPeer(context.TODO(), ToPeerEvent(NodeWithCustomDomains(t, testNetConfig.DomainType, spectypes.DomainType{})))
 	require.NoError(t, err)
 
-	// Matching next domain
+	// Our next domain in the peer's main key (post-fork Anchor shape) is accepted
+	err = dvs.checkPeer(context.TODO(), ToPeerEvent(NodeWithCustomDomains(t, testNetConfig.NextDomainType, spectypes.DomainType{})))
+	require.NoError(t, err)
+
+	// The peer's next-domain key is ignored: a zero main domain is rejected even when
+	// the peer's next key matches our domain
 	err = dvs.checkPeer(context.TODO(), ToPeerEvent(NodeWithCustomDomains(t, spectypes.DomainType{}, testNetConfig.DomainType)))
-	require.ErrorContains(t, err, "domain type 00000000 doesn't match 00000302")
+	require.ErrorContains(t, err, "domain type 00000000 matches neither 00000302 nor 00000303")
 
 	// Mismatching domains
 	err = dvs.checkPeer(context.TODO(), ToPeerEvent(NodeWithCustomDomains(t, spectypes.DomainType{}, spectypes.DomainType{})))
-	require.ErrorContains(t, err, "domain type 00000000 doesn't match 00000302")
+	require.ErrorContains(t, err, "domain type 00000000 matches neither 00000302 nor 00000303")
 
 	// No subnets
 	err = dvs.checkPeer(context.TODO(), ToPeerEvent(NodeWithoutSubnets(t)))

--- a/networkconfig/ssv.go
+++ b/networkconfig/ssv.go
@@ -35,7 +35,9 @@ type SSV struct {
 	// Name looks similar to Beacon.Name, however, it's used to differentiate configs on the same
 	// beacon network, e.g. holesky, holesky-stage, holesky-e2e, disallowing node start with different config,
 	// even if the beacon network is the same.
-	Name       string
+	Name string
+	// DomainType is the domain type currently active on the network. It's advertised in
+	// the primary ENR entry and domain-separates SSV message signatures between networks.
 	DomainType spectypes.DomainType
 	// NextDomainType is the domain type expected to become active after the next fork.
 	// Discovery accepts peers advertising either DomainType or a distinct non-zero

--- a/networkconfig/ssv.go
+++ b/networkconfig/ssv.go
@@ -35,8 +35,14 @@ type SSV struct {
 	// Name looks similar to Beacon.Name, however, it's used to differentiate configs on the same
 	// beacon network, e.g. holesky, holesky-stage, holesky-e2e, disallowing node start with different config,
 	// even if the beacon network is the same.
-	Name                 string
-	DomainType           spectypes.DomainType
+	Name       string
+	DomainType spectypes.DomainType
+	// NextDomainType is the domain type expected to become active after the next fork.
+	// Discovery accepts peers advertising either DomainType or a distinct non-zero
+	// NextDomainType, so networks that need cross-client discovery around a fork must
+	// set it. Zero means no next domain (discovery is strict to DomainType). YAML/JSON
+	// parsing defaults it to DomainType when omitted; only configs built from struct
+	// literals can leave it zero.
 	NextDomainType       spectypes.DomainType
 	RegistrySyncOffset   *big.Int
 	RegistryContractAddr ethcommon.Address


### PR DESCRIPTION
Fixes #2967. Related: sigp/anchor#1185 (audit), sigp/anchor#1187 (Anchor-side fix).

## Problem

Post-Boole, `checkPeer` compares the peer's main `domaintype` ENR entry strictly against the static `ssvConfig.DomainType`. go-ssv keeps advertising the static current domain in its main key, while Anchor advertises the *active* domain — Boole post-fork. This is a permanent steady-state mismatch, not a transition window: go-ssv can never discover or dial Anchor peers, so cross-client edges form only when Anchor initiates. Live confirmation on stage-hoodi: `domainTypeMismatch` is the top discovery skip reason fleet-wide, and handshake logs show `want one of [0x00003115]`.

The handshake filter is already fork-aware, so discovery is the only blocker — widening it makes the connection succeed end-to-end.

## Change

`checkPeer` now accepts a peer whose advertised main domain equals either `DomainType` or `NextDomainType`. `NextDomainType` is only honored when non-zero: config parsing defaults it to `DomainType`, but struct-literal configs leave it zero, and an all-zero advertised domain must not be accepted.

Strictly widens the accept set — one production call site, no structural changes. The fork-aware handshake filter and per-slot message validation remain the authoritative fork enforcement.

## Tests

- ENR with main `domaintype == NextDomainType` (post-fork Anchor shape) passes
- ENR with main `domaintype == DomainType` still passes
- All-zero main domain rejected when `NextDomainType` is unset (zero-value guard)
- Unrelated domain (e.g. prod-hoodi's `0x00000503`) still rejected with `domainTypeMismatch`
- Peer's *next*-domain ENR key remains ignored (only the main key is compared)

## Post-merge verification (stage)

Restart a couple of stage nodes and confirm they establish outbound connections to the Anchor operators (415–418). sigp's acceptance criterion from sigp/anchor#1185: a post-fork restarted node forms ≥1 direct go-ssv→Anchor outbound edge.