### PR TITLE
network: detect a wedged discv5 socket (operator health check + boot-node /healthz)

### DIFF
--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -78,6 +78,9 @@ type DiscV5Service struct {
 
 	conn       *net.UDPConn
 	sharedConn *SharedUDPConn
+	// socketConn wraps conn to time socket reads; the post-fork listener drains
+	// through it, so DiscoveryStale can detect a wedged socket.
+	socketConn *TimedConn
 
 	ssvConfig *networkconfig.SSV
 	subnets   commons.Subnets
@@ -157,6 +160,21 @@ func (dvs *DiscV5Service) close() error {
 		}
 	}
 	return nil
+}
+
+// DiscoveryStale reports whether the discv5 socket has gone unread for longer
+// than grace — the sign discovery has wedged. False before the listener is built
+// (or after a failed init), when there's nothing to judge.
+//
+// The operator health check polls this periodically, so it doubles as the
+// sampling point for the read-staleness gauge.
+func (dvs *DiscV5Service) DiscoveryStale(grace time.Duration) bool {
+	if dvs.socketConn == nil {
+		return false
+	}
+	age, ok := dvs.socketConn.ReadStaleness()
+	recordDiscoveryReadStaleness(dvs.ctx, int64(age.Seconds()))
+	return ok && age > grace
 }
 
 // Self returns self node
@@ -402,6 +420,12 @@ func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) (err error) {
 	}
 	dvs.conn = udpConn
 
+	// Wrap the socket for liveness (see DiscoveryStale): only the post-fork
+	// listener drains it, so only it gets the wrapped conn — the pre-fork
+	// listener reads sharedConn's buffer, not the socket.
+	socketConn := NewTimedConn(udpConn)
+	dvs.socketConn = socketConn
+
 	// Registered before anything else can fail, so every error path below
 	// releases the socket. Runs last of the deferred cleanups, by which point a
 	// listener may already have closed it.
@@ -409,6 +433,7 @@ func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) (err error) {
 		if err != nil {
 			_ = udpConn.Close()
 			dvs.conn = nil
+			dvs.socketConn = nil
 		}
 	}()
 
@@ -453,7 +478,7 @@ func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) (err error) {
 		return err
 	}
 
-	dv5PostForkListener, err := listenV5(udpConn, localNode, *dv5PostForkCfg)
+	dv5PostForkListener, err := listenV5(socketConn, localNode, *dv5PostForkCfg)
 	if err != nil {
 		return fmt.Errorf("could not create discV5 listener: %w", err)
 	}

--- a/network/discovery/dv5_service.go
+++ b/network/discovery/dv5_service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -81,6 +82,9 @@ type DiscV5Service struct {
 	// socketConn wraps conn to time socket reads; the post-fork listener drains
 	// through it, so DiscoveryStale can detect a wedged socket.
 	socketConn *TimedConn
+	// stalenessReg is the read-staleness gauge callback for socketConn,
+	// unregistered on close.
+	stalenessReg metric.Registration
 
 	ssvConfig *networkconfig.SSV
 	subnets   commons.Subnets
@@ -140,6 +144,10 @@ func (dvs *DiscV5Service) close() error {
 	if dvs.cancel != nil {
 		dvs.cancel()
 	}
+	if dvs.stalenessReg != nil {
+		// Stop reporting the read-staleness gauge for a closed service.
+		_ = dvs.stalenessReg.Unregister()
+	}
 	// Order matters. The post-fork listener produces into sharedConn.Unhandled,
 	// so it must be fully stopped before that channel is closed — closing it
 	// mid-send panics the producer. Stopping the listeners first is safe:
@@ -164,17 +172,14 @@ func (dvs *DiscV5Service) close() error {
 
 // DiscoveryStale reports whether the discv5 socket has gone unread for longer
 // than grace — the sign discovery has wedged. False before the listener is built
-// (or after a failed init), when there's nothing to judge.
-//
-// The operator health check polls this periodically, so it doubles as the
-// sampling point for the read-staleness gauge.
+// (or after a failed init), when there's nothing to judge. The read-staleness
+// gauge is sampled separately at scrape time (see observeDiscoveryReadStaleness),
+// keeping this a pure predicate.
 func (dvs *DiscV5Service) DiscoveryStale(grace time.Duration) bool {
 	if dvs.socketConn == nil {
 		return false
 	}
-	age, ok := dvs.socketConn.ReadStaleness()
-	recordDiscoveryReadStaleness(dvs.ctx, int64(age.Seconds()))
-	return ok && age > grace
+	return dvs.socketConn.StaleFor(grace)
 }
 
 // Self returns self node
@@ -512,6 +517,15 @@ func (dvs *DiscV5Service) initDiscV5Listener(discOpts *Options) (err error) {
 
 	dvs.dv5Listener = NewForkingDV5Listener(dvs.logger, dv5PreForkListener, dv5PostForkListener, 5*time.Second)
 	dvs.bootnodes = dv5PreForkCfg.Bootnodes // Just take bootnodes from one of the config since they're equal
+
+	// Registered last so the callback only outlives init if the service does.
+	// Registration fails only on instrument misuse and the gauge is optional,
+	// so a failure is logged, not returned.
+	if reg, regErr := observeDiscoveryReadStaleness(socketConn); regErr != nil {
+		dvs.logger.Warn("could not register discovery read-staleness gauge", zap.Error(regErr))
+	} else {
+		dvs.stalenessReg = reg
+	}
 
 	return nil
 }

--- a/network/discovery/dv5_service_stale_test.go
+++ b/network/discovery/dv5_service_stale_test.go
@@ -16,7 +16,7 @@ func TestDiscV5Service_DiscoveryStale(t *testing.T) {
 
 	sc := NewTimedConn(nil)
 	t0 := sc.LastRead()
-	dvs := &DiscV5Service{ctx: t.Context(), socketConn: sc}
+	dvs := &DiscV5Service{socketConn: sc}
 
 	// Never read → never stale, however long it sits idle: an operator that has
 	// simply had no inbound discv5 traffic yet must not be flagged as wedged.

--- a/network/discovery/dv5_service_stale_test.go
+++ b/network/discovery/dv5_service_stale_test.go
@@ -1,0 +1,35 @@
+package discovery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDiscV5Service_DiscoveryStale covers the operator-side liveness accessor:
+// nil before the listener is built, never stale until the socket has actually
+// been read, and driven by the wrapped socket's last-read time thereafter.
+func TestDiscV5Service_DiscoveryStale(t *testing.T) {
+	// No socket wrapped yet (not-yet / failed init) → never stale.
+	require.False(t, (&DiscV5Service{}).DiscoveryStale(3*time.Minute))
+
+	sc := NewTimedConn(nil)
+	t0 := sc.LastRead()
+	dvs := &DiscV5Service{ctx: t.Context(), socketConn: sc}
+
+	// Never read → never stale, however long it sits idle: an operator that has
+	// simply had no inbound discv5 traffic yet must not be flagged as wedged.
+	sc.now = func() time.Time { return t0.Add(time.Hour) }
+	require.False(t, dvs.DiscoveryStale(3*time.Minute), "never-read socket is not a wedge")
+
+	// A read arms the signal, stamped at t0.
+	sc.read.Store(true)
+	sc.lastReadUnixNano.Store(t0.UnixNano())
+
+	sc.now = func() time.Time { return t0.Add(2 * time.Minute) }
+	require.False(t, dvs.DiscoveryStale(3*time.Minute), "read within grace → not stale")
+
+	sc.now = func() time.Time { return t0.Add(4 * time.Minute) }
+	require.True(t, dvs.DiscoveryStale(3*time.Minute), "read then unread past grace → stale")
+}

--- a/network/discovery/local_service.go
+++ b/network/discovery/local_service.go
@@ -114,6 +114,12 @@ func (md *localDiscovery) PublishENR() {
 	// TODO
 }
 
+// DiscoveryStale implements Service. Local discovery has no discv5 socket to
+// wedge, so it's never stale.
+func (md *localDiscovery) DiscoveryStale(time.Duration) bool {
+	return false
+}
+
 // discoveryNotifee gets notified when we find a new peer via mDNS discovery
 type discoveryNotifee struct {
 	handler HandleNewPeer

--- a/network/discovery/observability.go
+++ b/network/discovery/observability.go
@@ -67,18 +67,37 @@ var (
 			metric.WithDescription("total number of packets forwarded to the pre-fork listener that were dropped because its buffer was full")))
 
 	discoveryReadStalenessGauge = metrics.New(
-		meter.Int64Gauge(
+		meter.Int64ObservableGauge(
 			observability.InstrumentName(observabilityNamespace, "socket.read_staleness"),
 			metric.WithUnit("s"),
-			metric.WithDescription("seconds since the discv5 socket was last read; 0 until the first read")))
+			metric.WithDescription("seconds since the discv5 socket was last read; -1 until the first read")))
 )
 
 func recordUnhandledPacketDropped(ctx context.Context) {
 	unhandledPacketsDroppedCounter.Add(ctx, 1)
 }
 
-func recordDiscoveryReadStaleness(ctx context.Context, seconds int64) {
-	discoveryReadStalenessGauge.Record(ctx, seconds)
+// observeDiscoveryReadStaleness registers a callback reporting conn's read
+// staleness at scrape time. Async sampling keeps the series alive regardless of
+// the health-check path — a gauge recorded from Healthy goes quiet whenever an
+// earlier check short-circuits, i.e. exactly when discovery is broken. The
+// registration must be unregistered when the owning service closes.
+func observeDiscoveryReadStaleness(conn *TimedConn) (metric.Registration, error) {
+	return meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
+		observer.ObserveInt64(discoveryReadStalenessGauge, readStalenessSeconds(conn))
+		return nil
+	}, discoveryReadStalenessGauge)
+}
+
+// readStalenessSeconds flattens ReadStaleness for the gauge: never-read reports
+// -1 — the state the health check deliberately ignores, kept visible for
+// alerting — distinct from a just-read socket at 0.
+func readStalenessSeconds(conn *TimedConn) int64 {
+	age, everRead := conn.ReadStaleness()
+	if !everRead {
+		return -1
+	}
+	return int64(age.Seconds())
 }
 
 func recordPeerSkipped(ctx context.Context, reason skipReason) {

--- a/network/discovery/observability.go
+++ b/network/discovery/observability.go
@@ -65,10 +65,20 @@ var (
 			observability.InstrumentName(observabilityNamespace, "unhandled_packets.dropped"),
 			metric.WithUnit("{packet}"),
 			metric.WithDescription("total number of packets forwarded to the pre-fork listener that were dropped because its buffer was full")))
+
+	discoveryReadStalenessGauge = metrics.New(
+		meter.Int64Gauge(
+			observability.InstrumentName(observabilityNamespace, "socket.read_staleness"),
+			metric.WithUnit("s"),
+			metric.WithDescription("seconds since the discv5 socket was last read; 0 until the first read")))
 )
 
 func recordUnhandledPacketDropped(ctx context.Context) {
 	unhandledPacketsDroppedCounter.Add(ctx, 1)
+}
+
+func recordDiscoveryReadStaleness(ctx context.Context, seconds int64) {
+	discoveryReadStalenessGauge.Record(ctx, seconds)
 }
 
 func recordPeerSkipped(ctx context.Context, reason skipReason) {

--- a/network/discovery/service.go
+++ b/network/discovery/service.go
@@ -62,6 +62,9 @@ type Service interface {
 	DeregisterSubnets(subnets ...uint64) (updated bool, err error)
 	Bootstrap(handler HandleNewPeer) error
 	PublishENR()
+	// DiscoveryStale reports whether discovery has stopped draining its socket
+	// for longer than grace (the "wedge").
+	DiscoveryStale(grace time.Duration) bool
 }
 
 type DiscoveredPeer struct {

--- a/network/discovery/service_test.go
+++ b/network/discovery/service_test.go
@@ -37,6 +37,7 @@ func TestNewDiscV5Service(t *testing.T) {
 
 	assert.NotNil(t, dvs.dv5Listener)
 	assert.NotNil(t, dvs.conns)
+	assert.NotNil(t, dvs.socketConn)
 	assert.NotNil(t, dvs.subnetsIdx)
 	assert.NotNil(t, dvs.ssvConfig)
 

--- a/network/discovery/service_test.go
+++ b/network/discovery/service_test.go
@@ -38,6 +38,7 @@ func TestNewDiscV5Service(t *testing.T) {
 	assert.NotNil(t, dvs.dv5Listener)
 	assert.NotNil(t, dvs.conns)
 	assert.NotNil(t, dvs.socketConn)
+	assert.NotNil(t, dvs.stalenessReg, "read-staleness gauge callback must be registered")
 	assert.NotNil(t, dvs.subnetsIdx)
 	assert.NotNil(t, dvs.ssvConfig)
 
@@ -417,6 +418,9 @@ func TestDiscV5ServiceListenerType(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// testHostAddress is an arbitrary non-loopback address for address-configuration tests.
+const testHostAddress = "192.168.1.100"
+
 // TestServiceAddressConfiguration tests the address configuration logic in the discovery service.
 // It verifies that host addresses and DNS names are correctly resolved and applied
 // to the local node. HostDNS and HostAddress are mutually exclusive - providing both
@@ -434,9 +438,9 @@ func TestServiceAddressConfiguration(t *testing.T) {
 	}{
 		{
 			name:           "only HostAddress",
-			hostAddress:    "192.168.1.100",
+			hostAddress:    testHostAddress,
 			hostDNS:        "",
-			expectedResult: "192.168.1.100",
+			expectedResult: testHostAddress,
 			expectError:    false,
 		},
 		{
@@ -448,7 +452,7 @@ func TestServiceAddressConfiguration(t *testing.T) {
 		},
 		{
 			name:        "both HostAddress and HostDNS",
-			hostAddress: "192.168.1.100",
+			hostAddress: testHostAddress,
 			hostDNS:     "localhost",
 			expectError: true,
 		},

--- a/network/discovery/shared_conn_test.go
+++ b/network/discovery/shared_conn_test.go
@@ -312,6 +312,33 @@ func TestInitDiscV5Listener_CleansUpOnError(t *testing.T) {
 	}
 }
 
+// TestInitDiscV5Listener_WrapsPostForkConn pins the wiring the wedge detector
+// depends on: the post-fork listener — the only one that drains the real socket —
+// must read through the TimedConn, and the pre-fork listener must read the
+// SharedUDPConn buffer. Every other test builds these conns by hand, so without
+// this a refactor that passed the wrong conn to ListenV5 would leave the detector
+// silently reporting "healthy" forever while the whole suite still passed.
+//
+// Swaps the package-level listenV5, so the test must stay non-parallel.
+func TestInitDiscV5Listener_WrapsPostForkConn(t *testing.T) {
+	orig := listenV5
+	t.Cleanup(func() { listenV5 = orig })
+
+	var conns []discover.UDPConn
+	listenV5 = func(conn discover.UDPConn, ln *enode.LocalNode, cfg discover.Config) (Listener, error) {
+		conns = append(conns, conn)
+		return orig(conn, ln, cfg)
+	}
+
+	dvs := testingDiscovery(t)
+	t.Cleanup(func() { require.NoError(t, dvs.Close()) })
+
+	require.Len(t, conns, 2, "init builds the post-fork listener, then the pre-fork one")
+	require.IsType(t, &TimedConn{}, conns[0], "post-fork listener must read through the TimedConn")
+	require.Same(t, dvs.socketConn, conns[0].(*TimedConn), "and it must be the service's own socketConn")
+	require.IsType(t, &SharedUDPConn{}, conns[1], "pre-fork listener must read the SharedUDPConn buffer")
+}
+
 // TestSharedUDPConn_DrainsWhileClosing guards the shutdown ordering: the
 // producer keeps forwarding while the reader shuts down, and must not block or
 // panic. Previously Close() closed Unhandled, so an in-flight send panicked

--- a/network/discovery/timed_conn.go
+++ b/network/discovery/timed_conn.go
@@ -16,6 +16,13 @@ import (
 // shows up as a last-read timestamp that stops advancing. StaleFor turns that
 // into a liveness signal, used by both the operator and boot nodes.
 //
+// The signal is scoped to the socket. On the operator only the post-fork
+// listener reads it (through this wrapper); the pre-fork listener consumes
+// decode-rejected packets relayed via SharedUDPConn's buffer. A stall confined
+// to the pre-fork listener therefore moves neither this timestamp nor the
+// post-fork reader, whose relay into that buffer drops rather than blocks
+// (#2980). The boot node runs a single listener reading the socket directly.
+//
 // Only ReadFromUDPAddrPort is overridden; writes, Close and LocalAddr fall
 // through to the embedded conn.
 type TimedConn struct {

--- a/network/discovery/timed_conn.go
+++ b/network/discovery/timed_conn.go
@@ -1,0 +1,84 @@
+package discovery
+
+import (
+	"net"
+	"net/netip"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/discover"
+)
+
+// TimedConn wraps a discv5 UDP socket and records when it was last read from.
+//
+// A discv5 listener drains its socket only through ReadFromUDPAddrPort, so a
+// wedged socket — bound but no longer read, leaving discovery silently dead —
+// shows up as a last-read timestamp that stops advancing. StaleFor turns that
+// into a liveness signal, used by both the operator and boot nodes.
+//
+// Only ReadFromUDPAddrPort is overridden; writes, Close and LocalAddr fall
+// through to the embedded conn.
+type TimedConn struct {
+	discover.UDPConn
+
+	lastReadUnixNano atomic.Int64
+	read             atomic.Bool      // set once the socket has been read at least once
+	now              func() time.Time // overridable in tests; nil means time.Now
+}
+
+var _ discover.UDPConn = (*TimedConn)(nil)
+
+// NewTimedConn wraps conn, seeding the last-read time so LastRead reports a
+// sensible value before the first read. Staleness only arms once the socket has
+// actually been read (see StaleFor).
+func NewTimedConn(conn *net.UDPConn) *TimedConn {
+	c := &TimedConn{UDPConn: conn}
+	c.lastReadUnixNano.Store(c.nowFn().UnixNano())
+	return c
+}
+
+func (c *TimedConn) nowFn() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+// ReadFromUDPAddrPort delegates and, on success, records the read time and marks
+// the socket as having been read. Errors leave both untouched, so a closed or
+// failing socket can't look freshly drained.
+func (c *TimedConn) ReadFromUDPAddrPort(b []byte) (n int, addr netip.AddrPort, err error) {
+	n, addr, err = c.UDPConn.ReadFromUDPAddrPort(b)
+	if err == nil {
+		c.lastReadUnixNano.Store(c.nowFn().UnixNano())
+		c.read.Store(true)
+	}
+	return n, addr, err
+}
+
+// LastRead reports when a packet was last read from the socket.
+func (c *TimedConn) LastRead() time.Time {
+	return time.Unix(0, c.lastReadUnixNano.Load())
+}
+
+// ReadStaleness reports how long the socket has gone unread, and whether it has
+// ever been read. Before the first successful read there is nothing to measure,
+// so ok is false: a socket that has never delivered a packet is not wedged, it
+// has simply had no inbound discv5 traffic yet (unreachable bootnodes, blocked
+// UDP), which a restart cannot fix.
+func (c *TimedConn) ReadStaleness() (age time.Duration, ok bool) {
+	if !c.read.Load() {
+		return 0, false
+	}
+	return c.nowFn().Sub(c.LastRead()), true
+}
+
+// StaleFor reports whether the socket has wedged: it was being drained, then
+// went unread for longer than d. A socket that has never been read is never
+// stale — a wedge can only arise after draining has started, so requiring a
+// prior read rules out the false positive (a healthy node that has simply had
+// no inbound traffic yet) without missing any real wedge.
+func (c *TimedConn) StaleFor(d time.Duration) bool {
+	age, ok := c.ReadStaleness()
+	return ok && age > d
+}

--- a/network/discovery/timed_conn_test.go
+++ b/network/discovery/timed_conn_test.go
@@ -108,3 +108,21 @@ func TestTimedConn_FailedReadDoesNotStamp(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, t0.UnixNano(), c.LastRead().UnixNano(), "errored read must not stamp")
 }
+
+// TestReadStalenessSeconds: the gauge flattening keeps never-read (-1) — the
+// state the health check deliberately ignores — distinguishable from a
+// just-read socket (0), and reports whole seconds once armed.
+func TestReadStalenessSeconds(t *testing.T) {
+	c := NewTimedConn(nil)
+	t0 := c.LastRead()
+
+	c.now = func() time.Time { return t0.Add(time.Hour) }
+	require.Equal(t, int64(-1), readStalenessSeconds(c), "never-read reports the sentinel, not an age")
+
+	c.read.Store(true)
+	c.lastReadUnixNano.Store(t0.Add(time.Hour).UnixNano())
+	require.Equal(t, int64(0), readStalenessSeconds(c), "just read → 0")
+
+	c.now = func() time.Time { return t0.Add(time.Hour + 42*time.Second) }
+	require.Equal(t, int64(42), readStalenessSeconds(c))
+}

--- a/network/discovery/timed_conn_test.go
+++ b/network/discovery/timed_conn_test.go
@@ -1,0 +1,110 @@
+package discovery
+
+import (
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeUDPConn is a minimal discover.UDPConn so the read path can be exercised
+// without a real socket.
+type fakeUDPConn struct {
+	readErr error
+}
+
+func (f *fakeUDPConn) ReadFromUDPAddrPort(b []byte) (int, netip.AddrPort, error) {
+	if f.readErr != nil {
+		return 0, netip.AddrPort{}, f.readErr
+	}
+	n := copy(b, []byte{0x1})
+	return n, netip.MustParseAddrPort("1.2.3.4:30303"), nil
+}
+
+func (f *fakeUDPConn) WriteToUDPAddrPort(b []byte, _ netip.AddrPort) (int, error) {
+	return len(b), nil
+}
+
+func (f *fakeUDPConn) Close() error        { return nil }
+func (f *fakeUDPConn) LocalAddr() net.Addr { return nil }
+
+// TestTimedConn_SeededNotStale: a freshly constructed conn is not stale — it has
+// not been read yet, so there is nothing to flag at startup.
+func TestTimedConn_SeededNotStale(t *testing.T) {
+	c := NewTimedConn(nil)
+	require.False(t, c.StaleFor(3*time.Minute))
+}
+
+// TestTimedConn_NeverReadNeverStale: a socket that has never delivered a packet
+// is not a wedge — it's a node with no inbound discv5 traffic (unreachable
+// bootnodes, blocked UDP), which a restart cannot fix — so it must never report
+// stale, however much time passes. Once it has been read, staleness arms as
+// usual.
+func TestTimedConn_NeverReadNeverStale(t *testing.T) {
+	c := NewTimedConn(nil)
+	t0 := c.LastRead()
+
+	c.now = func() time.Time { return t0.Add(time.Hour) }
+	require.False(t, c.StaleFor(3*time.Minute), "never-read socket must not be stale")
+	_, ok := c.ReadStaleness()
+	require.False(t, ok, "never-read socket has no staleness to report")
+
+	// A successful read arms the signal; from the read time on, it goes stale.
+	c.UDPConn = &fakeUDPConn{}
+	_, _, err := c.ReadFromUDPAddrPort(make([]byte, 16))
+	require.NoError(t, err)
+	age, ok := c.ReadStaleness()
+	require.True(t, ok, "a read arms the signal")
+	require.Zero(t, age, "staleness resets to the read time")
+
+	c.now = func() time.Time { return t0.Add(time.Hour + 4*time.Minute) }
+	require.True(t, c.StaleFor(3*time.Minute), "past grace after a read")
+}
+
+// TestTimedConn_StaleForTransitions pins the staleness boundary using an
+// injected clock, so no real time passes.
+func TestTimedConn_StaleForTransitions(t *testing.T) {
+	c := NewTimedConn(nil)
+	c.read.Store(true) // staleness only arms once the socket has been read
+	t0 := c.LastRead()
+
+	c.now = func() time.Time { return t0.Add(2 * time.Minute) }
+	require.False(t, c.StaleFor(3*time.Minute), "within grace")
+
+	c.now = func() time.Time { return t0.Add(3 * time.Minute) }
+	require.False(t, c.StaleFor(3*time.Minute), "exactly at grace is not yet stale")
+
+	c.now = func() time.Time { return t0.Add(4 * time.Minute) }
+	require.True(t, c.StaleFor(3*time.Minute), "past grace")
+}
+
+// TestTimedConn_ReadStampsLastRead: a successful read advances the timestamp,
+// so an actively drained socket stays fresh.
+func TestTimedConn_ReadStampsLastRead(t *testing.T) {
+	c := &TimedConn{UDPConn: &fakeUDPConn{}}
+	t0 := time.Now()
+	c.lastReadUnixNano.Store(t0.UnixNano())
+	c.now = func() time.Time { return t0.Add(time.Hour) }
+
+	n, addr, err := c.ReadFromUDPAddrPort(make([]byte, 16))
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Equal(t, netip.MustParseAddrPort("1.2.3.4:30303"), addr)
+	require.Equal(t, t0.Add(time.Hour).UnixNano(), c.LastRead().UnixNano())
+}
+
+// TestTimedConn_FailedReadDoesNotStamp: a read error must leave the timestamp
+// untouched, so a wedged/closed socket cannot look freshly drained.
+func TestTimedConn_FailedReadDoesNotStamp(t *testing.T) {
+	c := &TimedConn{UDPConn: &fakeUDPConn{readErr: errors.New("boom")}}
+	t0 := time.Now()
+	c.lastReadUnixNano.Store(t0.UnixNano())
+	c.now = func() time.Time { return t0.Add(time.Hour) }
+
+	_, _, err := c.ReadFromUDPAddrPort(make([]byte, 16))
+	require.Error(t, err)
+	require.Equal(t, t0.UnixNano(), c.LastRead().UnixNano(), "errored read must not stamp")
+}

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -545,6 +545,11 @@ func (n *p2pNetwork) isReady() bool {
 	return atomic.LoadInt32(&n.state) == stateReady
 }
 
+// discoveryStaleGrace is how long the discv5 socket may go unread before Healthy
+// treats discovery as wedged — comfortably above normal quiet on a live network,
+// where inbound traffic and query responses keep the socket busy.
+const discoveryStaleGrace = 3 * time.Minute
+
 // Healthy reports whether the p2p network is operating normally.
 // It satisfies the health-check interface from hprobe package.
 func (n *p2pNetwork) Healthy(ctx context.Context) error {
@@ -556,6 +561,16 @@ func (n *p2pNetwork) Healthy(ctx context.Context) error {
 	}
 	if n.discoveryFailed.Load() {
 		return fmt.Errorf("discovery bootstrap failed")
+	}
+	// A wedged discv5 socket leaves discovery silently dead while bootstrap keeps
+	// looping; surface it so the hprobe watchdog restarts the node. n.disc is nil
+	// in tests and briefly at startup, hence the guard.
+	if n.disc != nil && n.disc.DiscoveryStale(discoveryStaleGrace) {
+		// Surface the wedge in the log alongside the exit reason, so a restart
+		// isn't the only evidence that discovery died.
+		n.logger.Warn("discv5 socket wedged: not drained within grace, discovery stalled",
+			zap.Duration("grace", discoveryStaleGrace))
+		return fmt.Errorf("discv5 socket not drained for >%s (discovery wedged)", discoveryStaleGrace)
 	}
 	return nil
 }

--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -550,6 +550,16 @@ func (n *p2pNetwork) isReady() bool {
 // where inbound traffic and query responses keep the socket busy.
 const discoveryStaleGrace = 3 * time.Minute
 
+// discoveryStalePeerFloor decides what a stale discv5 socket means: below it
+// the node is effectively isolated and a restart is worth attempting; at or
+// above it the node keeps serving duties over its established connections.
+// The floor is needed because staleness alone can't tell a wedged read loop
+// from inbound UDP lost upstream (firewall/NAT changes) — a restart can't fix
+// the latter, and since any stray packet re-arms the check after boot,
+// restarting unconditionally would turn one external UDP fault into a
+// fleet-correlated restart loop.
+const discoveryStalePeerFloor = 10
+
 // Healthy reports whether the p2p network is operating normally.
 // It satisfies the health-check interface from hprobe package.
 func (n *p2pNetwork) Healthy(ctx context.Context) error {
@@ -563,14 +573,26 @@ func (n *p2pNetwork) Healthy(ctx context.Context) error {
 		return fmt.Errorf("discovery bootstrap failed")
 	}
 	// A wedged discv5 socket leaves discovery silently dead while bootstrap keeps
-	// looping; surface it so the hprobe watchdog restarts the node. n.disc is nil
-	// in tests and briefly at startup, hence the guard.
+	// looping; failing here makes the hprobe watchdog restart the node. Restart
+	// only when the wedge is actually biting — the peer set has degraded (see
+	// discoveryStalePeerFloor). n.disc is nil in tests and briefly at startup,
+	// hence the guard.
 	if n.disc != nil && n.disc.DiscoveryStale(discoveryStaleGrace) {
-		// Surface the wedge in the log alongside the exit reason, so a restart
-		// isn't the only evidence that discovery died.
-		n.logger.Warn("discv5 socket wedged: not drained within grace, discovery stalled",
-			zap.Duration("grace", discoveryStaleGrace))
-		return fmt.Errorf("discv5 socket not drained for >%s (discovery wedged)", discoveryStaleGrace)
+		peers := 0
+		if h := n.Host(); h != nil {
+			peers = len(h.Network().Peers())
+		}
+		if peers < discoveryStalePeerFloor {
+			// Surface the wedge in the log alongside the exit reason, so a restart
+			// isn't the only evidence that discovery died.
+			n.logger.Warn("discv5 socket wedged and peer set degraded, failing health check",
+				zap.Duration("grace", discoveryStaleGrace), zap.Int("peers", peers))
+			return fmt.Errorf("discv5 socket not drained for >%s with %d peers (discovery wedged)", discoveryStaleGrace, peers)
+		}
+		// This log is the only signal: the node stays up on its established peers
+		// and fails the probe only if they erode.
+		n.logger.Error("discv5 socket not drained within grace, holding restart while peer set is healthy",
+			zap.Duration("grace", discoveryStaleGrace), zap.Int("peers", peers))
 	}
 	return nil
 }

--- a/network/p2p/p2p_health_test.go
+++ b/network/p2p/p2p_health_test.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/network/discovery"
 )
 
 func TestP2PNetwork_Healthy(t *testing.T) {
@@ -14,6 +18,7 @@ func TestP2PNetwork_Healthy(t *testing.T) {
 		state           int32
 		discoveryFailed bool
 		cancelCtx       bool
+		disc            discovery.Service
 		wantErr         string
 	}{
 		{
@@ -43,11 +48,23 @@ func TestP2PNetwork_Healthy(t *testing.T) {
 			cancelCtx: true,
 			wantErr:   "context canceled",
 		},
+		{
+			name:    "discovery wedged",
+			state:   stateReady,
+			disc:    staleDiscovery{stale: true},
+			wantErr: "discovery wedged",
+		},
+		{
+			name:  "ready with live discovery",
+			state: stateReady,
+			disc:  staleDiscovery{stale: false},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n := &p2pNetwork{}
+			n := &p2pNetwork{logger: zap.NewNop()}
+			n.disc = tt.disc
 			atomic.StoreInt32(&n.state, tt.state)
 			if tt.discoveryFailed {
 				n.discoveryFailed.Store(true)
@@ -69,3 +86,12 @@ func TestP2PNetwork_Healthy(t *testing.T) {
 		})
 	}
 }
+
+// staleDiscovery is a discovery.Service whose only real method is DiscoveryStale;
+// Healthy calls nothing else, so the embedded nil Service is never dereferenced.
+type staleDiscovery struct {
+	discovery.Service
+	stale bool
+}
+
+func (d staleDiscovery) DiscoveryStale(time.Duration) bool { return d.stale }

--- a/network/p2p/p2p_health_test.go
+++ b/network/p2p/p2p_health_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/host"
+	p2pnet "github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -13,12 +16,15 @@ import (
 )
 
 func TestP2PNetwork_Healthy(t *testing.T) {
+	const wedgedErr = "discovery wedged"
+
 	tests := []struct {
 		name            string
 		state           int32
 		discoveryFailed bool
 		cancelCtx       bool
 		disc            discovery.Service
+		hostPeers       int // connected-peer count; -1 means no host at all
 		wantErr         string
 	}{
 		{
@@ -49,15 +55,35 @@ func TestP2PNetwork_Healthy(t *testing.T) {
 			wantErr:   "context canceled",
 		},
 		{
-			name:    "discovery wedged",
-			state:   stateReady,
-			disc:    staleDiscovery{stale: true},
-			wantErr: "discovery wedged",
+			// No host set at all: peer count reads as zero, so the wedge is fatal
+			// (also pins that Healthy survives a nil host).
+			name:      "discovery wedged",
+			state:     stateReady,
+			disc:      staleDiscovery{stale: true},
+			hostPeers: -1,
+			wantErr:   wedgedErr,
 		},
 		{
-			name:  "ready with live discovery",
-			state: stateReady,
-			disc:  staleDiscovery{stale: false},
+			name:      "discovery wedged with degraded peer set",
+			state:     stateReady,
+			disc:      staleDiscovery{stale: true},
+			hostPeers: discoveryStalePeerFloor - 1,
+			wantErr:   wedgedErr,
+		},
+		{
+			// A stale socket with a healthy peer set may just be inbound UDP lost
+			// upstream; a restart can't fix that and would drop every live
+			// connection, so it must not fail the probe (no restart loop).
+			name:      "discovery wedged but peer set healthy",
+			state:     stateReady,
+			disc:      staleDiscovery{stale: true},
+			hostPeers: discoveryStalePeerFloor,
+		},
+		{
+			name:      "ready with live discovery",
+			state:     stateReady,
+			disc:      staleDiscovery{stale: false},
+			hostPeers: -1,
 		},
 	}
 
@@ -68,6 +94,10 @@ func TestP2PNetwork_Healthy(t *testing.T) {
 			atomic.StoreInt32(&n.state, tt.state)
 			if tt.discoveryFailed {
 				n.discoveryFailed.Store(true)
+			}
+			if tt.hostPeers >= 0 {
+				var h host.Host = fakeHost{peers: tt.hostPeers}
+				n.host.Store(&h)
 			}
 
 			ctx := t.Context()
@@ -95,3 +125,19 @@ type staleDiscovery struct {
 }
 
 func (d staleDiscovery) DiscoveryStale(time.Duration) bool { return d.stale }
+
+// fakeHost/fakeNet expose just the connected-peer count Healthy consults; the
+// embedded nil interfaces are never dereferenced.
+type fakeHost struct {
+	host.Host
+	peers int
+}
+
+func (h fakeHost) Network() p2pnet.Network { return fakeNet{peers: h.peers} }
+
+type fakeNet struct {
+	p2pnet.Network
+	peers int
+}
+
+func (n fakeNet) Peers() []peer.ID { return make([]peer.ID, n.peers) }

--- a/utils/boot_node/health.go
+++ b/utils/boot_node/health.go
@@ -1,0 +1,97 @@
+package bootnode
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+const (
+	// bootReadStaleGrace is how long the socket may go unread before /healthz
+	// fails. A boot node is queried continuously, so a wedge stops reads well
+	// inside this.
+	bootReadStaleGrace = 3 * time.Minute
+
+	// bootEmptyTableGrace tolerates cold start, when the table is briefly empty
+	// before the boot node discovers peers.
+	bootEmptyTableGrace = 10 * time.Minute
+)
+
+// nodeLister is the slice of discovery.Listener the health check needs.
+type nodeLister interface {
+	AllNodes() []*enode.Node
+}
+
+// socketDrainState reports socket-read staleness; satisfied by *discovery.TimedConn.
+type socketDrainState interface {
+	StaleFor(time.Duration) bool
+}
+
+// bootNodeHealth backs /healthz. A boot node's whole job is discovery, so it's
+// broken if its socket has wedged or its routing table has been empty past cold
+// start; either fails /healthz closed so a liveness probe restarts the pod.
+type bootNodeHealth struct {
+	lister          nodeLister
+	socket          socketDrainState
+	readStaleGrace  time.Duration
+	emptyTableGrace time.Duration
+	now             func() time.Time
+	lastNonEmpty    atomic.Int64 // unix nanos of the last observation with a non-empty table
+}
+
+func newBootNodeHealth(lister nodeLister, socket socketDrainState) *bootNodeHealth {
+	h := &bootNodeHealth{
+		lister:          lister,
+		socket:          socket,
+		readStaleGrace:  bootReadStaleGrace,
+		emptyTableGrace: bootEmptyTableGrace,
+		now:             time.Now,
+	}
+	h.lastNonEmpty.Store(h.now().UnixNano())
+	return h
+}
+
+// check returns a reason when discovery looks broken, or nil when healthy.
+//
+// The socket-staleness check only applies while the routing table is populated:
+// discv5 revalidates those peers and should be reading their responses, so a
+// stale socket then means the read loop has wedged. An empty table generates no
+// such traffic, so staleness there is expected (cold start, or a quiet node with
+// no peers) and is judged only by the empty-table grace, which tolerates cold
+// start. lastNonEmpty is seeded at startup, so it catches both "never populated"
+// and "populated then emptied".
+//
+// One case slips past the fast path: a wedge present from boot. On restart discv5
+// loads seed nodes from the persistent enode DB straight into the table, so
+// AllNodes() can be >0 before the socket has been read once — and StaleFor stays
+// disarmed until that first read. Those seeds then fail revalidation and age out,
+// the table empties, and the empty-table grace trips instead. A runtime wedge
+// (socket drained, then stopped) is unaffected: a prior read has already armed
+// StaleFor.
+func (h *bootNodeHealth) check() error {
+	now := h.now()
+	if len(h.lister.AllNodes()) > 0 {
+		h.lastNonEmpty.Store(now.UnixNano())
+		if h.socket.StaleFor(h.readStaleGrace) {
+			return fmt.Errorf("discv5 socket not drained for >%s while routing table is populated", h.readStaleGrace)
+		}
+		return nil
+	}
+	if emptyFor := now.Sub(time.Unix(0, h.lastNonEmpty.Load())); emptyFor > h.emptyTableGrace {
+		return fmt.Errorf("discv5 routing table empty for >%s", h.emptyTableGrace)
+	}
+	return nil
+}
+
+func (h *bootNodeHealth) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		if err := h.check(); err != nil {
+			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}
+}

--- a/utils/boot_node/health.go
+++ b/utils/boot_node/health.go
@@ -1,12 +1,14 @@
 package bootnode
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"go.uber.org/zap"
 )
 
 const (
@@ -18,6 +20,10 @@ const (
 	// bootEmptyTableGrace tolerates cold start, when the table is briefly empty
 	// before the boot node discovers peers.
 	bootEmptyTableGrace = 10 * time.Minute
+
+	// bootHealthSamplePeriod is how often the routing table is sampled; health
+	// verdicts read the samples (see sample).
+	bootHealthSamplePeriod = time.Second
 )
 
 // nodeLister is the slice of discovery.Listener the health check needs.
@@ -25,71 +31,125 @@ type nodeLister interface {
 	AllNodes() []*enode.Node
 }
 
-// socketDrainState reports socket-read staleness; satisfied by *discovery.TimedConn.
+// socketDrainState reports how long the discv5 socket has gone unread and
+// whether it has ever been read; satisfied by *discovery.TimedConn.
 type socketDrainState interface {
-	StaleFor(time.Duration) bool
+	ReadStaleness() (time.Duration, bool)
 }
 
-// bootNodeHealth backs /healthz. A boot node's whole job is discovery, so it's
-// broken if its socket has wedged or its routing table has been empty past cold
-// start; either fails /healthz closed so a liveness probe restarts the pod.
+// bootNodeHealth backs /healthz. A boot node's whole job is discovery, so it is
+// broken when its socket has wedged or its routing table has been empty past
+// cold start; both fail /healthz closed so a liveness probe restarts the pod.
+// The one deliberate exception — an empty table while the socket is demonstrably
+// drained — is logged instead: see check.
 type bootNodeHealth struct {
+	logger          *zap.Logger
 	lister          nodeLister
 	socket          socketDrainState
 	readStaleGrace  time.Duration
 	emptyTableGrace time.Duration
+	samplePeriod    time.Duration
 	now             func() time.Time
-	lastNonEmpty    atomic.Int64 // unix nanos of the last observation with a non-empty table
+
+	// Table state as of the last sample; written by sample, read by check.
+	tablePopulated atomic.Bool
+	lastNonEmpty   atomic.Int64 // unix nanos of the last sample with a non-empty table
 }
 
-func newBootNodeHealth(lister nodeLister, socket socketDrainState) *bootNodeHealth {
+func newBootNodeHealth(logger *zap.Logger, lister nodeLister, socket socketDrainState) *bootNodeHealth {
 	h := &bootNodeHealth{
+		logger:          logger,
 		lister:          lister,
 		socket:          socket,
 		readStaleGrace:  bootReadStaleGrace,
 		emptyTableGrace: bootEmptyTableGrace,
+		samplePeriod:    bootHealthSamplePeriod,
 		now:             time.Now,
 	}
 	h.lastNonEmpty.Store(h.now().UnixNano())
 	return h
 }
 
+// start launches the table sampler; it stops when ctx is canceled.
+func (h *bootNodeHealth) start(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(h.samplePeriod)
+		defer ticker.Stop()
+		h.sample()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				h.sample()
+			}
+		}
+	}()
+}
+
+// sample records whether the routing table is currently populated. It is the
+// only place the table is consulted (AllNodes takes the discv5 table mutex and
+// allocates), keeping /healthz requests cheap and the empty-table clock
+// probe-independent: the clock advances with the table, not with whatever probe
+// cadence the endpoint happens to see.
+func (h *bootNodeHealth) sample() {
+	populated := len(h.lister.AllNodes()) > 0
+	h.tablePopulated.Store(populated)
+	if populated {
+		h.lastNonEmpty.Store(h.now().UnixNano())
+	}
+}
+
 // check returns a reason when discovery looks broken, or nil when healthy.
 //
-// The socket-staleness check only applies while the routing table is populated:
-// discv5 revalidates those peers and should be reading their responses, so a
-// stale socket then means the read loop has wedged. An empty table generates no
-// such traffic, so staleness there is expected (cold start, or a quiet node with
-// no peers) and is judged only by the empty-table grace, which tolerates cold
-// start. lastNonEmpty is seeded at startup, so it catches both "never populated"
-// and "populated then emptied".
+// Socket staleness only counts while the routing table is populated: discv5
+// revalidates those peers and should be reading their responses, so a stale
+// socket then means the read loop has wedged. An empty table generates no such
+// traffic, so staleness there is expected (cold start, or a quiet node).
 //
-// One case slips past the fast path: a wedge present from boot. On restart discv5
-// loads seed nodes from the persistent enode DB straight into the table, so
-// AllNodes() can be >0 before the socket has been read once — and StaleFor stays
-// disarmed until that first read. Those seeds then fail revalidation and age out,
-// the table empties, and the empty-table grace trips instead. A runtime wedge
-// (socket drained, then stopped) is unaffected: a prior read has already armed
-// StaleFor.
+// An empty table past the grace is judged by the socket:
+//   - undrained (never read, or read then gone stale): fail closed — nothing
+//     arrives or the read path is dead, and a restart may recover it. This is
+//     the definitional boot-node failure (#2979).
+//   - actively drained: healthy, with an error log — packets arrive and are
+//     read, yet nothing completes a handshake into the table. That is a
+//     config/compatibility mismatch (e.g. DiscoveryProtocolID) a restart cannot
+//     fix; failing would crash-loop the pod and take /p2p down with it.
+//
+// Accepted blind spot: a table populated from persistent-DB seeds while the
+// socket has never been read. Normally revalidation ages such seeds out (its
+// pings time out, failed peers are dropped), emptying the table so the rules
+// above take over — but a dispatch loop wedged before the first socket read
+// stalls revalidation with the seeds in place, and this check stays green.
+// That takes a from-boot dispatch wedge with zero packets ever read (a single
+// read arms the staleness check); no known cause since #2980.
 func (h *bootNodeHealth) check() error {
-	now := h.now()
-	if len(h.lister.AllNodes()) > 0 {
-		h.lastNonEmpty.Store(now.UnixNano())
-		if h.socket.StaleFor(h.readStaleGrace) {
+	if h.tablePopulated.Load() {
+		if age, everRead := h.socket.ReadStaleness(); everRead && age > h.readStaleGrace {
 			return fmt.Errorf("discv5 socket not drained for >%s while routing table is populated", h.readStaleGrace)
 		}
 		return nil
 	}
-	if emptyFor := now.Sub(time.Unix(0, h.lastNonEmpty.Load())); emptyFor > h.emptyTableGrace {
-		return fmt.Errorf("discv5 routing table empty for >%s", h.emptyTableGrace)
+	emptyFor := h.now().Sub(time.Unix(0, h.lastNonEmpty.Load()))
+	if emptyFor <= h.emptyTableGrace {
+		return nil
 	}
-	return nil
+	if age, everRead := h.socket.ReadStaleness(); everRead && age <= h.readStaleGrace {
+		h.logger.Error("discv5 routing table empty past grace while socket is drained: a restart cannot fix this, check DiscoveryProtocolID/network config against the fleet",
+			zap.Duration("empty_for", emptyFor), zap.Duration("read_age", age))
+		return nil
+	}
+	return fmt.Errorf("discv5 routing table empty for >%s and socket undrained", h.emptyTableGrace)
 }
 
+// handler serves /healthz. The endpoint is reachable on the ENR-advertised TCP
+// port, so it stays cheap and opaque: sampled state only, and a fixed body —
+// the reason is logged, not disclosed.
 func (h *bootNodeHealth) handler() http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		if err := h.check(); err != nil {
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			h.logger.Warn("healthz check failed", zap.Error(err))
+			http.Error(w, "unhealthy", http.StatusServiceUnavailable)
 			return
 		}
 		_, _ = w.Write([]byte("ok"))

--- a/utils/boot_node/health_test.go
+++ b/utils/boot_node/health_test.go
@@ -3,30 +3,46 @@ package bootnode
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 type fakeLister struct{ count int }
 
 func (f fakeLister) AllNodes() []*enode.Node { return make([]*enode.Node, f.count) }
 
-type fakeSocket struct{ stale bool }
+type fakeSocket struct {
+	age      time.Duration
+	everRead bool
+}
 
-func (f fakeSocket) StaleFor(time.Duration) bool { return f.stale }
+func (f fakeSocket) ReadStaleness() (time.Duration, bool) { return f.age, f.everRead }
+
+// Common socket states.
+var (
+	freshSocket     = fakeSocket{age: time.Second, everRead: true}
+	staleSocket     = fakeSocket{age: bootReadStaleGrace + time.Minute, everRead: true}
+	neverReadSocket = fakeSocket{everRead: false}
+)
 
 func newTestHealth(lister nodeLister, socket socketDrainState, now func() time.Time) *bootNodeHealth {
 	h := &bootNodeHealth{
+		logger:          zap.NewNop(),
 		lister:          lister,
 		socket:          socket,
 		readStaleGrace:  bootReadStaleGrace,
 		emptyTableGrace: bootEmptyTableGrace,
+		samplePeriod:    bootHealthSamplePeriod,
 		now:             now,
 	}
 	h.lastNonEmpty.Store(now().UnixNano())
+	h.sample()
 	return h
 }
 
@@ -35,51 +51,141 @@ func TestBootNodeHealth_Check(t *testing.T) {
 	fixed := func() time.Time { return base }
 
 	// Populated table + fresh socket → healthy.
-	require.NoError(t, newTestHealth(fakeLister{count: 5}, fakeSocket{stale: false}, fixed).check())
+	require.NoError(t, newTestHealth(fakeLister{count: 5}, freshSocket, fixed).check())
 
 	// Populated table + stale socket → wedged (discv5 should be revalidating those
 	// peers and reading responses, but isn't).
 	require.ErrorContains(t,
-		newTestHealth(fakeLister{count: 5}, fakeSocket{stale: true}, fixed).check(),
+		newTestHealth(fakeLister{count: 5}, staleSocket, fixed).check(),
 		"socket not drained")
 
-	// Empty table + stale socket, within cold-start grace → healthy: a quiet node
-	// with no peers produces no reads, so staleness must not flag it (regression
-	// for the "quiet socket looks wedged" false positive).
+	// Empty table + never-read socket, within cold-start grace → healthy: a quiet
+	// node with no peers produces no reads, so staleness must not flag it
+	// (regression for the "quiet socket looks wedged" false positive).
 	require.NoError(t,
-		newTestHealth(fakeLister{count: 0}, fakeSocket{stale: true}, fixed).check(),
+		newTestHealth(fakeLister{count: 0}, neverReadSocket, fixed).check(),
 		"empty/quiet table must not trip the socket-staleness check")
 
-	// Empty table but still within cold-start grace → healthy; once it stays
-	// empty past the grace → unhealthy.
+	// Empty table within cold-start grace → healthy; once it stays empty past the
+	// grace with nothing arriving on the socket → unhealthy.
 	now := base
-	h := newTestHealth(fakeLister{count: 0}, fakeSocket{stale: false}, func() time.Time { return now })
+	h := newTestHealth(fakeLister{count: 0}, neverReadSocket, func() time.Time { return now })
 	require.NoError(t, h.check(), "empty table within cold-start grace is tolerated")
 	now = base.Add(bootEmptyTableGrace + time.Minute)
 	require.ErrorContains(t, h.check(), "routing table empty")
 
-	// A non-empty observation resets the empty-table clock, so a brief later
-	// emptiness is tolerated again.
+	// Same, but the socket was read once and then went stale: still unhealthy —
+	// a dead read path plus an empty table is the definitional failure.
 	now = base
-	h = newTestHealth(fakeLister{count: 3}, fakeSocket{stale: false}, func() time.Time { return now })
-	now = base.Add(bootEmptyTableGrace + time.Minute) // long after, but table is non-empty here
-	require.NoError(t, h.check(), "a non-empty table refreshes the clock")
-	h.lister = fakeLister{count: 0} // now empties, but only briefly
-	now = now.Add(time.Minute)
-	require.NoError(t, h.check(), "just-emptied table is within grace of the last non-empty observation")
+	h = newTestHealth(fakeLister{count: 0}, staleSocket, func() time.Time { return now })
+	now = base.Add(bootEmptyTableGrace + time.Minute)
+	require.ErrorContains(t, h.check(), "socket undrained")
 }
+
+// TestBootNodeHealth_EmptyTableButDrained: empty past grace with a drained
+// socket is a config mismatch a restart cannot fix, so /healthz must stay
+// healthy — and must log, since that log is the only signal left.
+func TestBootNodeHealth_EmptyTableButDrained(t *testing.T) {
+	base := time.Now()
+	now := base
+	h := newTestHealth(fakeLister{count: 0}, freshSocket, func() time.Time { return now })
+
+	core, logs := observer.New(zap.ErrorLevel)
+	h.logger = zap.New(core)
+
+	now = base.Add(bootEmptyTableGrace + time.Minute)
+	require.NoError(t, h.check(), "empty-but-drained is not restart-fixable, must stay healthy")
+	require.Equal(t, 1, logs.FilterMessageSnippet("restart cannot fix").Len(),
+		"the error log is the only signal in this state")
+}
+
+// TestBootNodeHealth_ClockIsSampleDriven: the empty-table clock follows the
+// sampler, not probe arrivals — a long probe-free stretch with a populated
+// table must not become an instant past-grace verdict when the table empties
+// and the next probe lands (the old probe-driven clock failed exactly here).
+func TestBootNodeHealth_ClockIsSampleDriven(t *testing.T) {
+	base := time.Now()
+	now := base
+	h := newTestHealth(fakeLister{count: 3}, neverReadSocket, func() time.Time { return now })
+
+	// Sampler keeps running with no probes at all; last populated sample is late.
+	now = base.Add(3 * bootEmptyTableGrace)
+	h.sample()
+
+	// Table empties; the first probe arrives a minute later.
+	h.lister = fakeLister{count: 0}
+	now = now.Add(30 * time.Second)
+	h.sample()
+	now = now.Add(30 * time.Second)
+	require.NoError(t, h.check(), "emptiness is measured from the last populated sample, not the last probe")
+
+	// And once genuinely empty past the grace, it still trips.
+	now = now.Add(bootEmptyTableGrace)
+	h.sample()
+	require.ErrorContains(t, h.check(), "routing table empty")
+}
+
+// TestBootNodeHealth_CheckReadsSamplesOnly: check must never consult the table
+// directly — a probe observes the sampled state (and so stays cheap on the
+// public port).
+func TestBootNodeHealth_CheckReadsSamplesOnly(t *testing.T) {
+	base := time.Now()
+	now := base
+	h := newTestHealth(fakeLister{count: 3}, freshSocket, func() time.Time { return now })
+
+	// The table empties, but no sample has run since: the verdict must still
+	// reflect the sampled (populated) state.
+	h.lister = fakeLister{count: 0}
+	now = base.Add(bootEmptyTableGrace + time.Minute)
+	require.NoError(t, h.check(), "check must read sampled state, not the live table")
+}
+
+// TestBootNodeHealth_Sampler: start's ticker goroutine keeps the sampled state
+// current until the context is canceled.
+func TestBootNodeHealth_Sampler(t *testing.T) {
+	lister := &atomicLister{}
+	lister.count.Store(2)
+	h := newTestHealth(fakeLister{count: 0}, freshSocket, time.Now)
+	h.lister = lister
+	h.samplePeriod = 5 * time.Millisecond
+
+	h.start(t.Context())
+	require.Eventually(t, h.tablePopulated.Load, 2*time.Second, 5*time.Millisecond)
+
+	lister.count.Store(0)
+	require.Eventually(t, func() bool { return !h.tablePopulated.Load() }, 2*time.Second, 5*time.Millisecond)
+}
+
+// atomicLister lets the sampler goroutine and the test mutate/read the node
+// count without a data race.
+type atomicLister struct{ count atomic.Int64 }
+
+func (l *atomicLister) AllNodes() []*enode.Node { return make([]*enode.Node, l.count.Load()) }
 
 func TestBootNodeHealth_Handler(t *testing.T) {
 	base := time.Now()
 	fixed := func() time.Time { return base }
 
 	rr := httptest.NewRecorder()
-	newTestHealth(fakeLister{count: 5}, fakeSocket{stale: false}, fixed).
+	newTestHealth(fakeLister{count: 5}, freshSocket, fixed).
 		handler()(rr, httptest.NewRequest(http.MethodGet, "/healthz", nil))
 	require.Equal(t, http.StatusOK, rr.Code)
 
+	// Unhealthy → 503 with a fixed, non-disclosing body (the reason is logged).
 	rr = httptest.NewRecorder()
-	newTestHealth(fakeLister{count: 5}, fakeSocket{stale: true}, fixed).
+	newTestHealth(fakeLister{count: 5}, staleSocket, fixed).
 		handler()(rr, httptest.NewRequest(http.MethodGet, "/healthz", nil))
 	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+	require.Equal(t, "unhealthy\n", rr.Body.String())
+
+	// The endpoints are read-only views: non-GET/HEAD is rejected before the
+	// handler runs, HEAD works (some probes use it).
+	h := newTestHealth(fakeLister{count: 5}, freshSocket, fixed)
+	rr = httptest.NewRecorder()
+	getOnly(h.handler())(rr, httptest.NewRequest(http.MethodPost, "/healthz", nil))
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+
+	rr = httptest.NewRecorder()
+	getOnly(h.handler())(rr, httptest.NewRequest(http.MethodHead, "/healthz", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
 }

--- a/utils/boot_node/health_test.go
+++ b/utils/boot_node/health_test.go
@@ -1,0 +1,85 @@
+package bootnode
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeLister struct{ count int }
+
+func (f fakeLister) AllNodes() []*enode.Node { return make([]*enode.Node, f.count) }
+
+type fakeSocket struct{ stale bool }
+
+func (f fakeSocket) StaleFor(time.Duration) bool { return f.stale }
+
+func newTestHealth(lister nodeLister, socket socketDrainState, now func() time.Time) *bootNodeHealth {
+	h := &bootNodeHealth{
+		lister:          lister,
+		socket:          socket,
+		readStaleGrace:  bootReadStaleGrace,
+		emptyTableGrace: bootEmptyTableGrace,
+		now:             now,
+	}
+	h.lastNonEmpty.Store(now().UnixNano())
+	return h
+}
+
+func TestBootNodeHealth_Check(t *testing.T) {
+	base := time.Now()
+	fixed := func() time.Time { return base }
+
+	// Populated table + fresh socket → healthy.
+	require.NoError(t, newTestHealth(fakeLister{count: 5}, fakeSocket{stale: false}, fixed).check())
+
+	// Populated table + stale socket → wedged (discv5 should be revalidating those
+	// peers and reading responses, but isn't).
+	require.ErrorContains(t,
+		newTestHealth(fakeLister{count: 5}, fakeSocket{stale: true}, fixed).check(),
+		"socket not drained")
+
+	// Empty table + stale socket, within cold-start grace → healthy: a quiet node
+	// with no peers produces no reads, so staleness must not flag it (regression
+	// for the "quiet socket looks wedged" false positive).
+	require.NoError(t,
+		newTestHealth(fakeLister{count: 0}, fakeSocket{stale: true}, fixed).check(),
+		"empty/quiet table must not trip the socket-staleness check")
+
+	// Empty table but still within cold-start grace → healthy; once it stays
+	// empty past the grace → unhealthy.
+	now := base
+	h := newTestHealth(fakeLister{count: 0}, fakeSocket{stale: false}, func() time.Time { return now })
+	require.NoError(t, h.check(), "empty table within cold-start grace is tolerated")
+	now = base.Add(bootEmptyTableGrace + time.Minute)
+	require.ErrorContains(t, h.check(), "routing table empty")
+
+	// A non-empty observation resets the empty-table clock, so a brief later
+	// emptiness is tolerated again.
+	now = base
+	h = newTestHealth(fakeLister{count: 3}, fakeSocket{stale: false}, func() time.Time { return now })
+	now = base.Add(bootEmptyTableGrace + time.Minute) // long after, but table is non-empty here
+	require.NoError(t, h.check(), "a non-empty table refreshes the clock")
+	h.lister = fakeLister{count: 0} // now empties, but only briefly
+	now = now.Add(time.Minute)
+	require.NoError(t, h.check(), "just-emptied table is within grace of the last non-empty observation")
+}
+
+func TestBootNodeHealth_Handler(t *testing.T) {
+	base := time.Now()
+	fixed := func() time.Time { return base }
+
+	rr := httptest.NewRecorder()
+	newTestHealth(fakeLister{count: 5}, fakeSocket{stale: false}, fixed).
+		handler()(rr, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	rr = httptest.NewRecorder()
+	newTestHealth(fakeLister{count: 5}, fakeSocket{stale: true}, fixed).
+		handler()(rr, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}

--- a/utils/boot_node/node.go
+++ b/utils/boot_node/node.go
@@ -106,13 +106,11 @@ func (n *bootNode) Start(ctx context.Context) error {
 	}
 
 	ipAddr, err := network.ExternalIP()
-	// ipAddr = "127.0.0.1"
-	n.logger.Info("TEST Ip addr----", zap.String("ip_addr", ipAddr))
 	if err != nil {
 		n.logger.Fatal("Failed to get ExternalIP", zap.Error(err))
 	}
 
-	listener := n.createListener(ipAddr, n.discv5port, privKey)
+	listener, socketConn := n.createListener(ipAddr, n.discv5port, privKey)
 	node := listener.LocalNode().Node()
 	n.logger.Info("Running",
 		zap.Stringer("node", node),
@@ -124,8 +122,10 @@ func (n *bootNode) Start(ctx context.Context) error {
 		logger:   n.logger,
 		listener: listener,
 	}
+	health := newBootNodeHealth(listener, socketConn)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/p2p", handler.httpHandler())
+	mux.HandleFunc("/healthz", health.handler())
 
 	const timeout = 3 * time.Second
 
@@ -143,7 +143,7 @@ func (n *bootNode) Start(ctx context.Context) error {
 	return nil
 }
 
-func (n *bootNode) createListener(ipAddr string, port uint16, privateKey *ecdsa.PrivateKey) discovery.Listener {
+func (n *bootNode) createListener(ipAddr string, port uint16, privateKey *ecdsa.PrivateKey) (discovery.Listener, *discovery.TimedConn) {
 	// Create the UDP listener and the LocalNode record.
 	ip := net.ParseIP(ipAddr)
 	if ip.To4() == nil {
@@ -169,20 +169,22 @@ func (n *bootNode) createListener(ipAddr string, port uint16, privateKey *ecdsa.
 	if err != nil {
 		n.logger.Fatal("Failed to create UDP server", zap.Error(err))
 	}
+	// Wrap the socket so /healthz can tell whether discv5 is still draining it.
+	socketConn := discovery.NewTimedConn(conn)
 	localNode, err := n.createLocalNode(privateKey, ip, port)
 	if err != nil {
 		n.logger.Fatal("Failed to create local node", zap.Error(err))
 	}
 
-	listener, err := discover.ListenV5(conn, localNode, discover.Config{
+	listener, err := discover.ListenV5(socketConn, localNode, discover.Config{
 		PrivateKey:   privateKey,
 		V5ProtocolID: &n.ssvConfig.DiscoveryProtocolID,
 	})
 	if err != nil {
-		n.logger.Fatal("Filed to create UDPv5 listener", zap.Error(err))
+		n.logger.Fatal("failed to create UDPv5 listener", zap.Error(err))
 	}
 
-	return listener
+	return listener, socketConn
 }
 
 func (n *bootNode) createLocalNode(privKey *ecdsa.PrivateKey, ipAddr net.IP, port uint16) (*enode.LocalNode, error) {

--- a/utils/boot_node/node.go
+++ b/utils/boot_node/node.go
@@ -77,12 +77,25 @@ type handler struct {
 	listener discovery.Listener
 }
 
+// getOnly rejects methods other than GET/HEAD: both endpoints are read-only
+// views served on the ENR-advertised TCP port.
+func getOnly(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", "GET, HEAD")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		next(w, r)
+	}
+}
+
 func (h *handler) httpHandler() func(w http.ResponseWriter, _ *http.Request) {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		write := func(w io.Writer, b []byte) {
 			if _, err := w.Write(b); err != nil {
-				h.logger.Error("Failed to write to http response", zap.Error(err))
+				h.logger.Error("failed to write to HTTP response", zap.Error(err))
 			}
 		}
 		allNodes := h.listener.AllNodes()
@@ -102,17 +115,17 @@ func (h *handler) httpHandler() func(w http.ResponseWriter, _ *http.Request) {
 func (n *bootNode) Start(ctx context.Context) error {
 	privKey, err := utils.ECDSAPrivateKey(n.logger, n.privateKey)
 	if err != nil {
-		n.logger.Fatal("Failed to get p2p privateKey", zap.Error(err))
+		n.logger.Fatal("failed to get p2p private key", zap.Error(err))
 	}
 
 	ipAddr, err := network.ExternalIP()
 	if err != nil {
-		n.logger.Fatal("Failed to get ExternalIP", zap.Error(err))
+		n.logger.Fatal("failed to get external IP", zap.Error(err))
 	}
 
 	listener, socketConn := n.createListener(ipAddr, n.discv5port, privKey)
 	node := listener.LocalNode().Node()
-	n.logger.Info("Running",
+	n.logger.Info("running",
 		zap.Stringer("node", node),
 		zap.Stringer("config", n.ssvConfig),
 		fields.ProtocolID(n.ssvConfig.DiscoveryProtocolID),
@@ -122,10 +135,11 @@ func (n *bootNode) Start(ctx context.Context) error {
 		logger:   n.logger,
 		listener: listener,
 	}
-	health := newBootNodeHealth(listener, socketConn)
+	health := newBootNodeHealth(n.logger, listener, socketConn)
+	health.start(ctx)
 	mux := http.NewServeMux()
-	mux.HandleFunc("/p2p", handler.httpHandler())
-	mux.HandleFunc("/healthz", health.handler())
+	mux.HandleFunc("/p2p", getOnly(handler.httpHandler()))
+	mux.HandleFunc("/healthz", getOnly(health.handler()))
 
 	const timeout = 3 * time.Second
 
@@ -137,7 +151,7 @@ func (n *bootNode) Start(ctx context.Context) error {
 	}
 
 	if err := httpServer.ListenAndServe(); err != nil {
-		n.logger.Fatal("Failed to start server", zap.Error(err))
+		n.logger.Fatal("failed to start server", zap.Error(err))
 	}
 
 	return nil
@@ -147,7 +161,7 @@ func (n *bootNode) createListener(ipAddr string, port uint16, privateKey *ecdsa.
 	// Create the UDP listener and the LocalNode record.
 	ip := net.ParseIP(ipAddr)
 	if ip.To4() == nil {
-		n.logger.Fatal("IPV4 address not provided", fields.Address(ipAddr))
+		n.logger.Fatal("IPv4 address not provided", fields.Address(ipAddr))
 	}
 	var bindIP net.IP
 	var networkVersion string
@@ -159,7 +173,7 @@ func (n *bootNode) createListener(ipAddr string, port uint16, privateKey *ecdsa.
 		bindIP = net.IPv4zero
 		networkVersion = "udp4"
 	default:
-		n.logger.Fatal("Valid ip address not provided", fields.Address(ipAddr))
+		n.logger.Fatal("valid IP address not provided", fields.Address(ipAddr))
 	}
 	udpAddr := &net.UDPAddr{
 		IP:   bindIP,
@@ -167,13 +181,13 @@ func (n *bootNode) createListener(ipAddr string, port uint16, privateKey *ecdsa.
 	}
 	conn, err := net.ListenUDP(networkVersion, udpAddr)
 	if err != nil {
-		n.logger.Fatal("Failed to create UDP server", zap.Error(err))
+		n.logger.Fatal("failed to create UDP server", zap.Error(err))
 	}
 	// Wrap the socket so /healthz can tell whether discv5 is still draining it.
 	socketConn := discovery.NewTimedConn(conn)
 	localNode, err := n.createLocalNode(privateKey, ip, port)
 	if err != nil {
-		n.logger.Fatal("Failed to create local node", zap.Error(err))
+		n.logger.Fatal("failed to create local node", zap.Error(err))
 	}
 
 	listener, err := discover.ListenV5(socketConn, localNode, discover.Config{
@@ -195,9 +209,9 @@ func (n *bootNode) createLocalNode(privKey *ecdsa.PrivateKey, ipAddr net.IP, por
 	external := net.ParseIP(n.externalIP)
 	if n.externalIP == "" {
 		external = ipAddr
-		n.logger.Info("Running with IP", zap.String("ip", ipAddr.String()))
+		n.logger.Info("running with IP", zap.String("ip", ipAddr.String()))
 	} else {
-		n.logger.Info("Running with External IP", zap.String("external_ip", n.externalIP))
+		n.logger.Info("running with external IP", zap.String("external_ip", n.externalIP))
 	}
 
 	localNode := enode.NewLocalNode(db, privKey)


### PR DESCRIPTION
## Problem

A discv5 socket can wedge — stay bound but stop being drained — leaving discovery silently dead while the process still looks healthy. #2979 documents a boot node that sat like this for ~20 days undetected. Neither node type surfaces it today: the operator's `p2pNetwork.Healthy()` only checks a discovery-*bootstrap* flag (a runtime wedge never trips it, since the bootstrap loop keeps running and just yields nothing), and the boot node's HTTP handler always returns `200`.

#2980 removes one *cause* of the wedge on the operator (the blocking `Unhandled` send); this PR adds the missing *detection*, so a wedge from any cause becomes a self-correcting restart.

## Approach

One shared, cause-agnostic signal — "how long since the discv5 socket was last read" — with actuation scoped per node type.

- **`TimedConn`** (`network/discovery`): wraps the socket and stamps the last successful read; `StaleFor(d)` is the wedge signal, armed only once the socket has been read at least once (a node that never had inbound UDP isn't wedged — a restart can't fix that). Both node types wrap the conn they hand to `ListenV5`. Read staleness is also exported as an async gauge (`ssv.p2p.discovery.socket.read_staleness`, sampled at scrape time; `-1` = never read).
- **Operator**: the post-fork listener (the one that drains the socket) gets the wrapped conn; `DiscoveryStale` feeds `p2pNetwork.Healthy()`, and the existing `hprobe` watchdog restarts the node on a wedge — but only while the connected-peer set is degraded (< 10 peers). Staleness alone can't distinguish a wedged read loop from inbound UDP lost upstream, which a restart can't fix; a well-connected node logs an error and stays up, tripping the probe later only if its peers erode. No routing-table check here — a stale-but-populated table would mask it on an operator.
- **Boot node**: a fail-closed `/healthz` returns non-200 when the socket has gone unread while the routing table is populated (discv5 revalidates its peers, so a populated-but-unread socket is a wedge), or when the table has been empty past a cold-start grace while the socket is undrained. Empty-table is the boot node's definitional health (the 0-vs-72/102 datapoint in #2979) — with one deliberate exception: an empty table while the socket is actively drained is a config/compatibility mismatch (e.g. `DiscoveryProtocolID`) a restart can't fix, so it stays 200 with a loud error log instead of crash-looping the pod. Table state is sampled by an owned 1s ticker (probe-independent empty-table clock, cheap requests); both HTTP endpoints are GET/HEAD-only and the 503 body is fixed, with the reason logged.

Grace values: 3 min read-staleness (both node types); 10 min empty-table cold-start and 1s table sampling (boot node); 10-peer floor gating the operator restart.

## Notes

- **Was stacked on #2980** (the operator change wraps the socket in `initDiscV5Listener`, which #2980 rewrote); #2980 has merged and this PR targets `stage` directly.
- Out of scope (dropped from #2979 as not worth the effort): boot-node `/debug/pprof`, and a second `sepolia` boot node.
- Infra follow-up (not code in this repo): the boot node has no pod-restarting probe today (only an AWS LB TCP check, which is blind to the wedge); a k8s `livenessProbe` on `/healthz` is added by the downstream PRs below.

## Tests

- `TimedConn`: seeded-not-stale, never-read-never-stale, stale boundary (injected clock, no real sleeps), read-stamps, errored-read-doesn't-stamp, gauge flattening (`-1` sentinel).
- Operator: `DiscoveryStale`; `TestP2PNetwork_Healthy` covers the wedge across peer-set states — degraded / nil-host / floor-boundary fail the probe, wedged-but-well-connected passes it (no restart loop on an external UDP fault) — plus `ready with live discovery`; the existing nil-`disc` cases stay green. `TestInitDiscV5Listener_WrapsPostForkConn` pins the wiring the detector rests on.
- Boot node: `/healthz` across populated+fresh, populated+wedged, empty-within-grace (incl. the quiet-socket regression), and empty-past-grace undrained (503) vs drained (200 + error log, asserted via a zap observer); the sampler clock is probe-independent and `check` reads samples only; method filter (405, HEAD ok) and fixed 503 body.

Closes #2979. Full discovery + p2p + boot_node suites pass, discovery also under `-race`.

## Downstream infra PRs for the boot-node side of this (what makes the boot node self-healing)

- ssvlabs/charts#183 — adds the optional `livenessProbe` to the `boot-node` chart (inert by default).
- ssvlabs/gitops-production#881 — adopts it on the three boot nodes (draft; blocked on a boot-node image from this PR that serves `/healthz`).

Merge order: #2980 → this → build image → ssvlabs/charts#183 → ssvlabs/gitops-production#881.

