### PR TITLE
cli/operator: log the Boole fork schedule at boot

### DIFF
--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -106,6 +106,16 @@ func buildNode(ctx context.Context, cfg *config, logger *zap.Logger) (*node, err
 		Beacon: consensusClient.BeaconConfig(),
 	}
 
+	// Log the Boole fork schedule at boot — the SSV-fork analog of the beacon-side "Gloas (ePBS)
+	// fork scheduled" log — so operators and tooling can read each node's epoch and cross-check
+	// agreement across the fleet. Unscheduled networks pin Forks.Boole to math.MaxUint64, surfaced
+	// at DEBUG to flag a net where Boole should be scheduled but isn't.
+	if networkConfig.BooleForkScheduled() {
+		logger.Info("boole fork scheduled", fields.Epoch(networkConfig.SSV.Forks.Boole))
+	} else {
+		logger.Debug("boole fork not scheduled")
+	}
+
 	var executionAddrList []string
 	for _, addr := range strings.Split(cfg.ExecutionClient.Addr, ";") {
 		if addr = strings.TrimSpace(addr); addr != "" {


### PR DESCRIPTION
Adds a single INFO line at operator boot — `Boole fork scheduled` with an `epoch` field — the SSV-fork analog of the beacon-side `Gloas (ePBS) fork scheduled` log. Operators and fleet tooling can then read each node's Boole epoch directly and cross-check agreement across the network, instead of inferring it from the first Boole topic subscription (which ssvlabs/aetheria#168's `(boole)` suite otherwise has to).

Networks with no Boole fork pin `Forks.Boole` to `math.MaxUint64` and log at DEBUG (`Boole fork not scheduled`) instead, flagging a misconfiguration on a net where Boole should be scheduled.

**Base:** `stage` — the Boole fork machinery isn't on `main` yet.

### Notes
- Epoch-only, mirroring the Gloas log: `fields.Epoch` emits the same `epoch` key, so tooling treats both forks uniformly. Domain types omitted — `setupSSVNetwork` already logs the full SSV config, so they'd be redundant here.
- Placed in `buildNode` (SSV-side), not `spec.go`: Boole is an SSV fork the beacon goclient doesn't know about. Uses the existing `BooleForkScheduled()` helper.
- No test — the Gloas analog has none, and exercising `buildNode` needs full CL/EL setup.

Closes #2984
