### PR TITLE
eth: verify registry-event completeness after optimistic historical sync (#2990)

### DIFF
--- a/cli/operator/eventsync.go
+++ b/cli/operator/eventsync.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/ssvlabs/ssv/eth/eventhandler"
 	"github.com/ssvlabs/ssv/eth/eventparser"
@@ -82,6 +83,14 @@ func syncContractEvents(
 		return eventSyncer, nil, nil
 	}
 
+	// If a previous run's background verification flagged a resync (or an earlier repair was
+	// interrupted), drop/keep registry state as appropriate and rebuild below with inline
+	// verification (verify=true).
+	resyncing, err := prepareRegistryResync(nodeStorage, logger)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	// Determine the block to resume contract sync from.
 	fromBlock, found, err := nodeStorage.GetLastProcessedBlock(nil)
 	if err != nil {
@@ -96,9 +105,15 @@ func syncContractEvents(
 		fromBlock = new(big.Int).SetUint64(fromBlock.Uint64() + 1)
 	}
 
-	// Sync historical registry events.
-	logger.Debug("syncing historical registry events", zap.Uint64("fromBlock", fromBlock.Uint64()))
-	lastProcessedBlock, err := eventSyncer.SyncHistory(ctx, fromBlock.Uint64())
+	// Decide whether to verify the historical sync inline. A restart catch-up small enough to
+	// bloom-check cheaply is verified inline, so the node starts with guaranteed-complete state;
+	// a large cold sync from the registry offset stays optimistic and is checked afterwards by
+	// the background verifier. The resync-repair path always verifies inline.
+	verify := resyncing || shouldVerifyCatchUpInline(ctx, executionClient, fromBlock.Uint64(), logger)
+
+	logger.Debug("syncing historical registry events",
+		zap.Uint64("fromBlock", fromBlock.Uint64()), zap.Bool("verify_inline", verify))
+	lastProcessedBlock, err := eventSyncer.SyncHistory(ctx, fromBlock.Uint64(), verify)
 	switch {
 	case errors.Is(err, executionclient.ErrNothingToSync):
 		// Nothing was synced, keep fromBlock as is.
@@ -114,6 +129,18 @@ func syncContractEvents(
 		fromBlock = new(big.Int).SetUint64(lastProcessedBlock + 1)
 	default:
 		return nil, nil, fmt.Errorf("failed to sync historical registry events: %w", err)
+	}
+
+	// The verified resync finished (we only reach here on success); clear both resync flags so the
+	// next start is a normal boot. Clearing them only now — after completion — is what lets an
+	// interrupted repair resume from the marker instead of restarting from scratch.
+	if resyncing {
+		if err := nodeStorage.ClearResyncRequired(nil); err != nil {
+			return nil, nil, fmt.Errorf("failed to clear resync-required flag: %w", err)
+		}
+		if err := nodeStorage.ClearResyncInProgress(nil); err != nil {
+			return nil, nil, fmt.Errorf("failed to clear resync-in-progress flag: %w", err)
+		}
 	}
 
 	// Print registry stats.
@@ -150,14 +177,117 @@ func syncContractEvents(
 	// cancellation returns nil; any other error is returned as a startupError carrying
 	// last_processed_block.
 	startOngoingSync := func(ctx context.Context) error {
-		if err := eventSyncer.SyncOngoing(ctx, fromBlock.Uint64()); err != nil && !errors.Is(err, context.Canceled) {
-			return startupError{
-				err:    fmt.Errorf("failed syncing ongoing registry events: %w", err),
-				fields: []zap.Field{zap.Uint64("last_processed_block", lastProcessedBlock)},
+		g, ctx := errgroup.WithContext(ctx)
+
+		// Verify any optimistically-synced ranges (large cold syncs) in the background, off the
+		// critical path, checking each block's recorded log digest against chain data. It runs
+		// concurrently with ongoing sync (below vs. above the last-processed marker) and retries
+		// transient failures in-process. If it finds the optimistic sync missed events it returns
+		// ErrResyncRequired: we surface that so the node terminates and restarts into the clean,
+		// inline-verified resync (the flag is already persisted).
+		g.Go(func() error {
+			err := eventSyncer.VerifyWithRetry(ctx)
+			switch {
+			case err == nil, errors.Is(err, context.Canceled):
+				return nil
+			case errors.Is(err, eventsyncer.ErrResyncRequired):
+				return startupError{
+					err:    err,
+					fields: []zap.Field{zap.Uint64("last_processed_block", lastProcessedBlock)},
+				}
+			default:
+				// VerifyWithRetry only returns nil, a context error, or ErrResyncRequired, so this
+				// is unexpected; log it and let the node keep running rather than crash.
+				logger.Error("background verification stopped unexpectedly", zap.Error(err))
+				return nil
 			}
-		}
-		return nil
+		})
+
+		g.Go(func() error {
+			if err := eventSyncer.SyncOngoing(ctx, fromBlock.Uint64()); err != nil && !errors.Is(err, context.Canceled) {
+				return startupError{
+					err:    fmt.Errorf("failed syncing ongoing registry events: %w", err),
+					fields: []zap.Field{zap.Uint64("last_processed_block", lastProcessedBlock)},
+				}
+			}
+			return nil
+		})
+
+		return g.Wait()
 	}
 
 	return eventSyncer, startOngoingSync, nil
+}
+
+// prepareRegistryResync decides whether the node should rebuild registry state with inline
+// verification, and gets storage ready for it. Registry events are order-dependent and carry
+// per-owner nonces, so they can't be patched in place — a full rebuild is the remedy.
+//
+// It handles two cases:
+//   - A resync was flagged (a background-verification miss) but not yet started: drop registry
+//     state and the stale verification journal, then mark the resync in progress. The drop
+//     happens before the mark, so a crash in between just re-drops and restarts cleanly.
+//   - A resync is already in progress (a previous repair was interrupted): do NOT drop again —
+//     everything synced so far was inline-verified, so resume from the last-processed marker.
+//
+// Either way it returns true (rebuild with verify=true). The flags are cleared by the caller
+// only once the resync completes, which is what makes an interrupted repair resumable.
+func prepareRegistryResync(nodeStorage operatorstorage.Storage, logger *zap.Logger) (bool, error) {
+	inProgress, err := nodeStorage.IsResyncInProgress(nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to check resync-in-progress flag: %w", err)
+	}
+	if inProgress {
+		logger.Warn("resuming an interrupted registry resync from the last processed block (its progress was inline-verified)")
+		return true, nil
+	}
+
+	required, err := nodeStorage.IsResyncRequired(nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to check resync-required flag: %w", err)
+	}
+	if !required {
+		return false, nil
+	}
+
+	logger.Warn("registry resync required: background verification previously found missing events; dropping registry state and resyncing from scratch with inline verification")
+	if err := nodeStorage.DropRegistryData(); err != nil {
+		return false, fmt.Errorf("failed to drop registry data for resync: %w", err)
+	}
+	if err := nodeStorage.DropVerificationJournal(); err != nil {
+		return false, fmt.Errorf("failed to drop verification journal for resync: %w", err)
+	}
+	if err := nodeStorage.SetResyncInProgress(nil); err != nil {
+		return false, fmt.Errorf("failed to mark resync in progress: %w", err)
+	}
+	return true, nil
+}
+
+// maxInlineVerifyCatchUp is the largest historical catch-up (in blocks) we bloom-check inline
+// on startup rather than syncing optimistically. Sized at roughly a week of mainnet blocks: it
+// covers all but the most prolonged restarts — which then start with guaranteed-complete state
+// instead of an optimistic window — while a cold sync from the registry offset stays optimistic
+// (background-verified) so a fresh node isn't blocked on it. Tunable.
+const maxInlineVerifyCatchUp = 50_000
+
+// shouldVerifyCatchUpInline reports whether the historical catch-up from fromBlock is small
+// enough to bloom-check inline (so the node starts with guaranteed-complete registry state)
+// rather than sync it optimistically and rely on the background verifier. On any error sizing
+// the range it returns false: optimistic is the safe, always-available default.
+func shouldVerifyCatchUpInline(ctx context.Context, ec executionclient.Provider, fromBlock uint64, logger *zap.Logger) bool {
+	head, err := ec.HeaderByNumber(ctx, nil)
+	if err != nil || head == nil || head.Number == nil {
+		logger.Debug("could not size historical catch-up; syncing optimistically", zap.Error(err))
+		return false
+	}
+
+	headBlock := head.Number.Uint64()
+	if headBlock < executionclient.FollowDistance {
+		return true // below the follow distance there is nothing to sync; inline is trivially cheap
+	}
+	toBlock := headBlock - executionclient.FollowDistance
+	if toBlock < fromBlock {
+		return true // nothing to sync
+	}
+	return toBlock-fromBlock+1 <= maxInlineVerifyCatchUp
 }

--- a/cli/operator/eventsync.go
+++ b/cli/operator/eventsync.go
@@ -86,7 +86,7 @@ func syncContractEvents(
 	// If a previous run's background verification flagged a resync (or an earlier repair was
 	// interrupted), drop/keep registry state as appropriate and rebuild below with inline
 	// verification (verify=true).
-	resyncing, err := prepareRegistryResync(nodeStorage, logger)
+	resyncing, err := prepareRegistryResync(logger, nodeStorage)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -109,7 +109,7 @@ func syncContractEvents(
 	// bloom-check cheaply is verified inline, so the node starts with guaranteed-complete state;
 	// a large cold sync from the registry offset stays optimistic and is checked afterwards by
 	// the background verifier. The resync-repair path always verifies inline.
-	verify := resyncing || shouldVerifyCatchUpInline(ctx, executionClient, fromBlock.Uint64(), logger)
+	verify := resyncing || shouldVerifyCatchUpInline(ctx, logger, executionClient, fromBlock.Uint64())
 
 	logger.Debug("syncing historical registry events",
 		zap.Uint64("fromBlock", fromBlock.Uint64()), zap.Bool("verify_inline", verify))
@@ -232,7 +232,7 @@ func syncContractEvents(
 //
 // Either way it returns true (rebuild with verify=true). The flags are cleared by the caller
 // only once the resync completes, which is what makes an interrupted repair resumable.
-func prepareRegistryResync(nodeStorage operatorstorage.Storage, logger *zap.Logger) (bool, error) {
+func prepareRegistryResync(logger *zap.Logger, nodeStorage operatorstorage.Storage) (bool, error) {
 	inProgress, err := nodeStorage.IsResyncInProgress(nil)
 	if err != nil {
 		return false, fmt.Errorf("failed to check resync-in-progress flag: %w", err)
@@ -274,7 +274,7 @@ const maxInlineVerifyCatchUp = 50_000
 // enough to bloom-check inline (so the node starts with guaranteed-complete registry state)
 // rather than sync it optimistically and rely on the background verifier. On any error sizing
 // the range it returns false: optimistic is the safe, always-available default.
-func shouldVerifyCatchUpInline(ctx context.Context, ec executionclient.Provider, fromBlock uint64, logger *zap.Logger) bool {
+func shouldVerifyCatchUpInline(ctx context.Context, logger *zap.Logger, ec executionclient.Provider, fromBlock uint64) bool {
 	head, err := ec.HeaderByNumber(ctx, nil)
 	if err != nil || head == nil || head.Number == nil {
 		logger.Debug("could not size historical catch-up; syncing optimistically", zap.Error(err))

--- a/cli/operator/eventsync_test.go
+++ b/cli/operator/eventsync_test.go
@@ -1,0 +1,158 @@
+package operator
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/ssvlabs/ssv/eth/executionclient"
+	"github.com/ssvlabs/ssv/networkconfig"
+	"github.com/ssvlabs/ssv/observability/log"
+	operatorstorage "github.com/ssvlabs/ssv/operator/storage"
+	kv "github.com/ssvlabs/ssv/storage/badger"
+	"github.com/ssvlabs/ssv/storage/basedb"
+)
+
+func newResyncTestStorage(t *testing.T) operatorstorage.Storage {
+	db, err := kv.NewInMemory(log.TestLogger(t), basedb.Options{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	ns, err := operatorstorage.NewNodeStorage(networkconfig.TestNetwork.Beacon, log.TestLogger(t), db)
+	require.NoError(t, err)
+	return ns
+}
+
+func TestPrepareRegistryResync_NoFlag(t *testing.T) {
+	ns := newResyncTestStorage(t)
+	require.NoError(t, ns.SaveLastProcessedBlock(nil, big.NewInt(123)))
+
+	resync, err := prepareRegistryResync(ns, log.TestLogger(t))
+	require.NoError(t, err)
+	require.False(t, resync)
+
+	// Without the flag set, nothing is dropped.
+	lpb, found, err := ns.GetLastProcessedBlock(nil)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, uint64(123), lpb.Uint64())
+}
+
+func TestPrepareRegistryResync_FlagSet(t *testing.T) {
+	ns := newResyncTestStorage(t)
+	require.NoError(t, ns.SaveLastProcessedBlock(nil, big.NewInt(123)))
+	require.NoError(t, ns.SaveUnverifiedRange(nil, operatorstorage.UnverifiedRange{From: 1, To: 9, Cursor: 1}))
+	require.NoError(t, ns.SaveBlockLogDigest(nil, 5, []byte("digest")))
+	require.NoError(t, ns.SetResyncRequired(nil))
+
+	resync, err := prepareRegistryResync(ns, log.TestLogger(t))
+	require.NoError(t, err)
+	require.True(t, resync)
+
+	// Registry marker and the verification journal are dropped for a clean rebuild...
+	_, found, err := ns.GetLastProcessedBlock(nil)
+	require.NoError(t, err)
+	require.False(t, found)
+
+	ranges, err := ns.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Empty(t, ranges)
+
+	_, digestFound, err := ns.GetBlockLogDigest(nil, 5)
+	require.NoError(t, err)
+	require.False(t, digestFound)
+
+	// ...the resync-required flag stays set until completion (cleared by the caller)...
+	stillSet, err := ns.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.True(t, stillSet)
+
+	// ...and the resync is now marked in progress, so an interruption resumes rather than re-drops.
+	inProgress, err := ns.IsResyncInProgress(nil)
+	require.NoError(t, err)
+	require.True(t, inProgress)
+}
+
+func TestPrepareRegistryResync_ResumesInProgress(t *testing.T) {
+	ns := newResyncTestStorage(t)
+	// A previous repair got interrupted: it dropped and rebuilt partway (marker at 500) and left
+	// the in-progress flag set. The resync must resume, NOT drop the partial progress.
+	require.NoError(t, ns.SaveLastProcessedBlock(nil, big.NewInt(500)))
+	require.NoError(t, ns.SetResyncRequired(nil))
+	require.NoError(t, ns.SetResyncInProgress(nil))
+
+	resync, err := prepareRegistryResync(ns, log.TestLogger(t))
+	require.NoError(t, err)
+	require.True(t, resync)
+
+	// The partial progress is preserved (not re-dropped) so the resync continues from the marker.
+	lpb, found, err := ns.GetLastProcessedBlock(nil)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, uint64(500), lpb.Uint64())
+}
+
+func TestShouldVerifyCatchUpInline(t *testing.T) {
+	const followDistance = executionclient.FollowDistance
+
+	tests := []struct {
+		name      string
+		fromBlock uint64
+		head      *big.Int // nil => HeaderByNumber errors
+		want      bool
+	}{
+		{
+			name:      "small catch-up verified inline",
+			fromBlock: 100,
+			head:      big.NewInt(100 + followDistance + 1_000), // ~1k blocks to sync
+			want:      true,
+		},
+		{
+			name:      "at the cap verified inline",
+			fromBlock: 100,
+			head:      big.NewInt(100 + followDistance + maxInlineVerifyCatchUp - 1), // exactly the cap
+			want:      true,
+		},
+		{
+			name:      "above the cap stays optimistic",
+			fromBlock: 100,
+			head:      big.NewInt(100 + followDistance + maxInlineVerifyCatchUp), // one over the cap
+			want:      false,
+		},
+		{
+			name:      "cold sync from offset stays optimistic",
+			fromBlock: 1,
+			head:      big.NewInt(10_000_000),
+			want:      false,
+		},
+		{
+			name:      "nothing to sync verifies (moot) rather than blocks",
+			fromBlock: 5_000,
+			head:      big.NewInt(1_000),
+			want:      true,
+		},
+		{
+			name:      "head fetch error falls back to optimistic",
+			fromBlock: 100,
+			head:      nil,
+			want:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ec := executionclient.NewMockProvider(gomock.NewController(t))
+			if tc.head == nil {
+				ec.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(nil, errors.New("boom"))
+			} else {
+				ec.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(&ethtypes.Header{Number: tc.head}, nil)
+			}
+
+			got := shouldVerifyCatchUpInline(t.Context(), ec, tc.fromBlock, log.TestLogger(t))
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/cli/operator/eventsync_test.go
+++ b/cli/operator/eventsync_test.go
@@ -30,7 +30,7 @@ func TestPrepareRegistryResync_NoFlag(t *testing.T) {
 	ns := newResyncTestStorage(t)
 	require.NoError(t, ns.SaveLastProcessedBlock(nil, big.NewInt(123)))
 
-	resync, err := prepareRegistryResync(ns, log.TestLogger(t))
+	resync, err := prepareRegistryResync(log.TestLogger(t), ns)
 	require.NoError(t, err)
 	require.False(t, resync)
 
@@ -48,7 +48,7 @@ func TestPrepareRegistryResync_FlagSet(t *testing.T) {
 	require.NoError(t, ns.SaveBlockLogDigest(nil, 5, []byte("digest")))
 	require.NoError(t, ns.SetResyncRequired(nil))
 
-	resync, err := prepareRegistryResync(ns, log.TestLogger(t))
+	resync, err := prepareRegistryResync(log.TestLogger(t), ns)
 	require.NoError(t, err)
 	require.True(t, resync)
 
@@ -84,7 +84,7 @@ func TestPrepareRegistryResync_ResumesInProgress(t *testing.T) {
 	require.NoError(t, ns.SetResyncRequired(nil))
 	require.NoError(t, ns.SetResyncInProgress(nil))
 
-	resync, err := prepareRegistryResync(ns, log.TestLogger(t))
+	resync, err := prepareRegistryResync(log.TestLogger(t), ns)
 	require.NoError(t, err)
 	require.True(t, resync)
 
@@ -151,7 +151,7 @@ func TestShouldVerifyCatchUpInline(t *testing.T) {
 				ec.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(&ethtypes.Header{Number: tc.head}, nil)
 			}
 
-			got := shouldVerifyCatchUpInline(t.Context(), ec, tc.fromBlock, log.TestLogger(t))
+			got := shouldVerifyCatchUpInline(t.Context(), log.TestLogger(t), ec, tc.fromBlock)
 			require.Equal(t, tc.want, got)
 		})
 	}

--- a/eth/ethtest/eth_e2e_test.go
+++ b/eth/ethtest/eth_e2e_test.go
@@ -106,8 +106,8 @@ func TestEthExecLayer(t *testing.T) {
 			valAddInput.produce()
 			testEnv.CloseFollowDistance(&blockNum)
 
-			// Run SyncHistory
-			lastHandledBlockNum, err = eventSyncer.SyncHistory(ctx, lastHandledBlockNum)
+			// Run SyncHistory (optimistic path, as on a normal node boot).
+			lastHandledBlockNum, err = eventSyncer.SyncHistory(ctx, lastHandledBlockNum, false)
 			require.NoError(t, err)
 
 			//check all the events were handled correctly and block number was increased

--- a/eth/eventhandler/event_handler.go
+++ b/eth/eventhandler/event_handler.go
@@ -102,16 +102,24 @@ func New(
 	return eh, nil
 }
 
+// HandleBlockEventsStream processes each block's events, advancing the last-processed marker.
+// A non-nil journalFrom marks an optimistic historical sync: in the same transaction that
+// advances the marker, it records a per-block digest of the logs received and extends an
+// unverified range [*journalFrom, block], so the background verifier can later confirm the
+// getLogs responses were complete — and a crash can't leave a processed block outside the range
+// it checks. Streaming and verified resyncs pass nil. (It's a pointer, not a sentinel value, so
+// block 0 — e.g. a RegistrySyncOffset of 0 — is journalled rather than silently skipped.)
 func (eh *EventHandler) HandleBlockEventsStream(
 	ctx context.Context,
 	logStreamCh <-chan executionclient.BlockLogs,
 	executeTasks bool,
+	journalFrom *uint64,
 ) (lastProcessedBlock uint64, progressed bool, err error) {
 	for blockLogs := range logStreamCh {
 		logger := eh.logger.With(fields.BlockNumber(blockLogs.BlockNumber))
 
 		start := time.Now()
-		tasks, err := eh.processBlockEvents(ctx, blockLogs)
+		tasks, err := eh.processBlockEvents(ctx, blockLogs, journalFrom)
 		if err != nil {
 			return lastProcessedBlock, progressed, fmt.Errorf("process block events: %w", err)
 		}
@@ -146,7 +154,7 @@ func (eh *EventHandler) HandleBlockEventsStream(
 	return lastProcessedBlock, progressed, nil
 }
 
-func (eh *EventHandler) processBlockEvents(ctx context.Context, block executionclient.BlockLogs) ([]Task, error) {
+func (eh *EventHandler) processBlockEvents(ctx context.Context, block executionclient.BlockLogs, journalFrom *uint64) ([]Task, error) {
 	txn := eh.nodeStorage.Begin()
 	defer txn.Discard()
 
@@ -182,6 +190,25 @@ func (eh *EventHandler) processBlockEvents(ctx context.Context, block executionc
 
 	if err := eh.nodeStorage.SaveLastProcessedBlock(txn, new(big.Int).SetUint64(block.BlockNumber)); err != nil {
 		return nil, fmt.Errorf("set last processed block: %w", err)
+	}
+
+	// For an optimistic sync, record the verifier's bookkeeping in this same transaction, so a
+	// crash can't advance the marker past a block the verifier won't later check (which would
+	// silently skip its events). The range [journalFrom, block] tells the verifier which blocks
+	// to check; the per-block digest lets it confirm the logs received there were complete. Only
+	// non-empty blocks get a digest — a block the verifier finds to have logs but no digest was
+	// missed entirely.
+	if journalFrom != nil {
+		if len(block.Logs) > 0 {
+			digest := executionclient.BlockLogsDigest(block.Logs)
+			if err := eh.nodeStorage.SaveBlockLogDigest(txn, block.BlockNumber, digest); err != nil {
+				return nil, fmt.Errorf("save block-log digest: %w", err)
+			}
+		}
+		r := nodestorage.UnverifiedRange{From: *journalFrom, To: block.BlockNumber, Cursor: *journalFrom}
+		if err := eh.nodeStorage.SaveUnverifiedRange(txn, r); err != nil {
+			return nil, fmt.Errorf("extend unverified range: %w", err)
+		}
 	}
 
 	if err := txn.Commit(); err != nil {

--- a/eth/eventhandler/event_handler_test.go
+++ b/eth/eventhandler/event_handler_test.go
@@ -205,7 +205,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		require.Equal(t, 0, len(operators))
 
 		// Handle the event
-		lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+		lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 		require.Equal(t, blockNum+1, lastProcessedBlock)
 		require.NoError(t, err)
 		blockNum++
@@ -320,7 +320,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			eventsCh <- block
 		}()
 
-		lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+		lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 		require.NoError(t, err)
 		require.Equal(t, blockNum+1, lastProcessedBlock)
 		blockNum++
@@ -370,7 +370,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			lastProcessedBlock, _, err = eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err = eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.NoError(t, err)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			blockNum++
@@ -419,7 +419,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			lastProcessedBlock, _, err = eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err = eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.NoError(t, err)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			blockNum++
@@ -473,7 +473,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			lastProcessedBlock, _, err = eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err = eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.NoError(t, err)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			blockNum++
@@ -522,7 +522,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			}()
 
 			validator3StampedFrom = netCfgVarEpoch.EstimatedCurrentSlot()
-			lastProcessedBlock, _, err = eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err = eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.NoError(t, err)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			blockNum++
@@ -572,7 +572,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			lastProcessedBlock, _, err = eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err = eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.NoError(t, err)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			blockNum++
@@ -614,7 +614,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			require.NoError(t, err)
 			blockNum++
@@ -640,7 +640,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			require.NoError(t, err)
 			blockNum++
@@ -679,7 +679,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			require.NoError(t, err)
 			blockNum++
@@ -723,7 +723,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			require.NoError(t, err)
 			blockNum++
@@ -760,7 +760,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			require.NoError(t, err)
 			blockNum++
@@ -805,7 +805,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			require.NoError(t, err)
 			blockNum++
@@ -854,7 +854,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		require.NotNil(t, share)
 		require.False(t, share.Liquidated)
 
-		lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+		lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 		require.Equal(t, blockNum+1, lastProcessedBlock)
 		require.NoError(t, err)
 		blockNum++
@@ -908,7 +908,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		netCfgVarEpoch.GenesisTime = time.Now().Add(-1000 * netCfgVarEpoch.SlotDuration)
 
 		stampedFrom := netCfgVarEpoch.EstimatedCurrentSlot()
-		lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+		lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 		require.Equal(t, blockNum+1, lastProcessedBlock)
 		require.NoError(t, err)
 		stampedTo := netCfgVarEpoch.EstimatedCurrentSlot()
@@ -954,7 +954,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			eventsCh <- block
 		}()
 
-		lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+		lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 		require.Equal(t, blockNum+1, lastProcessedBlock)
 		require.NoError(t, err)
 		blockNum++
@@ -996,7 +996,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 		require.True(t, share.Liquidated)
 		netCfgVarEpoch.GenesisTime = time.Now().Add(-100 * netCfgVarEpoch.SlotDuration)
 
-		lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+		lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 		require.Equal(t, blockNum+1, lastProcessedBlock)
 		require.NoError(t, err)
 
@@ -1040,7 +1040,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			eventsCh <- block
 		}()
 
-		lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+		lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 		require.Equal(t, blockNum+1, lastProcessedBlock)
 		require.NoError(t, err)
 		blockNum++
@@ -1090,7 +1090,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			}()
 
 			// Handle the event
-			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			require.NoError(t, err)
 			blockNum++
@@ -1166,7 +1166,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			require.NoError(t, err)
 			blockNum++
@@ -1229,7 +1229,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 				eventsCh <- block
 			}()
 
-			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			require.NoError(t, err)
 			blockNum++
@@ -1264,7 +1264,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.Equal(t, len(ops), len(operators))
 
 			// Handle the event
-			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			require.NoError(t, err)
 			blockNum++
@@ -1308,7 +1308,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.Equal(t, len(ops), len(operators))
 
 			// Handle OperatorAdded event
-			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			require.NoError(t, err)
 			blockNum++
@@ -1337,7 +1337,7 @@ func TestHandleBlockEventsStream(t *testing.T) {
 			require.Equal(t, len(ops)+1, len(operators))
 
 			// Handle OperatorRemoved event
-			lastProcessedBlock, _, err = eh.HandleBlockEventsStream(ctx, eventsCh, false)
+			lastProcessedBlock, _, err = eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 			require.Equal(t, blockNum+1, lastProcessedBlock)
 			require.NoError(t, err)
 			blockNum++
@@ -1375,7 +1375,7 @@ func TestHandleBlockEventsStreamReturnsErrInferiorBlock(t *testing.T) {
 		eventsCh <- executionclient.BlockLogs{BlockNumber: 9}
 	}()
 
-	lastProcessedBlock, progressed, err := eh.HandleBlockEventsStream(ctx, eventsCh, false)
+	lastProcessedBlock, progressed, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, nil)
 	require.ErrorIs(t, err, ErrInferiorBlock)
 	require.Zero(t, lastProcessedBlock)
 	require.False(t, progressed)
@@ -1384,6 +1384,126 @@ func TestHandleBlockEventsStreamReturnsErrInferiorBlock(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Equal(t, uint64(10), storedLastProcessedBlock.Uint64())
+}
+
+// TestHandleBlockEventsStreamRecordsDigests verifies the optimistic historical path (a non-nil
+// journalFrom) persists the verifier's bookkeeping: an unverified range spanning journalFrom..lastBlock,
+// and a per-block digest for each non-empty block (empty progression blocks get none — the
+// verifier reads their absence as "no logs there").
+func TestHandleBlockEventsStreamRecordsDigests(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	ops, err := createOperators(1, 0)
+	require.NoError(t, err)
+
+	eh, _, err := setupEventHandler(t, ctx, logger, networkconfig.TestNetwork, ops[0], false)
+	require.NoError(t, err)
+
+	// Unknown topics are fine: they parse to no task without error, and digesting is over each
+	// log's (TxIndex, Index) identity regardless of the event type.
+	withLogs := executionclient.BlockLogs{
+		BlockNumber: 10,
+		Logs: []ethtypes.Log{
+			{BlockNumber: 10, TxIndex: 0, Index: 0, Topics: []ethcommon.Hash{{0x1}}},
+			{BlockNumber: 10, TxIndex: 1, Index: 3, Topics: []ethcommon.Hash{{0x2}}},
+		},
+	}
+	empty := executionclient.BlockLogs{BlockNumber: 11}
+
+	eventsCh := make(chan executionclient.BlockLogs, 2)
+	eventsCh <- withLogs
+	eventsCh <- empty
+	close(eventsCh)
+
+	journalFrom := uint64(10)
+	lastProcessedBlock, progressed, err := eh.HandleBlockEventsStream(ctx, eventsCh, false, &journalFrom)
+	require.NoError(t, err)
+	require.True(t, progressed)
+	require.Equal(t, uint64(11), lastProcessedBlock)
+
+	// The unverified range spans journalFrom..last block, cursor at the start.
+	ranges, err := eh.nodeStorage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Equal(t, []operatorstorage.UnverifiedRange{{From: journalFrom, To: 11, Cursor: journalFrom}}, ranges)
+
+	got, found, err := eh.nodeStorage.GetBlockLogDigest(nil, 10)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, executionclient.BlockLogsDigest(withLogs.Logs), got)
+
+	_, found, err = eh.nodeStorage.GetBlockLogDigest(nil, 11)
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+// TestHandleBlockEventsStreamJournalsRangeOnFailure verifies the crash-atomicity property: the
+// unverified range is extended in the same transaction that advances the marker, so even when
+// the stream aborts mid-way the completed prefix is still journalled for verification (it can't
+// be silently skipped).
+func TestHandleBlockEventsStreamJournalsRangeOnFailure(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	ops, err := createOperators(1, 0)
+	require.NoError(t, err)
+
+	eh, _, err := setupEventHandler(t, ctx, logger, networkconfig.TestNetwork, ops[0], false)
+	require.NoError(t, err)
+
+	// Blocks 10 and 11 process fine; the second block 11 is inferior (<= marker) and aborts the
+	// stream with an error, standing in for a crash partway through.
+	eventsCh := make(chan executionclient.BlockLogs, 3)
+	eventsCh <- executionclient.BlockLogs{BlockNumber: 10}
+	eventsCh <- executionclient.BlockLogs{BlockNumber: 11}
+	eventsCh <- executionclient.BlockLogs{BlockNumber: 11}
+	close(eventsCh)
+
+	journalFrom := uint64(10)
+	_, _, err = eh.HandleBlockEventsStream(ctx, eventsCh, false, &journalFrom)
+	require.ErrorIs(t, err, ErrInferiorBlock)
+
+	// The range covers exactly the successfully-processed prefix [10, 11].
+	ranges, err := eh.nodeStorage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Equal(t, []operatorstorage.UnverifiedRange{{From: journalFrom, To: 11, Cursor: journalFrom}}, ranges)
+}
+
+// TestHandleBlockEventsStreamJournalsFromBlockZero verifies journalFrom is honored as a pointer,
+// not a 0-sentinel: an offset-0 sync (RegistrySyncOffset == 0) still journals rather than
+// silently disabling verification.
+func TestHandleBlockEventsStreamJournalsFromBlockZero(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	ops, err := createOperators(1, 0)
+	require.NoError(t, err)
+
+	eh, _, err := setupEventHandler(t, ctx, logger, networkconfig.TestNetwork, ops[0], false)
+	require.NoError(t, err)
+
+	eventsCh := make(chan executionclient.BlockLogs, 1)
+	eventsCh <- executionclient.BlockLogs{
+		BlockNumber: 5,
+		Logs:        []ethtypes.Log{{BlockNumber: 5, TxIndex: 0, Index: 0, Topics: []ethcommon.Hash{{0x1}}}},
+	}
+	close(eventsCh)
+
+	journalFrom := uint64(0)
+	_, _, err = eh.HandleBlockEventsStream(ctx, eventsCh, false, &journalFrom)
+	require.NoError(t, err)
+
+	// The range is journalled starting at block 0, and the block's digest is recorded.
+	ranges, err := eh.nodeStorage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Equal(t, []operatorstorage.UnverifiedRange{{From: 0, To: 5, Cursor: 0}}, ranges)
+
+	_, found, err := eh.nodeStorage.GetBlockLogDigest(nil, 5)
+	require.NoError(t, err)
+	require.True(t, found)
 }
 
 func setupEventHandler(

--- a/eth/eventhandler/task_executor_test.go
+++ b/eth/eventhandler/task_executor_test.go
@@ -141,7 +141,7 @@ func TestHandleBlockEventsStreamWithExecution(t *testing.T) {
 			}
 		}()
 
-		lastProcessedBlock, progressed, err := eh.HandleBlockEventsStream(ctx, eventsCh, true)
+		lastProcessedBlock, progressed, err := eh.HandleBlockEventsStream(ctx, eventsCh, true, nil)
 		require.NoError(t, err)
 		require.Equal(t, uint64(0x89EBFF), lastProcessedBlock)
 		require.True(t, progressed)

--- a/eth/eventsyncer/e2e_test.go
+++ b/eth/eventsyncer/e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"math/big"
 	"net/http"
@@ -13,10 +14,12 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
@@ -28,6 +31,8 @@ import (
 	"github.com/ssvlabs/ssv/ssvsigner/keys/rsaencryption"
 	kv "github.com/ssvlabs/ssv/storage/badger"
 	"github.com/ssvlabs/ssv/storage/basedb"
+	"github.com/ssvlabs/ssv/utils/blskeygen"
+	"github.com/ssvlabs/ssv/utils/threshold"
 )
 
 // These tests drive the real historical-sync + background-verification + repair pipeline
@@ -43,6 +48,7 @@ type dropProxy struct {
 	dropBlock           uint64
 	dropActive          atomic.Bool
 	receiptsUnavailable atomic.Bool
+	receiptsEmpty       atomic.Bool
 }
 
 type jsonrpcMsg struct {
@@ -74,6 +80,9 @@ func newDropProxy(t *testing.T, base http.Handler, dropBlock uint64) (*httptest.
 		case req.Method == "eth_getBlockReceipts" && p.receiptsUnavailable.Load():
 			// -32601 = method not found; makes the client treat receipts as unsupported.
 			return jsonrpcMsg{Version: "2.0", ID: req.ID, Error: json.RawMessage(`{"code":-32601,"message":"the method eth_getBlockReceipts does not exist"}`)}
+		case req.Method == "eth_getBlockReceipts" && p.receiptsEmpty.Load():
+			// A broken receipt store: zero receipts for a block the caller knows holds logs.
+			return jsonrpcMsg{Version: "2.0", ID: req.ID, Result: json.RawMessage(`[]`)}
 		case req.Method == "eth_getLogs" && p.dropActive.Load():
 			resp := forward(req)
 			resp.Result = dropBlockLogs(t, resp.Result, p.dropBlock)
@@ -274,4 +283,245 @@ func TestE2E_ParksWhenReceiptsUnavailable(t *testing.T) {
 	ranges, err := nodeStorage.ListUnverifiedRanges(nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, ranges, "range stays pending (parked), not retired as verified")
+}
+
+// TestE2E_EmptyReceiptsNotTreatedAsAuthoritative: when eth_getBlockReceipts returns zero receipts
+// for a block the sync recorded logs for, that's a broken receipt store, not proof the block is
+// empty — the verifier must park (no authoritative source), not treat it as a confirmed miss and
+// trigger a false wipe+resync.
+func TestE2E_EmptyReceiptsNotTreatedAsAuthoritative(t *testing.T) {
+	ctx := t.Context()
+	es, nodeStorage, proxy, _ := setupVerifyE2E(t, ctx, 3)
+
+	// Optimistic sync records all 3 operators (digests written).
+	_, err := es.SyncHistory(ctx, 0, false)
+	require.NoError(t, err)
+	require.Equal(t, 3, operatorCount(t, nodeStorage))
+
+	// The log index drops the middle block AND receipts come back empty (a broken receipt store):
+	// the verify-time fetch disagrees with the recorded digest, and receipts can't authoritatively
+	// resolve it.
+	proxy.dropActive.Store(true)
+	proxy.receiptsEmpty.Store(true)
+
+	require.NoError(t, es.Verify(ctx), "empty receipts must not be treated as an authoritative empty block")
+	resync, err := nodeStorage.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.False(t, resync, "an inconsistent empty-receipts response must not trigger a resync")
+	ranges, err := nodeStorage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, ranges, "range parked (no authoritative source), not retired or resynced")
+}
+
+// TestE2E_ParkedRangeResolvesWhenReceiptsReturn: a range parked because the receipt store was
+// transiently broken (returned empty) is re-checked and cleared once receipts come back. Unlike an
+// unsupported-method (-32601) park — which latches and only clears on restart — an empty-receipts
+// park doesn't latch, so a later Verify pass resolves it in-process. Here the recorded digest is
+// vindicated by the receipts (the drop was only in the log index), so the range retires with no resync.
+func TestE2E_ParkedRangeResolvesWhenReceiptsReturn(t *testing.T) {
+	ctx := t.Context()
+	es, nodeStorage, proxy, _ := setupVerifyE2E(t, ctx, 3)
+
+	// Optimistic sync records all 3 operators.
+	_, err := es.SyncHistory(ctx, 0, false)
+	require.NoError(t, err)
+	require.Equal(t, 3, operatorCount(t, nodeStorage))
+
+	// Log index drops the middle block and the receipt store returns empty → the disagreeing block
+	// can't be resolved authoritatively, so the range parks (without latching receipts unsupported).
+	proxy.dropActive.Store(true)
+	proxy.receiptsEmpty.Store(true)
+	require.NoError(t, es.Verify(ctx))
+	ranges, err := nodeStorage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, ranges, "range parked while the receipt store was broken")
+
+	// Receipts come back. The next Verify resolves the parked block against them; the recorded
+	// digest matches the receipts truth, so the range retires clean with no resync.
+	proxy.receiptsEmpty.Store(false)
+	require.NoError(t, es.Verify(ctx))
+	resync, err := nodeStorage.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.False(t, resync, "recorded digest vindicated by receipts → no resync")
+	ranges, err = nodeStorage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Empty(t, ranges, "parked range retired once receipts became available")
+}
+
+// setupClusterDriftE2E builds the drift scenario from the #2990 field report
+// (https://github.com/ssvlabs/ssv/issues/2990#issuecomment-5339378358), where a dropped block
+// window was found to lose every registry event type it contained, not just OperatorAdded.
+// It registers four operators — the node's own operator first, so the sync learns its ID and
+// treats the validator below as its own — then:
+//
+//   - a kept block: a valid ValidatorAdded for the four-operator cluster owned by testAddr
+//     (bumps the owner nonce to 1, stores the share, and adds it to the node's key manager);
+//   - the block the proxy will drop: a FeeRecipientAddressUpdated, a ClusterLiquidated for that
+//     cluster, and a second ValidatorAdded (deliberately malformed: the handler skips it but
+//     still bumps the owner nonce, which is how the field report's stale-nonce drift arises).
+//
+// It returns the syncer, storage, proxy (drop not yet active), the validator public key, and
+// the updated fee recipient.
+func setupClusterDriftE2E(t *testing.T, ctx context.Context) (*EventSyncer, operatorstorage.Storage, *dropProxy, []byte, ethcommon.Address) {
+	logger := zaptest.NewLogger(t)
+
+	sim := simTestBackend(testAddr)
+	rpcServer, err := sim.Node().RPCHandler()
+	require.NoError(t, err)
+	t.Cleanup(rpcServer.Stop)
+
+	parsed, err := abi.JSON(strings.NewReader(simcontract.SimcontractMetaData.ABI))
+	require.NoError(t, err)
+	auth, err := bind.NewKeyedTransactorWithChainID(testKey, big.NewInt(1337))
+	require.NoError(t, err)
+	contractAddr, _, _, err := bind.DeployContract(auth, parsed, ethcommon.FromHex(simcontract.SimcontractMetaData.Bin), sim.Client())
+	require.NoError(t, err)
+	sim.Commit()
+
+	boundContract, err := simcontract.NewSimcontract(contractAddr, sim.Client())
+	require.NoError(t, err)
+
+	// Four operators, one per block; index 0 is the node's own key, so the sync assigns the node
+	// operator ID 1 and the validator below decrypts as its own share.
+	opKeys := make([]keys.OperatorPrivateKey, 4)
+	for i := range opKeys {
+		opKeys[i], err = keys.GeneratePrivateKey()
+		require.NoError(t, err)
+		pubKey, err := opKeys[i].Public().Base64()
+		require.NoError(t, err)
+		packed, err := eventparser.PackOperatorPublicKey(pubKey)
+		require.NoError(t, err)
+		_, err = boundContract.RegisterOperator(auth, packed, big.NewInt(100_000_000))
+		require.NoError(t, err)
+		sim.Commit()
+	}
+
+	// A valid validator for cluster {1,2,3,4}: a real BLS master key split into four shares, each
+	// encrypted to its operator, with the owner-nonce signature the handler verifies (nonce 0 —
+	// the owner's first registration).
+	threshold.Init()
+	masterSK, masterPK := blskeygen.GenBLSKeyPair()
+	shareKeys, err := threshold.Create(masterSK.Serialize(), 3, 4)
+	require.NoError(t, err)
+
+	operatorIDs := []uint64{1, 2, 3, 4}
+	sharePubKeys := make([]byte, 0, len(opKeys)*phase0.PublicKeyLength)
+	encryptedShares := make([]byte, 0, len(opKeys)*256)
+	for i, opKey := range opKeys {
+		shareSK := shareKeys[uint64(i+1)]
+		cipher, err := opKey.Public().Encrypt([]byte(shareSK.SerializeToHexStr()))
+		require.NoError(t, err)
+		sharePubKeys = append(sharePubKeys, shareSK.GetPublicKey().Serialize()...)
+		encryptedShares = append(encryptedShares, cipher...)
+	}
+	ownerNonceHash := crypto.Keccak256([]byte(fmt.Sprintf("%s:%d", testAddr.String(), 0)))
+	sharesData := masterSK.SignByte(ownerNonceHash).Serialize()
+	sharesData = append(sharesData, sharePubKeys...)
+	sharesData = append(sharesData, encryptedShares...)
+
+	cluster := simcontract.CallableCluster{
+		ValidatorCount:  1,
+		NetworkFeeIndex: 1,
+		Index:           1,
+		Active:          true,
+		Balance:         big.NewInt(100_000_000),
+	}
+	_, err = boundContract.RegisterValidator(auth, masterPK.Serialize(), operatorIDs, sharesData, big.NewInt(100_000_000), cluster)
+	require.NoError(t, err)
+	sim.Commit()
+
+	// The to-be-dropped block: three registry events of different types in one block.
+	updatedRecipient := ethcommon.HexToAddress("0x1111111111111111111111111111111111111111")
+	_, err = boundContract.SetFeeRecipientAddress(auth, updatedRecipient)
+	require.NoError(t, err)
+	_, err = boundContract.Liquidate(auth, testAddr, operatorIDs, cluster)
+	require.NoError(t, err)
+	// Deliberately malformed (wrong shares length): the handler skips it as malformed but still
+	// bumps the owner nonce, so dropping this block leaves a stale nonce behind.
+	_, err = boundContract.RegisterValidator(auth, bytes.Repeat([]byte{0xaa}, 48), operatorIDs, []byte("malformed"), big.NewInt(100_000_000), cluster)
+	require.NoError(t, err)
+	sim.Commit()
+	dropBlock, err := sim.Client().BlockNumber(ctx)
+	require.NoError(t, err)
+
+	// Pad past the follow distance so the dropped block is within the historical window.
+	for i := 0; i < executionclient.FollowDistance+2; i++ {
+		sim.Commit()
+	}
+
+	proxyURL, proxy := newDropProxy(t, rpcServer, dropBlock)
+
+	db, err := kv.NewInMemory(logger, basedb.Options{Ctx: ctx})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	nodeStorage, operatorData := setupOperatorStorage(logger, db, opKeys[0])
+	eh := setupEventHandler(t, ctx, logger, db, nodeStorage, operatorData, opKeys[0])
+
+	execClient, err := executionclient.New(ctx, proxyURL.URL, contractAddr, executionclient.WithLogger(logger))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = execClient.Close() })
+	require.NoError(t, execClient.Healthy(ctx))
+
+	es := New(nodeStorage, execClient, eh, WithLogger(logger))
+	es.verifyChunkDelay = 0
+
+	return es, nodeStorage, proxy, masterPK.Serialize(), updatedRecipient
+}
+
+// TestE2E_DriftBeyondOperatorsRepaired pins the full blast radius documented in the #2990 field
+// report: a dropped block loses whatever registry events it contained — here a fee-recipient
+// update, a cluster liquidation, and an owner-nonce bump — and the detect→repair loop restores
+// all of them. The validator belongs to the node's own operator, so the verified resync also
+// replays ValidatorAdded against a key manager that still holds the share account (the repair
+// drops registry state, never signer state) — pinning that AddShare tolerates the replay.
+func TestE2E_DriftBeyondOperatorsRepaired(t *testing.T) {
+	ctx := t.Context()
+	es, nodeStorage, proxy, validatorPK, updatedRecipient := setupClusterDriftE2E(t, ctx)
+	proxy.dropActive.Store(true) // persistently drop the fee-recipient/liquidation/nonce block
+
+	// Optimistic sync: the dropped block's three events are silently missing, so the node runs on
+	// drifted state — stale nonce, unliquidated share, default fee recipient — as in the field report.
+	_, err := es.SyncHistory(ctx, 0, false)
+	require.NoError(t, err)
+	require.Equal(t, 4, operatorCount(t, nodeStorage))
+
+	share, found := nodeStorage.Shares().Get(nil, validatorPK)
+	require.True(t, found, "the validator from the kept block must be stored")
+	require.True(t, share.BelongsToOperator(1), "the node is operator 1, so this is its own share")
+	require.False(t, share.Liquidated, "drift: the ClusterLiquidated was silently missed")
+
+	// The kept registration's nonce bump created the default recipient record (feeRecipient ==
+	// owner); the dropped update never moved it off the default — the field report's exact drift.
+	recipient, err := nodeStorage.GetFeeRecipient(testAddr)
+	require.NoError(t, err)
+	require.Equal(t, testAddr.Bytes(), recipient[:], "drift: the FeeRecipientAddressUpdated was silently missed, recipient is still the owner default")
+
+	nonce, err := nodeStorage.GetNextNonce(nil, testAddr)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, nonce, "drift: the dropped registration's nonce bump was silently missed")
+
+	// The background verifier recovers the block from receipts and flags the repair.
+	require.ErrorIs(t, es.Verify(ctx), ErrResyncRequired)
+
+	// Repair as the boot path does: drop registry state + journal (never the key manager) and
+	// resync with inline verification, which recovers the dropped block from receipts.
+	require.NoError(t, nodeStorage.DropRegistryData())
+	require.NoError(t, nodeStorage.DropVerificationJournal())
+	_, err = es.SyncHistory(ctx, 0, true)
+	require.NoError(t, err, "the resync must tolerate replaying ValidatorAdded over the existing share account")
+
+	// Every drifted class converges to canonical state.
+	share, found = nodeStorage.Shares().Get(nil, validatorPK)
+	require.True(t, found)
+	require.True(t, share.Liquidated, "repair restored the missed liquidation")
+
+	recipient, err = nodeStorage.GetFeeRecipient(testAddr)
+	require.NoError(t, err)
+	require.Equal(t, updatedRecipient.Bytes(), recipient[:], "repair restored the missed fee-recipient update")
+
+	nonce, err = nodeStorage.GetNextNonce(nil, testAddr)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, nonce, "repair restored the missed nonce bump")
+
+	require.NoError(t, es.Verify(ctx), "a fresh verification pass over the verified resync is clean")
 }

--- a/eth/eventsyncer/e2e_test.go
+++ b/eth/eventsyncer/e2e_test.go
@@ -1,0 +1,277 @@
+package eventsyncer
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/ssvlabs/ssv/eth/eventparser"
+	"github.com/ssvlabs/ssv/eth/executionclient"
+	"github.com/ssvlabs/ssv/eth/simulator/simcontract"
+	operatorstorage "github.com/ssvlabs/ssv/operator/storage"
+	"github.com/ssvlabs/ssv/ssvsigner/keys"
+	"github.com/ssvlabs/ssv/ssvsigner/keys/rsaencryption"
+	kv "github.com/ssvlabs/ssv/storage/badger"
+	"github.com/ssvlabs/ssv/storage/basedb"
+)
+
+// These tests drive the real historical-sync + background-verification + repair pipeline
+// (ExecutionClient → EventSyncer → EventHandler → BadgerDB) against a real go-ethereum RPC stack
+// (the simulated backend), with an HTTP JSON-RPC proxy in front that induces the exact #2990
+// failure — an incomplete eth_getLogs response — so we can watch the fix detect and repair it end
+// to end. Only the EL is in-process; every log/header/receipt is served by a real RPC handler.
+
+// dropProxy fronts an RPC handler and, while active, removes one block's logs from every
+// eth_getLogs response (range and single-block), optionally also failing eth_getBlockReceipts —
+// modeling a persistently-broken log index, with or without a usable receipt store.
+type dropProxy struct {
+	dropBlock           uint64
+	dropActive          atomic.Bool
+	receiptsUnavailable atomic.Bool
+}
+
+type jsonrpcMsg struct {
+	Version string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   json.RawMessage `json:"error,omitempty"`
+}
+
+func newDropProxy(t *testing.T, base http.Handler, dropBlock uint64) (*httptest.Server, *dropProxy) {
+	p := &dropProxy{dropBlock: dropBlock}
+
+	forward := func(req jsonrpcMsg) jsonrpcMsg {
+		body, err := json.Marshal(req)
+		require.NoError(t, err)
+		rec := httptest.NewRecorder()
+		httpReq := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+		httpReq.Header.Set("Content-Type", "application/json")
+		base.ServeHTTP(rec, httpReq)
+		var resp jsonrpcMsg
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		return resp
+	}
+
+	serve := func(req jsonrpcMsg) jsonrpcMsg {
+		switch {
+		case req.Method == "eth_getBlockReceipts" && p.receiptsUnavailable.Load():
+			// -32601 = method not found; makes the client treat receipts as unsupported.
+			return jsonrpcMsg{Version: "2.0", ID: req.ID, Error: json.RawMessage(`{"code":-32601,"message":"the method eth_getBlockReceipts does not exist"}`)}
+		case req.Method == "eth_getLogs" && p.dropActive.Load():
+			resp := forward(req)
+			resp.Result = dropBlockLogs(t, resp.Result, p.dropBlock)
+			return resp
+		default:
+			return forward(req)
+		}
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		// A batch request is a JSON array; serve each element through the same logic.
+		if bytes.HasPrefix(bytes.TrimSpace(raw), []byte("[")) {
+			var reqs []jsonrpcMsg
+			require.NoError(t, json.Unmarshal(raw, &reqs))
+			resps := make([]jsonrpcMsg, 0, len(reqs))
+			for _, req := range reqs {
+				resps = append(resps, serve(req))
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(resps))
+			return
+		}
+		var req jsonrpcMsg
+		require.NoError(t, json.Unmarshal(raw, &req))
+		require.NoError(t, json.NewEncoder(w).Encode(serve(req)))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, p
+}
+
+// dropBlockLogs removes all logs of the given block from an eth_getLogs result.
+func dropBlockLogs(t *testing.T, result json.RawMessage, block uint64) json.RawMessage {
+	if len(result) == 0 {
+		return result
+	}
+	var logs []map[string]any
+	require.NoError(t, json.Unmarshal(result, &logs))
+	kept := make([]map[string]any, 0, len(logs))
+	for _, l := range logs {
+		num, err := hexutil.DecodeUint64(l["blockNumber"].(string))
+		require.NoError(t, err)
+		if num != block {
+			kept = append(kept, l)
+		}
+	}
+	out, err := json.Marshal(kept)
+	require.NoError(t, err)
+	return out
+}
+
+func operatorCount(t *testing.T, s operatorstorage.Storage) int {
+	ops, err := s.ListOperators(nil, 0, 0)
+	require.NoError(t, err)
+	return len(ops)
+}
+
+// setupVerifyE2E deploys the contract, registers operatorsN operators (one per block), pads past
+// the follow distance, and wires the real pipeline through a drop-proxy targeting the middle
+// operator's block. It returns the syncer, storage, proxy, and that middle block number.
+func setupVerifyE2E(t *testing.T, ctx context.Context, operatorsN int) (*EventSyncer, operatorstorage.Storage, *dropProxy, uint64) {
+	logger := zaptest.NewLogger(t)
+
+	sim := simTestBackend(testAddr)
+	rpcServer, err := sim.Node().RPCHandler()
+	require.NoError(t, err)
+	t.Cleanup(rpcServer.Stop)
+
+	parsed, err := abi.JSON(strings.NewReader(simcontract.SimcontractMetaData.ABI))
+	require.NoError(t, err)
+	auth, err := bind.NewKeyedTransactorWithChainID(testKey, big.NewInt(1337))
+	require.NoError(t, err)
+	contractAddr, _, _, err := bind.DeployContract(auth, parsed, ethcommon.FromHex(simcontract.SimcontractMetaData.Bin), sim.Client())
+	require.NoError(t, err)
+	sim.Commit()
+
+	boundContract, err := simcontract.NewSimcontract(contractAddr, sim.Client())
+	require.NoError(t, err)
+
+	// Register operatorsN operators, one per block; remember the middle one's block to drop.
+	var midBlock uint64
+	for i := 0; i < operatorsN; i++ {
+		pubKey, _, err := rsaencryption.GenerateKeyPairPEM()
+		require.NoError(t, err)
+		packed, err := eventparser.PackOperatorPublicKey(base64.StdEncoding.EncodeToString(pubKey))
+		require.NoError(t, err)
+		_, err = boundContract.RegisterOperator(auth, packed, big.NewInt(100_000_000))
+		require.NoError(t, err)
+		sim.Commit()
+		if i == operatorsN/2 {
+			midBlock, err = sim.Client().BlockNumber(ctx)
+			require.NoError(t, err)
+		}
+	}
+	// Pad past the follow distance so all operator blocks are within the historical window.
+	for i := 0; i < executionclient.FollowDistance+2; i++ {
+		sim.Commit()
+	}
+
+	proxyURL, proxy := newDropProxy(t, rpcServer, midBlock)
+
+	db, err := kv.NewInMemory(logger, basedb.Options{Ctx: ctx})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	privateKey, err := keys.GeneratePrivateKey()
+	require.NoError(t, err)
+	nodeStorage, operatorData := setupOperatorStorage(logger, db, privateKey)
+	eh := setupEventHandler(t, ctx, logger, db, nodeStorage, operatorData, privateKey)
+
+	execClient, err := executionclient.New(ctx, proxyURL.URL, contractAddr, executionclient.WithLogger(logger))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = execClient.Close() })
+	require.NoError(t, execClient.Healthy(ctx))
+
+	es := New(nodeStorage, execClient, eh, WithLogger(logger))
+	es.verifyChunkDelay = 0
+
+	return es, nodeStorage, proxy, midBlock
+}
+
+// TestE2E_HealthyEL_VerifiesClean is the no-regression baseline: against a healthy EL the
+// optimistic sync stores every operator and the background verifier retires the range clean —
+// no false-positive resync.
+func TestE2E_HealthyEL_VerifiesClean(t *testing.T) {
+	ctx := t.Context()
+	es, nodeStorage, _, _ := setupVerifyE2E(t, ctx, 3)
+
+	_, err := es.SyncHistory(ctx, 0, false) // optimistic (cold-sync path)
+	require.NoError(t, err)
+	require.Equal(t, 3, operatorCount(t, nodeStorage))
+
+	require.NoError(t, es.Verify(ctx))
+
+	resync, err := nodeStorage.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.False(t, resync)
+	ranges, err := nodeStorage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Empty(t, ranges, "clean range should be retired")
+}
+
+// TestE2E_DropDetectedAndRepaired is the #2990 end-to-end: a persistently-lying EL drops one
+// operator's logs, the optimistic sync silently misses it, the background verifier recovers the
+// block from receipts and flags a resync, and the verified resync rebuilds complete state.
+func TestE2E_DropDetectedAndRepaired(t *testing.T) {
+	ctx := t.Context()
+	es, nodeStorage, proxy, dropped := setupVerifyE2E(t, ctx, 3)
+	proxy.dropActive.Store(true) // persistently drop the middle operator's block from getLogs
+
+	// Optimistic sync silently loses the dropped operator — the #2990 failure.
+	_, err := es.SyncHistory(ctx, 0, false)
+	require.NoError(t, err)
+	require.Equal(t, 2, operatorCount(t, nodeStorage), "one operator silently missed (block %d dropped)", dropped)
+
+	// Background verification recovers the block via receipts, sees the mismatch, flags a resync.
+	require.ErrorIs(t, es.Verify(ctx), ErrResyncRequired)
+	resync, err := nodeStorage.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.True(t, resync)
+
+	// Repair (what the boot path does): drop registry + journal, then resync with inline
+	// verification — which recovers the dropped block from receipts.
+	require.NoError(t, nodeStorage.DropRegistryData())
+	require.NoError(t, nodeStorage.DropVerificationJournal())
+	_, err = es.SyncHistory(ctx, 0, true) // verify=true (inline)
+	require.NoError(t, err)
+
+	require.Equal(t, 3, operatorCount(t, nodeStorage), "resync recovered the dropped operator")
+
+	// A fresh verification pass over the (verified) resync finds nothing to do.
+	require.NoError(t, es.Verify(ctx))
+}
+
+// TestE2E_ParksWhenReceiptsUnavailable: when a disagreement can't be resolved against receipts
+// (EL without eth_getBlockReceipts), the verifier parks the range — no resync on a guess, and the
+// range stays visible/pending rather than being retired as verified.
+func TestE2E_ParksWhenReceiptsUnavailable(t *testing.T) {
+	ctx := t.Context()
+	es, nodeStorage, proxy, _ := setupVerifyE2E(t, ctx, 3)
+
+	// Optimistic sync sees the full chain (all 3 operators recorded, digests written).
+	_, err := es.SyncHistory(ctx, 0, false)
+	require.NoError(t, err)
+	require.Equal(t, 3, operatorCount(t, nodeStorage))
+
+	// Now the EL's log index breaks for that block AND receipts become unavailable — so the
+	// verify-time fetch disagrees with the recorded digest and there's no authoritative source.
+	proxy.dropActive.Store(true)
+	proxy.receiptsUnavailable.Store(true)
+
+	require.NoError(t, es.Verify(ctx), "unresolvable disagreement must not resync")
+
+	resync, err := nodeStorage.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.False(t, resync, "must not resync without an authoritative source")
+
+	ranges, err := nodeStorage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, ranges, "range stays pending (parked), not retired as verified")
+}

--- a/eth/eventsyncer/event_syncer.go
+++ b/eth/eventsyncer/event_syncer.go
@@ -24,7 +24,9 @@ const (
 )
 
 type ExecutionClient interface {
-	FetchHistoricalLogs(ctx context.Context, fromBlock uint64) (logsCh <-chan executionclient.BlockLogs, errsCh <-chan error, err error)
+	FetchHistoricalLogs(ctx context.Context, fromBlock uint64, verify bool) (logsCh <-chan executionclient.BlockLogs, errsCh <-chan error, err error)
+	VerifyLogs(ctx context.Context, fromBlock, toBlock uint64) ([]executionclient.BlockLogs, error)
+	BlockContractLogs(ctx context.Context, block uint64) (logs []types.Log, receiptsAvailable bool, err error)
 	StreamLogs(ctx context.Context, fromBlock uint64) (logsCh chan executionclient.BlockLogs)
 	HeaderByNumber(ctx context.Context, blockNumber *big.Int) (*types.Header, error)
 }
@@ -34,6 +36,7 @@ type EventHandler interface {
 		ctx context.Context,
 		logStreamCh <-chan executionclient.BlockLogs,
 		executeTasks bool,
+		journalFrom *uint64,
 	) (lastProcessedBlock uint64, progressed bool, err error)
 }
 
@@ -47,6 +50,12 @@ type EventSyncer struct {
 	logger             *zap.Logger
 	stalenessThreshold time.Duration
 
+	verifyChunkSize         uint64
+	verifyChunkDelay        time.Duration
+	verifyRetryInitialDelay time.Duration
+	verifyRetryMaxDelay     time.Duration
+	resyncCooldown          time.Duration
+
 	lastProcessedBlock       uint64
 	lastProcessedBlockChange time.Time
 }
@@ -57,8 +66,13 @@ func New(nodeStorage nodestorage.Storage, executionClient ExecutionClient, event
 		executionClient: executionClient,
 		eventHandler:    eventHandler,
 
-		logger:             zap.NewNop(),
-		stalenessThreshold: defaultStalenessThreshold,
+		logger:                  zap.NewNop(),
+		stalenessThreshold:      defaultStalenessThreshold,
+		verifyChunkSize:         defaultVerifyChunkSize,
+		verifyChunkDelay:        defaultVerifyChunkDelay,
+		verifyRetryInitialDelay: defaultVerifyRetryInitialDelay,
+		verifyRetryMaxDelay:     defaultVerifyRetryMaxDelay,
+		resyncCooldown:          defaultResyncCooldown,
 	}
 
 	for _, opt := range opts {
@@ -95,21 +109,24 @@ func (es *EventSyncer) ensureBlockAboveThreshold(ctx context.Context, block *big
 		return fmt.Errorf("failed to get header for block %d: %w", block, err)
 	}
 
-	// #nosec G115
-	if header.Time < uint64(time.Now().Add(-es.stalenessThreshold).Unix()) {
+	// Compare in signed space: a staleness threshold large enough to push the cutoff before
+	// the Unix epoch would wrap the uint64 cast and flag every block as too old.
+	cutoff := time.Now().Add(-es.stalenessThreshold).Unix()
+	// #nosec G115 -- block timestamps fit in int64
+	if int64(header.Time) < cutoff {
 		return fmt.Errorf("block %d is too old", block)
 	}
 
 	return nil
 }
 
-func (es *EventSyncer) syncHistory(ctx context.Context, fromBlock uint64) (
+func (es *EventSyncer) syncHistory(ctx context.Context, fromBlock uint64, journalFrom *uint64, verify bool) (
 	lastProcessedBlock uint64,
 	progressed bool,
 	err error,
 	retryable bool,
 ) {
-	fetchLogsCh, fetchErrCh, err := es.executionClient.FetchHistoricalLogs(ctx, fromBlock)
+	fetchLogsCh, fetchErrCh, err := es.executionClient.FetchHistoricalLogs(ctx, fromBlock, verify)
 	if errors.Is(err, executionclient.ErrNothingToSync) {
 		// Nothing to sync, should keep ongoing sync from the given fromBlock.
 		return 0, false, executionclient.ErrNothingToSync, false
@@ -118,8 +135,9 @@ func (es *EventSyncer) syncHistory(ctx context.Context, fromBlock uint64) (
 		return 0, false, fmt.Errorf("failed to fetch historical events: %w", err), true
 	}
 
-	// Process all the logs fetched until there are no more.
-	lastProcessedBlock, progressed, err = es.eventHandler.HandleBlockEventsStream(ctx, fetchLogsCh, false)
+	// An optimistic sync passes journalFrom so the handler records verification bookkeeping as it
+	// advances the marker; a verified resync passes nil (its batches are already checked inline).
+	lastProcessedBlock, progressed, err = es.eventHandler.HandleBlockEventsStream(ctx, fetchLogsCh, false, journalFrom)
 	if err != nil {
 		return lastProcessedBlock, progressed, fmt.Errorf("handle block events stream (last processed block = %d): %w", lastProcessedBlock, err), true
 	}
@@ -146,11 +164,27 @@ func (es *EventSyncer) syncHistory(ctx context.Context, fromBlock uint64) (
 	return lastProcessedBlock, progressed, nil, false
 }
 
-// SyncHistory reads and processes historical events since the given fromBlock.
-func (es *EventSyncer) SyncHistory(ctx context.Context, fromBlock uint64) (lastProcessedBlock uint64, errs error) {
+// SyncHistory reads and processes historical events since the given fromBlock. When verify is
+// false (the normal path) the sync is optimistic and fast: the handler journals an unverified
+// range and per-block digests as it advances the marker, for the background verifier to check
+// for completeness later. When true (the resync-repair path) each batch is verified inline, so
+// the result is guaranteed complete and nothing is journalled.
+func (es *EventSyncer) SyncHistory(ctx context.Context, fromBlock uint64, verify bool) (lastProcessedBlock uint64, errs error) {
+	// journalFrom keys the unverified range recorded during an optimistic sync; it stays fixed at
+	// the original start across retries so the range spans the whole optimistic span. A verified
+	// resync journals nothing (nil). It's a pointer, not a 0 sentinel, so an offset-0 network
+	// (RegistrySyncOffset == 0) still journals block 0 instead of silently skipping verification.
+	// Journaling happens in the handler's marker transaction, so a crash can't advance the marker
+	// past a block the verifier won't later check.
+	var journalFrom *uint64
+	if !verify {
+		from := fromBlock
+		journalFrom = &from
+	}
+
 	const maxTries = 3
 	for i := 0; i < maxTries; i++ {
-		lpb, progressed, err, retryable := es.syncHistory(ctx, fromBlock)
+		lpb, progressed, err, retryable := es.syncHistory(ctx, fromBlock, journalFrom, verify)
 		if err == nil {
 			// Success, errors encountered so far (if any) don't matter, no need to log them.
 			lastProcessedBlock = lpb
@@ -178,8 +212,10 @@ func (es *EventSyncer) SyncHistory(ctx context.Context, fromBlock uint64) (lastP
 func (es *EventSyncer) SyncOngoing(ctx context.Context, fromBlock uint64) error {
 	es.logger.Info("subscribing to ongoing registry events", fields.FromBlock(fromBlock))
 
+	// Streaming is verified inline (StreamLogs cross-checks each batch), so no verification
+	// bookkeeping is journalled (journalFrom=nil) and no background verification is needed.
 	logStreamCh := es.executionClient.StreamLogs(ctx, fromBlock)
-	lastProcessedBlock, progressed, err := es.eventHandler.HandleBlockEventsStream(ctx, logStreamCh, true)
+	lastProcessedBlock, progressed, err := es.eventHandler.HandleBlockEventsStream(ctx, logStreamCh, true, nil)
 	if err != nil {
 		if progressed {
 			return fmt.Errorf("handle block events stream (last processed block = %d): %w", lastProcessedBlock, err)

--- a/eth/eventsyncer/event_syncer_mock.go
+++ b/eth/eventsyncer/event_syncer_mock.go
@@ -43,10 +43,26 @@ func (m *MockExecutionClient) EXPECT() *MockExecutionClientMockRecorder {
 	return m.recorder
 }
 
-// FetchHistoricalLogs mocks base method.
-func (m *MockExecutionClient) FetchHistoricalLogs(ctx context.Context, fromBlock uint64) (<-chan executionclient.BlockLogs, <-chan error, error) {
+// BlockContractLogs mocks base method.
+func (m *MockExecutionClient) BlockContractLogs(ctx context.Context, block uint64) ([]types.Log, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchHistoricalLogs", ctx, fromBlock)
+	ret := m.ctrl.Call(m, "BlockContractLogs", ctx, block)
+	ret0, _ := ret[0].([]types.Log)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// BlockContractLogs indicates an expected call of BlockContractLogs.
+func (mr *MockExecutionClientMockRecorder) BlockContractLogs(ctx, block any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockContractLogs", reflect.TypeOf((*MockExecutionClient)(nil).BlockContractLogs), ctx, block)
+}
+
+// FetchHistoricalLogs mocks base method.
+func (m *MockExecutionClient) FetchHistoricalLogs(ctx context.Context, fromBlock uint64, verify bool) (<-chan executionclient.BlockLogs, <-chan error, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchHistoricalLogs", ctx, fromBlock, verify)
 	ret0, _ := ret[0].(<-chan executionclient.BlockLogs)
 	ret1, _ := ret[1].(<-chan error)
 	ret2, _ := ret[2].(error)
@@ -54,9 +70,9 @@ func (m *MockExecutionClient) FetchHistoricalLogs(ctx context.Context, fromBlock
 }
 
 // FetchHistoricalLogs indicates an expected call of FetchHistoricalLogs.
-func (mr *MockExecutionClientMockRecorder) FetchHistoricalLogs(ctx, fromBlock any) *gomock.Call {
+func (mr *MockExecutionClientMockRecorder) FetchHistoricalLogs(ctx, fromBlock, verify any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchHistoricalLogs", reflect.TypeOf((*MockExecutionClient)(nil).FetchHistoricalLogs), ctx, fromBlock)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchHistoricalLogs", reflect.TypeOf((*MockExecutionClient)(nil).FetchHistoricalLogs), ctx, fromBlock, verify)
 }
 
 // HeaderByNumber mocks base method.
@@ -88,6 +104,21 @@ func (mr *MockExecutionClientMockRecorder) StreamLogs(ctx, fromBlock any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamLogs", reflect.TypeOf((*MockExecutionClient)(nil).StreamLogs), ctx, fromBlock)
 }
 
+// VerifyLogs mocks base method.
+func (m *MockExecutionClient) VerifyLogs(ctx context.Context, fromBlock, toBlock uint64) ([]executionclient.BlockLogs, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyLogs", ctx, fromBlock, toBlock)
+	ret0, _ := ret[0].([]executionclient.BlockLogs)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VerifyLogs indicates an expected call of VerifyLogs.
+func (mr *MockExecutionClientMockRecorder) VerifyLogs(ctx, fromBlock, toBlock any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyLogs", reflect.TypeOf((*MockExecutionClient)(nil).VerifyLogs), ctx, fromBlock, toBlock)
+}
+
 // MockEventHandler is a mock of EventHandler interface.
 type MockEventHandler struct {
 	ctrl     *gomock.Controller
@@ -113,9 +144,9 @@ func (m *MockEventHandler) EXPECT() *MockEventHandlerMockRecorder {
 }
 
 // HandleBlockEventsStream mocks base method.
-func (m *MockEventHandler) HandleBlockEventsStream(ctx context.Context, logStreamCh <-chan executionclient.BlockLogs, executeTasks bool) (uint64, bool, error) {
+func (m *MockEventHandler) HandleBlockEventsStream(ctx context.Context, logStreamCh <-chan executionclient.BlockLogs, executeTasks bool, journalFrom *uint64) (uint64, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleBlockEventsStream", ctx, logStreamCh, executeTasks)
+	ret := m.ctrl.Call(m, "HandleBlockEventsStream", ctx, logStreamCh, executeTasks, journalFrom)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -123,7 +154,7 @@ func (m *MockEventHandler) HandleBlockEventsStream(ctx context.Context, logStrea
 }
 
 // HandleBlockEventsStream indicates an expected call of HandleBlockEventsStream.
-func (mr *MockEventHandlerMockRecorder) HandleBlockEventsStream(ctx, logStreamCh, executeTasks any) *gomock.Call {
+func (mr *MockEventHandlerMockRecorder) HandleBlockEventsStream(ctx, logStreamCh, executeTasks, journalFrom any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBlockEventsStream", reflect.TypeOf((*MockEventHandler)(nil).HandleBlockEventsStream), ctx, logStreamCh, executeTasks)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBlockEventsStream", reflect.TypeOf((*MockEventHandler)(nil).HandleBlockEventsStream), ctx, logStreamCh, executeTasks, journalFrom)
 }

--- a/eth/eventsyncer/event_syncer_test.go
+++ b/eth/eventsyncer/event_syncer_test.go
@@ -139,7 +139,7 @@ func TestEventSyncer(t *testing.T) {
 		err = eventSyncer.Healthy(ctx)
 		require.NoError(t, err)
 
-		lastProcessedBlock, err := eventSyncer.SyncHistory(ctx, 0)
+		lastProcessedBlock, err := eventSyncer.SyncHistory(ctx, 0, false)
 		require.NoError(t, err)
 		require.NoError(t, client.Close())
 		require.NoError(t, eventSyncer.SyncOngoing(ctx, lastProcessedBlock+1))
@@ -178,7 +178,7 @@ func TestEventSyncer(t *testing.T) {
 		err = eventSyncer.Healthy(ctx)
 		require.NoError(t, err)
 
-		lastProcessedBlock, err := eventSyncer.SyncHistory(ctx, 0)
+		lastProcessedBlock, err := eventSyncer.SyncHistory(ctx, 0, false)
 		require.NoError(t, err)
 
 		cancel()
@@ -323,11 +323,100 @@ func TestSyncOngoingPropagatesErrInferiorBlock(t *testing.T) {
 		StreamLogs(ctx, uint64(11)).
 		Return(stream)
 	eventHandlerMock.EXPECT().
-		HandleBlockEventsStream(ctx, stream, true).
+		HandleBlockEventsStream(ctx, stream, true, gomock.Nil()).
 		Return(uint64(12), true, fmt.Errorf("process block events: %w", eventhandler.ErrInferiorBlock))
 
 	err := syncer.SyncOngoing(ctx, 11)
 	require.Error(t, err)
 	require.ErrorIs(t, err, eventhandler.ErrInferiorBlock)
 	require.ErrorContains(t, err, "last processed block = 12")
+}
+
+// blockLogsChan / closedErrChan build the channels a mocked FetchHistoricalLogs returns.
+func blockLogsChan(blocks ...executionclient.BlockLogs) <-chan executionclient.BlockLogs {
+	ch := make(chan executionclient.BlockLogs, len(blocks))
+	for _, b := range blocks {
+		ch <- b
+	}
+	close(ch)
+	return ch
+}
+
+func closedErrChan() <-chan error {
+	ch := make(chan error)
+	close(ch)
+	return ch
+}
+
+// TestEventSyncer_RepairLoop exercises the whole seam end to end against the real event handler
+// and storage (only the execution client is mocked): an optimistic sync records an incomplete
+// digest, background verification reads it back, compares against authoritative logs, detects the
+// miss and flags a resync; then the repair (drop journal + registry, keep the flag) and a
+// verified resync rebuild clean state and clear the flag.
+func TestEventSyncer_RepairLoop(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	ctx := t.Context()
+
+	db, err := kv.NewInMemory(logger, basedb.Options{Ctx: ctx})
+	require.NoError(t, err)
+	privateKey, err := keys.GeneratePrivateKey()
+	require.NoError(t, err)
+	nodeStorage, operatorData := setupOperatorStorage(logger, db, privateKey)
+	eh := setupEventHandler(t, ctx, logger, db, nodeStorage, operatorData, privateKey)
+
+	execClient := NewMockExecutionClient(gomock.NewController(t))
+	es := New(nodeStorage, execClient, eh, WithLogger(logger))
+	es.verifyChunkDelay = 0
+
+	const fromBlock = 10
+	// Unknown topics: the handler records digests without needing decodable events.
+	recordedLog := ethtypes.Log{BlockNumber: fromBlock, TxIndex: 0, Index: 0, Topics: []ethcommon.Hash{{0x1}}}
+	missedLog := ethtypes.Log{BlockNumber: fromBlock, TxIndex: 0, Index: 1, Topics: []ethcommon.Hash{{0x2}}}
+
+	// Recent header so the staleness guard passes for both syncs.
+	recentHeader := &ethtypes.Header{Time: uint64(time.Now().Unix())}
+	execClient.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(recentHeader, nil).AnyTimes()
+
+	// Optimistic sync delivers only the recorded log; the handler journals the range and its
+	// (incomplete) digest.
+	execClient.EXPECT().FetchHistoricalLogs(gomock.Any(), uint64(fromBlock), false).DoAndReturn(
+		func(context.Context, uint64, bool) (<-chan executionclient.BlockLogs, <-chan error, error) {
+			return blockLogsChan(executionclient.BlockLogs{BlockNumber: fromBlock, Logs: []ethtypes.Log{recordedLog}}), closedErrChan(), nil
+		})
+	_, err = es.SyncHistory(ctx, fromBlock, false)
+	require.NoError(t, err)
+
+	// Background verification: VerifyLogs shows both logs, and receipts confirm them → the recorded
+	// digest (one log) disagrees with receipts truth → resync flagged.
+	execClient.EXPECT().VerifyLogs(gomock.Any(), uint64(fromBlock), uint64(fromBlock)).Return(
+		[]executionclient.BlockLogs{{BlockNumber: fromBlock, Logs: []ethtypes.Log{recordedLog, missedLog}}}, nil)
+	execClient.EXPECT().BlockContractLogs(gomock.Any(), uint64(fromBlock)).Return(
+		[]ethtypes.Log{recordedLog, missedLog}, true, nil)
+	require.ErrorIs(t, es.Verify(ctx), ErrResyncRequired)
+
+	flagged, err := nodeStorage.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.True(t, flagged)
+
+	// Repair, as the boot path does on the next start: drop journal + registry, keep the flag.
+	require.NoError(t, nodeStorage.DropVerificationJournal())
+	require.NoError(t, nodeStorage.DropRegistryData())
+
+	// Verified resync delivers the complete set; nothing is journalled (journalFrom=0).
+	execClient.EXPECT().FetchHistoricalLogs(gomock.Any(), uint64(fromBlock), true).DoAndReturn(
+		func(context.Context, uint64, bool) (<-chan executionclient.BlockLogs, <-chan error, error) {
+			return blockLogsChan(executionclient.BlockLogs{BlockNumber: fromBlock, Logs: []ethtypes.Log{recordedLog, missedLog}}), closedErrChan(), nil
+		})
+	_, err = es.SyncHistory(ctx, fromBlock, true)
+	require.NoError(t, err)
+	require.NoError(t, nodeStorage.ClearResyncRequired(nil))
+
+	// Repaired: flag clear, journal empty, and a fresh verification pass is a no-op.
+	flagged, err = nodeStorage.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.False(t, flagged)
+	ranges, err := nodeStorage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Empty(t, ranges)
+	require.NoError(t, es.Verify(ctx))
 }

--- a/eth/eventsyncer/observability.go
+++ b/eth/eventsyncer/observability.go
@@ -26,11 +26,13 @@ var (
 			observability.InstrumentName(observabilityNamespace, "pending_ranges"),
 			metric.WithDescription("number of optimistically-synced ranges awaiting background verification")))
 
-	// verifyCursorGauge reports the highest block the verifier has confirmed complete so far.
+	// verifyCursorGauge reports the top block of the most recently verified chunk. With multiple
+	// pending ranges it is not a global watermark: it jumps between ranges as their chunks are
+	// verified, so read it as recent progress rather than a monotonic high-water mark.
 	verifyCursorGauge = metrics.New(
 		meter.Int64Gauge(
 			observability.InstrumentName(observabilityNamespace, "cursor"),
-			metric.WithDescription("highest block confirmed complete by the background verifier")))
+			metric.WithDescription("top block of the most recently verified chunk (jumps between ranges when several are pending)")))
 
 	// verifyMissCounter counts receipts-confirmed misses (a block whose recorded digest disagreed
 	// with the receipts truth). Any increment schedules a full resync — it should stay at zero.

--- a/eth/eventsyncer/observability.go
+++ b/eth/eventsyncer/observability.go
@@ -1,0 +1,77 @@
+package eventsyncer
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/ssvlabs/ssv/observability"
+	"github.com/ssvlabs/ssv/observability/metrics"
+)
+
+const (
+	observabilityName      = "github.com/ssvlabs/ssv/eth/eventsyncer"
+	observabilityNamespace = "ssv.event_syncer.verify"
+)
+
+var (
+	meter = otel.Meter(observabilityName)
+
+	// verifyPendingRangesGauge reports how many optimistically-synced ranges still await
+	// background completeness verification. A nonzero value means the node's registry state
+	// may be temporarily incomplete for those ranges.
+	verifyPendingRangesGauge = metrics.New(
+		meter.Int64Gauge(
+			observability.InstrumentName(observabilityNamespace, "pending_ranges"),
+			metric.WithDescription("number of optimistically-synced ranges awaiting background verification")))
+
+	// verifyCursorGauge reports the highest block the verifier has confirmed complete so far.
+	verifyCursorGauge = metrics.New(
+		meter.Int64Gauge(
+			observability.InstrumentName(observabilityNamespace, "cursor"),
+			metric.WithDescription("highest block confirmed complete by the background verifier")))
+
+	// verifyMissCounter counts receipts-confirmed misses (a block whose recorded digest disagreed
+	// with the receipts truth). Any increment schedules a full resync — it should stay at zero.
+	verifyMissCounter = metrics.New(
+		meter.Int64Counter(
+			observability.InstrumentName(observabilityNamespace, "misses"),
+			metric.WithDescription("registry-event completeness misses confirmed by the background verifier")))
+
+	// verifyParkedCounter counts ranges left pending because a disagreeing block couldn't be
+	// authoritatively resolved (eth_getBlockReceipts unavailable). Nonzero means verification is
+	// inconclusive — the node may be on incomplete state; investigate the execution client.
+	verifyParkedCounter = metrics.New(
+		meter.Int64Counter(
+			observability.InstrumentName(observabilityNamespace, "parked"),
+			metric.WithDescription("ranges left pending because a block couldn't be authoritatively verified")))
+
+	// verifySuppressedCounter counts confirmed misses whose resync was suppressed by the rate
+	// limit. Nonzero means a repair is being deferred — investigate the execution client.
+	verifySuppressedCounter = metrics.New(
+		meter.Int64Counter(
+			observability.InstrumentName(observabilityNamespace, "suppressed"),
+			metric.WithDescription("confirmed misses whose automatic resync was rate-limited")))
+)
+
+func recordVerifyPendingRanges(ctx context.Context, n int) {
+	verifyPendingRangesGauge.Record(ctx, int64(n))
+}
+
+func recordVerifyCursor(ctx context.Context, block uint64) {
+	// #nosec G115 -- block numbers fit in int64
+	verifyCursorGauge.Record(ctx, int64(block))
+}
+
+func recordVerifyMiss(ctx context.Context) {
+	verifyMissCounter.Add(ctx, 1)
+}
+
+func recordVerifyParked(ctx context.Context) {
+	verifyParkedCounter.Add(ctx, 1)
+}
+
+func recordVerifySuppressed(ctx context.Context) {
+	verifySuppressedCounter.Add(ctx, 1)
+}

--- a/eth/eventsyncer/verifier.go
+++ b/eth/eventsyncer/verifier.go
@@ -94,7 +94,7 @@ func (es *EventSyncer) Verify(ctx context.Context) error {
 	recordVerifyPendingRanges(ctx, len(remaining))
 
 	if parked > 0 {
-		es.logger.Warn("background verification could not fully verify some ranges; they remain pending and will be retried (see earlier warnings)",
+		es.logger.Warn("background verification could not fully verify some ranges; they remain pending and will be re-checked on the next node start (see earlier warnings)",
 			zap.Int("parked_ranges", parked))
 	} else {
 		es.logger.Info("background verification complete: optimistically-synced registry events are consistent with chain data")
@@ -102,10 +102,11 @@ func (es *EventSyncer) Verify(ctx context.Context) error {
 	return nil
 }
 
-// VerifyWithRetry runs Verify and, on a transient failure, retries with capped exponential
-// backoff until the ranges verify clean (nil), a miss is found (ErrResyncRequired), or ctx is
-// canceled. It exists so a transient execution-client error doesn't leave an
-// optimistically-synced range unverified until the node's next restart.
+// VerifyWithRetry runs Verify, retrying only a transient failure with capped exponential backoff
+// until Verify returns nil (every range verified or parked), a miss is found (ErrResyncRequired),
+// or ctx is canceled. Parked ranges make Verify return nil, so they aren't retried here — they're
+// re-checked on the next node start; this loop exists only so a transient execution-client error
+// doesn't leave a range unverified until then.
 func (es *EventSyncer) VerifyWithRetry(ctx context.Context) error {
 	backoff := es.verifyRetryInitialDelay
 	for {

--- a/eth/eventsyncer/verifier.go
+++ b/eth/eventsyncer/verifier.go
@@ -224,7 +224,7 @@ func (es *EventSyncer) resolveMismatch(ctx context.Context, block uint64, stored
 		return false, fmt.Errorf("resolve block %d against receipts: %w", block, err)
 	}
 	if !receiptsAvailable {
-		es.logger.Warn("background verification: no authoritative source (eth_getBlockReceipts unavailable) to resolve a disagreeing block; leaving range pending",
+		es.logger.Warn("background verification: no authoritative receipts source to resolve a disagreeing block (eth_getBlockReceipts unsupported or unreliable); leaving range pending",
 			fields.BlockNumber(block))
 		return false, errRangeParked
 	}
@@ -242,13 +242,11 @@ func (es *EventSyncer) resolveMismatch(ctx context.Context, block uint64, stored
 
 	// The recorded digest disagrees with the receipts truth — the optimistic sync genuinely missed
 	// events (recorded is a subset of truth, so it can only be short, never over-recorded).
-	if err := es.flagResync(ctx, block, "receipts confirm the optimistic sync missed events"); err != nil {
-		if errors.Is(err, errResyncSuppressed) {
-			return false, errRangeParked
-		}
-		return false, err
+	err = es.flagResync(ctx, block, "receipts confirm the optimistic sync missed events")
+	if errors.Is(err, errResyncSuppressed) {
+		return false, errRangeParked
 	}
-	return false, nil // unreachable: flagResync never returns nil
+	return false, err
 }
 
 // commitVerifiedChunk advances the range's cursor past a clean chunk and drops that chunk's

--- a/eth/eventsyncer/verifier.go
+++ b/eth/eventsyncer/verifier.go
@@ -1,0 +1,312 @@
+package eventsyncer
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/eth/executionclient"
+	"github.com/ssvlabs/ssv/observability/log/fields"
+	nodestorage "github.com/ssvlabs/ssv/operator/storage"
+)
+
+const (
+	// defaultVerifyChunkSize is how many blocks the background verifier checks per iteration.
+	// Each chunk re-fetches the range's logs once (plus headers/receipts only for blocks that
+	// returned none), so a larger chunk means fewer round-trips at the cost of a bigger burst.
+	defaultVerifyChunkSize = 5000
+
+	// defaultVerifyChunkDelay paces the verifier between chunks to keep it off the hot path and
+	// gentle on the EL, trading verification latency for lower steady-state load.
+	defaultVerifyChunkDelay = 200 * time.Millisecond
+
+	// Backoff bounds for retrying a transient verification failure in-process (see
+	// VerifyWithRetry), so a brief EL hiccup doesn't leave a range unverified until the next
+	// restart. Capped exponential: quick first retry, backing off to gentle steady polling.
+	defaultVerifyRetryInitialDelay = 10 * time.Second
+	defaultVerifyRetryMaxDelay     = 5 * time.Minute
+
+	// defaultResyncCooldown rate-limits automatic repair: after a resync is flagged, further
+	// confirmed misses within this window are suppressed (logged, not acted on). This bounds a
+	// fatal+wipe+resync loop on a persistently-broken EL and caps a correlated network-wide
+	// resync from a common-mode EL fault. During the cooldown the node keeps running on
+	// possibly-incomplete state, with a loud log telling the operator to investigate.
+	defaultResyncCooldown = 6 * time.Hour
+)
+
+// ErrResyncRequired signals that background verification found registry events the optimistic
+// sync had missed. Registry events are order-dependent and carry per-owner nonces, so they
+// cannot be repaired in place; the caller must restart into a clean, inline-verified resync.
+// The resync-required flag is persisted before this is returned, so the next start performs it.
+var ErrResyncRequired = errors.New("registry resync required: background verification found missing events")
+
+// errResyncSuppressed is an internal signal that a receipts-confirmed miss was not acted on
+// because a resync was flagged too recently (rate-limited); the range is parked instead.
+var errResyncSuppressed = errors.New("resync suppressed by rate limit")
+
+// Verify checks, in the background, that every optimistically-synced range is complete with
+// respect to chain data. For each range it re-fetches the contract's logs (VerifyLogs) and
+// compares them, block by block, to the digests the optimistic sync recorded. Blocks that agree
+// are retired. On a disagreement it resolves the block against receipts — the index-independent
+// source of truth — and flags a resync (ErrResyncRequired) only when receipts confirm the sync
+// genuinely missed events; if receipts are unavailable it parks the range (leaves it pending and
+// visible on pending_ranges) rather than resyncing on unauthoritative evidence or claiming it
+// verified. Progress is persisted per chunk, so an interrupted run resumes where it left off.
+// Meant to run off the startup critical path.
+//
+// The residual blind spot: if the sync and the verify-time re-fetch drop the same logs, the
+// digests agree, no disagreement is raised, and receipts are never consulted — an identical
+// double-drop goes undetected. Resolving every block against receipts would close it but is far
+// more expensive, and the partial within-block drop it guards against has not been observed.
+func (es *EventSyncer) Verify(ctx context.Context) error {
+	ranges, err := es.nodeStorage.ListUnverifiedRanges(nil)
+	if err != nil {
+		return fmt.Errorf("list unverified ranges: %w", err)
+	}
+	recordVerifyPendingRanges(ctx, len(ranges))
+	if len(ranges) == 0 {
+		return nil
+	}
+
+	es.logger.Info("verifying completeness of optimistically-synced registry events",
+		zap.Int("pending_ranges", len(ranges)))
+
+	parked := 0
+	for _, r := range ranges {
+		wasParked, err := es.verifyRange(ctx, r)
+		if err != nil {
+			return err // ErrResyncRequired or a genuine failure; either way, stop verifying.
+		}
+		if wasParked {
+			parked++
+		}
+	}
+
+	// Whatever remains in the journal is the parked ranges (couldn't be authoritatively verified).
+	remaining, err := es.nodeStorage.ListUnverifiedRanges(nil)
+	if err != nil {
+		return fmt.Errorf("list unverified ranges: %w", err)
+	}
+	recordVerifyPendingRanges(ctx, len(remaining))
+
+	if parked > 0 {
+		es.logger.Warn("background verification could not fully verify some ranges; they remain pending and will be retried (see earlier warnings)",
+			zap.Int("parked_ranges", parked))
+	} else {
+		es.logger.Info("background verification complete: optimistically-synced registry events are consistent with chain data")
+	}
+	return nil
+}
+
+// VerifyWithRetry runs Verify and, on a transient failure, retries with capped exponential
+// backoff until the ranges verify clean (nil), a miss is found (ErrResyncRequired), or ctx is
+// canceled. It exists so a transient execution-client error doesn't leave an
+// optimistically-synced range unverified until the node's next restart.
+func (es *EventSyncer) VerifyWithRetry(ctx context.Context) error {
+	backoff := es.verifyRetryInitialDelay
+	for {
+		err := es.Verify(ctx)
+		if err == nil || errors.Is(err, ErrResyncRequired) || errors.Is(err, context.Canceled) {
+			return err
+		}
+
+		es.logger.Warn("background verification failed; retrying",
+			zap.Duration("retry_in", backoff), zap.Error(err))
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+		backoff = min(backoff*2, es.verifyRetryMaxDelay)
+	}
+}
+
+// verifyRange verifies a single journalled range chunk by chunk, resuming from its persisted
+// cursor. It returns parked=true when it left the range pending because a disagreeing block
+// couldn't be authoritatively resolved (receipts unavailable, or a resync was rate-limited);
+// ErrResyncRequired when receipts confirm a miss; nil once the whole range verifies clean (having
+// removed it from the journal); or a wrapped error on RPC/storage failure.
+func (es *EventSyncer) verifyRange(ctx context.Context, r nodestorage.UnverifiedRange) (parked bool, err error) {
+	cursor := max(r.Cursor, r.From)
+	for cursor <= r.To {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		default:
+		}
+
+		toBlock := min(cursor+es.verifyChunkSize-1, r.To)
+
+		authoritative, err := es.executionClient.VerifyLogs(ctx, cursor, toBlock)
+		if err != nil {
+			return false, fmt.Errorf("verify logs [%d,%d]: %w", cursor, toBlock, err)
+		}
+		authDigests := make(map[uint64][]byte, len(authoritative))
+		for _, bl := range authoritative {
+			authDigests[bl.BlockNumber] = executionclient.BlockLogsDigest(bl.Logs)
+		}
+
+		// Compare every block in the chunk against its recorded digest, collecting blocks that
+		// carry a digest so we can drop them once the chunk is confirmed clean.
+		recorded := make([]uint64, 0, len(authoritative))
+		for block := cursor; block <= toBlock; block++ {
+			stored, found, err := es.nodeStorage.GetBlockLogDigest(nil, block)
+			if err != nil {
+				return false, fmt.Errorf("get block-log digest for block %d: %w", block, err)
+			}
+			authDigest, hasAuth := authDigests[block]
+
+			// Fast path: the verify-time fetch agrees with what the optimistic sync recorded.
+			if found == hasAuth && (!found || bytes.Equal(stored, authDigest)) {
+				if found {
+					recorded = append(recorded, block)
+				}
+				continue
+			}
+
+			// They disagree. A verify-time getLogs isn't authoritative for a block (VerifyLogs only
+			// recovers blocks that returned nothing, and under MultiClient the two passes may hit
+			// different ELs), so resolve the block against receipts before doing anything drastic.
+			clean, err := es.resolveMismatch(ctx, block, stored, found)
+			if errors.Is(err, errRangeParked) {
+				// Couldn't authoritatively resolve it: commit progress up to here and leave the
+				// range pending (visible) rather than resyncing on unauthoritative evidence.
+				if err := es.commitVerifiedChunk(r, block, recorded); err != nil {
+					return false, err
+				}
+				recordVerifyParked(ctx)
+				return true, nil
+			}
+			if err != nil {
+				return false, err // ErrResyncRequired or a genuine failure.
+			}
+			if clean {
+				recorded = append(recorded, block)
+			}
+		}
+
+		nextCursor := toBlock + 1
+		if err := es.commitVerifiedChunk(r, nextCursor, recorded); err != nil {
+			return false, err
+		}
+		recordVerifyCursor(ctx, toBlock)
+		cursor = nextCursor
+
+		if cursor <= r.To {
+			select {
+			case <-ctx.Done():
+				return false, ctx.Err()
+			case <-time.After(es.verifyChunkDelay):
+			}
+		}
+	}
+	return false, nil
+}
+
+// errRangeParked signals verifyRange to leave the current range pending rather than resync,
+// because a disagreeing block couldn't be authoritatively resolved.
+var errRangeParked = errors.New("range parked: block could not be authoritatively verified")
+
+// resolveMismatch settles a block whose recorded digest disagrees with the verify-time fetch, by
+// consulting receipts (the index-independent source of truth). It returns clean=true when the
+// recorded digest matches the receipts (the verify-time getLogs was merely incomplete);
+// ErrResyncRequired when the recorded digest disagrees with the receipts (a confirmed miss);
+// errRangeParked when there's no authoritative source (receipts unavailable) or a resync is
+// rate-limited; or a wrapped error on RPC/storage failure.
+func (es *EventSyncer) resolveMismatch(ctx context.Context, block uint64, stored []byte, found bool) (clean bool, err error) {
+	receiptLogs, receiptsAvailable, err := es.executionClient.BlockContractLogs(ctx, block)
+	if err != nil {
+		return false, fmt.Errorf("resolve block %d against receipts: %w", block, err)
+	}
+	if !receiptsAvailable {
+		es.logger.Warn("background verification: no authoritative source (eth_getBlockReceipts unavailable) to resolve a disagreeing block; leaving range pending",
+			fields.BlockNumber(block))
+		return false, errRangeParked
+	}
+
+	// Compare what the sync recorded (a digest, or the empty digest if it recorded nothing) against
+	// the receipts-derived truth.
+	recordedDigest := executionclient.BlockLogsDigest(nil)
+	if found {
+		recordedDigest = stored
+	}
+	if bytes.Equal(recordedDigest, executionclient.BlockLogsDigest(receiptLogs)) {
+		// Recorded matches the receipts-derived truth; only the verify-time getLogs was incomplete.
+		return true, nil
+	}
+
+	// The recorded digest disagrees with the receipts truth — the optimistic sync genuinely missed
+	// events (recorded is a subset of truth, so it can only be short, never over-recorded).
+	if err := es.flagResync(ctx, block, "receipts confirm the optimistic sync missed events"); err != nil {
+		if errors.Is(err, errResyncSuppressed) {
+			return false, errRangeParked
+		}
+		return false, err
+	}
+	return false, nil // unreachable: flagResync never returns nil
+}
+
+// commitVerifiedChunk advances the range's cursor past a clean chunk and drops that chunk's
+// now-checked digests in one transaction, so an interrupted run resumes without re-checking
+// (nor leaking) it. Once the cursor passes the range end, the range itself is removed.
+func (es *EventSyncer) commitVerifiedChunk(r nodestorage.UnverifiedRange, nextCursor uint64, recorded []uint64) error {
+	txn := es.nodeStorage.Begin()
+	defer txn.Discard()
+
+	for _, block := range recorded {
+		if err := es.nodeStorage.DeleteBlockLogDigest(txn, block); err != nil {
+			return fmt.Errorf("delete block-log digest for block %d: %w", block, err)
+		}
+	}
+	if nextCursor > r.To {
+		if err := es.nodeStorage.DeleteUnverifiedRange(txn, r.From); err != nil {
+			return fmt.Errorf("delete verified range: %w", err)
+		}
+	} else {
+		r.Cursor = nextCursor
+		if err := es.nodeStorage.SaveUnverifiedRange(txn, r); err != nil {
+			return fmt.Errorf("save verification cursor: %w", err)
+		}
+	}
+	return txn.Commit()
+}
+
+// flagResync records a receipts-confirmed miss. Normally it persists the resync-required flag
+// (and the flag time) and returns ErrResyncRequired so the node restarts into a repair. But if a
+// resync was already flagged within the cooldown it suppresses this one — returning
+// errResyncSuppressed so the caller parks the range — to bound a fatal+wipe+resync loop on a
+// persistently-broken EL and to cap a correlated network-wide resync from a common-mode fault.
+// During the cooldown the node keeps running on possibly-incomplete state.
+func (es *EventSyncer) flagResync(ctx context.Context, block uint64, reason string) error {
+	last, found, err := es.nodeStorage.GetLastResyncTime(nil)
+	if err != nil {
+		return fmt.Errorf("get last resync time: %w", err)
+	}
+	if found && time.Since(last) < es.resyncCooldown {
+		recordVerifySuppressed(ctx)
+		es.logger.Warn("background verification found missing registry events, but a resync was flagged recently — suppressing the repair (rate-limited); the node keeps running on possibly-incomplete state, investigate the execution client",
+			fields.BlockNumber(block),
+			zap.String("reason", reason),
+			zap.Duration("cooldown", es.resyncCooldown),
+			zap.Time("last_resync", last),
+		)
+		return errResyncSuppressed
+	}
+
+	if err := es.nodeStorage.SetResyncRequired(nil); err != nil {
+		return fmt.Errorf("set resync-required flag: %w", err)
+	}
+	if err := es.nodeStorage.SetLastResyncTime(nil, time.Now()); err != nil {
+		return fmt.Errorf("set last resync time: %w", err)
+	}
+	recordVerifyMiss(ctx)
+	es.logger.Warn("background verification found the optimistic sync missed registry events; a full resync will run on the next start",
+		fields.BlockNumber(block),
+		zap.String("reason", reason),
+	)
+	return ErrResyncRequired
+}

--- a/eth/eventsyncer/verifier_test.go
+++ b/eth/eventsyncer/verifier_test.go
@@ -1,0 +1,302 @@
+package eventsyncer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/ssvlabs/ssv/eth/executionclient"
+	"github.com/ssvlabs/ssv/networkconfig"
+	operatorstorage "github.com/ssvlabs/ssv/operator/storage"
+	kv "github.com/ssvlabs/ssv/storage/badger"
+	"github.com/ssvlabs/ssv/storage/basedb"
+)
+
+// verifierHarness wires the syncer's background verifier to a mocked execution client (so we
+// control the authoritative logs) and real in-memory storage (so digests/ranges round-trip).
+type verifierHarness struct {
+	es      *EventSyncer
+	exec    *MockExecutionClient
+	storage operatorstorage.Storage
+}
+
+func newVerifierHarness(t *testing.T) *verifierHarness {
+	logger := zaptest.NewLogger(t)
+	db, err := kv.NewInMemory(logger, basedb.Options{Ctx: t.Context()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	nodeStorage, err := operatorstorage.NewNodeStorage(networkconfig.TestNetwork.Beacon, logger, db)
+	require.NoError(t, err)
+
+	exec := NewMockExecutionClient(gomock.NewController(t))
+	es := New(nodeStorage, exec, nil, WithLogger(logger))
+	es.verifyChunkDelay = 0 // keep multi-chunk tests fast
+
+	return &verifierHarness{es: es, exec: exec, storage: nodeStorage}
+}
+
+func logsWith(ids ...[2]uint) []ethtypes.Log {
+	logs := make([]ethtypes.Log, len(ids))
+	for i, id := range ids {
+		logs[i] = ethtypes.Log{TxIndex: id[0], Index: id[1]}
+	}
+	return logs
+}
+
+// expectReceipts mocks the authoritative (receipts-derived) logs for a block, used to resolve a
+// digest mismatch.
+func (h *verifierHarness) expectReceipts(block uint64, logs []ethtypes.Log) {
+	h.exec.EXPECT().BlockContractLogs(gomock.Any(), block).Return(logs, true, nil)
+}
+
+// expectNoReceipts mocks the EL reporting eth_getBlockReceipts unavailable for a block.
+func (h *verifierHarness) expectNoReceipts(block uint64) {
+	h.exec.EXPECT().BlockContractLogs(gomock.Any(), block).Return(nil, false, nil)
+}
+
+func TestVerify_NoRanges(t *testing.T) {
+	h := newVerifierHarness(t)
+	// No ranges journalled: Verify is a no-op and must not touch the execution client.
+	require.NoError(t, h.es.Verify(t.Context()))
+}
+
+func TestVerify_CleanRange(t *testing.T) {
+	h := newVerifierHarness(t)
+
+	logs12 := logsWith([2]uint{0, 0})
+	logs15 := logsWith([2]uint{0, 0}, [2]uint{1, 1})
+	require.NoError(t, h.storage.SaveBlockLogDigest(nil, 12, executionclient.BlockLogsDigest(logs12)))
+	require.NoError(t, h.storage.SaveBlockLogDigest(nil, 15, executionclient.BlockLogsDigest(logs15)))
+	require.NoError(t, h.storage.SaveUnverifiedRange(nil, operatorstorage.UnverifiedRange{From: 10, To: 20, Cursor: 10}))
+
+	// Authoritative logs match what the sync recorded, so the range is clean.
+	h.exec.EXPECT().VerifyLogs(gomock.Any(), uint64(10), uint64(20)).Return([]executionclient.BlockLogs{
+		{BlockNumber: 12, Logs: logs12},
+		{BlockNumber: 15, Logs: logs15},
+	}, nil)
+
+	require.NoError(t, h.es.Verify(t.Context()))
+
+	// A clean range is removed along with its digests, and no resync is flagged.
+	ranges, err := h.storage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Empty(t, ranges)
+	for _, block := range []uint64{12, 15} {
+		_, found, err := h.storage.GetBlockLogDigest(nil, block)
+		require.NoError(t, err)
+		require.False(t, found)
+	}
+	resync, err := h.storage.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.False(t, resync)
+}
+
+func TestVerify_ReceiptsConfirmMissingDigest(t *testing.T) {
+	h := newVerifierHarness(t)
+
+	// The sync recorded no digest for block 15, VerifyLogs shows contract logs there, and receipts
+	// confirm those logs exist — the silent miss #2990 is about. Resync.
+	logs := logsWith([2]uint{0, 0})
+	require.NoError(t, h.storage.SaveUnverifiedRange(nil, operatorstorage.UnverifiedRange{From: 15, To: 15, Cursor: 15}))
+	h.exec.EXPECT().VerifyLogs(gomock.Any(), uint64(15), uint64(15)).Return([]executionclient.BlockLogs{
+		{BlockNumber: 15, Logs: logs},
+	}, nil)
+	h.expectReceipts(15, logs)
+
+	require.ErrorIs(t, h.es.Verify(t.Context()), ErrResyncRequired)
+
+	resync, err := h.storage.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.True(t, resync)
+}
+
+func TestVerify_ReceiptsConfirmSubsetMiss(t *testing.T) {
+	h := newVerifierHarness(t)
+
+	// The sync recorded one log, VerifyLogs shows two, and receipts confirm two: the recorded
+	// response was an incomplete subset. Resync.
+	recorded := logsWith([2]uint{0, 0})
+	truth := logsWith([2]uint{0, 0}, [2]uint{1, 1})
+	require.NoError(t, h.storage.SaveBlockLogDigest(nil, 12, executionclient.BlockLogsDigest(recorded)))
+	require.NoError(t, h.storage.SaveUnverifiedRange(nil, operatorstorage.UnverifiedRange{From: 12, To: 12, Cursor: 12}))
+	h.exec.EXPECT().VerifyLogs(gomock.Any(), uint64(12), uint64(12)).Return([]executionclient.BlockLogs{
+		{BlockNumber: 12, Logs: truth},
+	}, nil)
+	h.expectReceipts(12, truth)
+
+	require.ErrorIs(t, h.es.Verify(t.Context()), ErrResyncRequired)
+
+	resync, err := h.storage.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.True(t, resync)
+}
+
+func TestVerify_ReceiptsVindicateVerifyTimeDrop(t *testing.T) {
+	h := newVerifierHarness(t)
+
+	// The sync recorded logs for block 12, but the verify-time VerifyLogs returns it empty (a
+	// verify-time getLogs blip, or a different EL under MultiClient). Receipts confirm the block
+	// really has those logs and the recorded digest matches — the sync was fine, no resync.
+	logs := logsWith([2]uint{0, 0})
+	require.NoError(t, h.storage.SaveBlockLogDigest(nil, 12, executionclient.BlockLogsDigest(logs)))
+	require.NoError(t, h.storage.SaveUnverifiedRange(nil, operatorstorage.UnverifiedRange{From: 12, To: 12, Cursor: 12}))
+	h.exec.EXPECT().VerifyLogs(gomock.Any(), uint64(12), uint64(12)).Return(nil, nil)
+	h.expectReceipts(12, logs)
+
+	require.NoError(t, h.es.Verify(t.Context()))
+
+	// No resync, and the range is retired clean (digest dropped).
+	resync, err := h.storage.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.False(t, resync)
+
+	ranges, err := h.storage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Empty(t, ranges)
+
+	_, found, err := h.storage.GetBlockLogDigest(nil, 12)
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func TestVerify_ParksWhenReceiptsUnavailable(t *testing.T) {
+	h := newVerifierHarness(t)
+
+	// A block disagrees, but the EL doesn't support eth_getBlockReceipts, so there's no
+	// authoritative source: don't resync, park the range (leave it pending and visible).
+	require.NoError(t, h.storage.SaveUnverifiedRange(nil, operatorstorage.UnverifiedRange{From: 15, To: 15, Cursor: 15}))
+	h.exec.EXPECT().VerifyLogs(gomock.Any(), uint64(15), uint64(15)).Return([]executionclient.BlockLogs{
+		{BlockNumber: 15, Logs: logsWith([2]uint{0, 0})},
+	}, nil)
+	h.expectNoReceipts(15)
+
+	require.NoError(t, h.es.Verify(t.Context()))
+
+	// No resync flagged, and the range stays pending (parked) rather than being retired.
+	resync, err := h.storage.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.False(t, resync)
+
+	ranges, err := h.storage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Len(t, ranges, 1)
+}
+
+func TestVerify_RateLimitSuppressesResync(t *testing.T) {
+	h := newVerifierHarness(t)
+
+	// A resync was flagged 1 minute ago (within the cooldown). A fresh confirmed miss is suppressed:
+	// no new resync is flagged and the range is parked, so the node doesn't fatal+wipe in a loop.
+	require.NoError(t, h.storage.SetLastResyncTime(nil, time.Now().Add(-time.Minute)))
+	logs := logsWith([2]uint{0, 0})
+	require.NoError(t, h.storage.SaveUnverifiedRange(nil, operatorstorage.UnverifiedRange{From: 15, To: 15, Cursor: 15}))
+	h.exec.EXPECT().VerifyLogs(gomock.Any(), uint64(15), uint64(15)).Return([]executionclient.BlockLogs{
+		{BlockNumber: 15, Logs: logs},
+	}, nil)
+	h.expectReceipts(15, logs)
+
+	require.NoError(t, h.es.Verify(t.Context()))
+
+	resync, err := h.storage.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.False(t, resync, "resync should be suppressed within the cooldown")
+
+	ranges, err := h.storage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Len(t, ranges, 1, "the range stays pending")
+}
+
+func TestVerify_ResumesFromCursor(t *testing.T) {
+	h := newVerifierHarness(t)
+
+	// Cursor at 20 means blocks 10-19 were already verified in a prior run; verification must
+	// resume at the cursor, not re-check from the range start.
+	require.NoError(t, h.storage.SaveUnverifiedRange(nil, operatorstorage.UnverifiedRange{From: 10, To: 30, Cursor: 20}))
+	h.exec.EXPECT().VerifyLogs(gomock.Any(), uint64(20), uint64(30)).Return(nil, nil)
+
+	require.NoError(t, h.es.Verify(t.Context()))
+
+	ranges, err := h.storage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Empty(t, ranges)
+}
+
+func TestVerify_ChunksRange(t *testing.T) {
+	h := newVerifierHarness(t)
+	h.es.verifyChunkSize = 5
+
+	// A range wider than the chunk size is verified in successive chunks.
+	require.NoError(t, h.storage.SaveUnverifiedRange(nil, operatorstorage.UnverifiedRange{From: 10, To: 20, Cursor: 10}))
+	gomock.InOrder(
+		h.exec.EXPECT().VerifyLogs(gomock.Any(), uint64(10), uint64(14)).Return(nil, nil),
+		h.exec.EXPECT().VerifyLogs(gomock.Any(), uint64(15), uint64(19)).Return(nil, nil),
+		h.exec.EXPECT().VerifyLogs(gomock.Any(), uint64(20), uint64(20)).Return(nil, nil),
+	)
+
+	require.NoError(t, h.es.Verify(t.Context()))
+
+	ranges, err := h.storage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Empty(t, ranges)
+}
+
+func TestVerifyWithRetry_RetriesTransientThenSucceeds(t *testing.T) {
+	h := newVerifierHarness(t)
+	h.es.verifyRetryInitialDelay = time.Millisecond
+	h.es.verifyRetryMaxDelay = time.Millisecond
+
+	require.NoError(t, h.storage.SaveUnverifiedRange(nil, operatorstorage.UnverifiedRange{From: 10, To: 10, Cursor: 10}))
+
+	// A transient failure is retried in-process; the second pass verifies the range clean.
+	gomock.InOrder(
+		h.exec.EXPECT().VerifyLogs(gomock.Any(), uint64(10), uint64(10)).Return(nil, errors.New("transient EL error")),
+		h.exec.EXPECT().VerifyLogs(gomock.Any(), uint64(10), uint64(10)).Return(nil, nil),
+	)
+
+	require.NoError(t, h.es.VerifyWithRetry(t.Context()))
+
+	ranges, err := h.storage.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Empty(t, ranges)
+}
+
+func TestVerifyWithRetry_DoesNotRetryResyncRequired(t *testing.T) {
+	h := newVerifierHarness(t)
+	h.es.verifyRetryInitialDelay = time.Millisecond
+	h.es.verifyRetryMaxDelay = time.Millisecond
+
+	logs := logsWith([2]uint{0, 0})
+	require.NoError(t, h.storage.SaveUnverifiedRange(nil, operatorstorage.UnverifiedRange{From: 15, To: 15, Cursor: 15}))
+	// A confirmed miss is terminal: VerifyLogs is called exactly once (Times(1)), no retry.
+	h.exec.EXPECT().VerifyLogs(gomock.Any(), uint64(15), uint64(15)).Return([]executionclient.BlockLogs{
+		{BlockNumber: 15, Logs: logs},
+	}, nil).Times(1)
+	h.expectReceipts(15, logs)
+
+	require.ErrorIs(t, h.es.VerifyWithRetry(t.Context()), ErrResyncRequired)
+}
+
+func TestVerifyWithRetry_StopsOnContextCancel(t *testing.T) {
+	h := newVerifierHarness(t)
+	h.es.verifyRetryInitialDelay = time.Hour // long enough that only cancellation ends the wait
+	h.es.verifyRetryMaxDelay = time.Hour
+
+	require.NoError(t, h.storage.SaveUnverifiedRange(nil, operatorstorage.UnverifiedRange{From: 10, To: 10, Cursor: 10}))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	// Fail transiently and cancel, so the backoff wait exits instead of retrying.
+	h.exec.EXPECT().VerifyLogs(gomock.Any(), uint64(10), uint64(10)).DoAndReturn(
+		func(context.Context, uint64, uint64) ([]executionclient.BlockLogs, error) {
+			cancel()
+			return nil, errors.New("transient")
+		})
+
+	require.ErrorIs(t, h.es.VerifyWithRetry(ctx), context.Canceled)
+}

--- a/eth/executionclient/bloom.go
+++ b/eth/executionclient/bloom.go
@@ -2,6 +2,7 @@ package executionclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sort"
@@ -139,7 +140,8 @@ func (ec *ExecutionClient) verifyLogCompleteness(ctx context.Context, logs []eth
 func (ec *ExecutionClient) resolveSuspectBlock(ctx context.Context, blockNum uint64) ([]ethtypes.Log, error) {
 	if !ec.receiptsUnsupported.Load() {
 		blockLogs, err := ec.blockLogsFromReceipts(ctx, blockNum)
-		if err == nil {
+		switch {
+		case err == nil:
 			if len(blockLogs) > 0 {
 				// The log index keeps omitting events that the block's receipts prove exist.
 				// Unlike a transient drop, this cannot be fixed by retrying eth_getLogs — any
@@ -156,12 +158,18 @@ func (ec *ExecutionClient) resolveSuspectBlock(ctx context.Context, blockNum uin
 				recordBloomFalsePositive(ctx)
 			}
 			return blockLogs, nil
-		}
-		if !isRPCMethodNotFoundError(err) {
+		case isRPCMethodNotFoundError(err):
+			ec.receiptsUnsupported.Store(true)
+			ec.logger.Info("execution client does not support eth_getBlockReceipts, falling back to timed log re-requests for suspect blocks")
+		case errors.Is(err, errInconsistentEmptyReceipts):
+			// A bloom-positive block with zero receipts is a self-inconsistent EL response; don't
+			// trust it as empty. Fall back to timed re-requests (a per-block glitch, so don't latch
+			// the receipts-unsupported memo).
+			ec.logger.Debug("block returned zero receipts for a bloom-positive block; retrying logs instead",
+				fields.BlockNumber(blockNum))
+		default:
 			return nil, fmt.Errorf("completeness check: fetch receipts for block %d: %w", blockNum, err)
 		}
-		ec.receiptsUnsupported.Store(true)
-		ec.logger.Info("execution client does not support eth_getBlockReceipts, falling back to timed log re-requests for suspect blocks")
 	}
 
 	blockLogs, err := ec.retryBlockLogs(ctx, blockNum)
@@ -227,14 +235,23 @@ func (ec *ExecutionClient) VerifyLogs(ctx context.Context, fromBlock, toBlock ui
 	return PackLogs(validLogs), nil
 }
 
-// blockLogsFromReceipts fetches the given block's transaction receipts and extracts the
-// logs emitted by the contract.
+// errInconsistentEmptyReceipts marks a block that returned zero receipts even though every
+// caller only consults receipts for a block already evidenced to hold logs (a bloom hit, or a
+// recorded/observed log). Zero receipts is then a self-inconsistent response — a broken receipt
+// store, not an authoritatively-empty block.
+var errInconsistentEmptyReceipts = errors.New("block returned zero receipts but was expected to hold logs")
+
+// blockLogsFromReceipts fetches the given block's transaction receipts and extracts the logs
+// emitted by the contract. A block with no receipts at all yields errInconsistentEmptyReceipts.
 func (ec *ExecutionClient) blockLogsFromReceipts(ctx context.Context, blockNum uint64) ([]ethtypes.Log, error) {
 	start := time.Now()
 	receipts, err := ec.client.BlockReceipts(ctx, blockNum)
 	recordRequest(ctx, ec.logger, "BlockReceipts", ec, time.Since(start), err)
 	if err != nil {
 		return nil, err
+	}
+	if len(receipts) == 0 {
+		return nil, errInconsistentEmptyReceipts
 	}
 
 	var logs []ethtypes.Log
@@ -253,8 +270,9 @@ func (ec *ExecutionClient) blockLogsFromReceipts(ctx context.Context, blockNum u
 
 // BlockContractLogs returns the contract's logs for a block derived from the block's receipts —
 // the index-independent source of truth, so it's authoritative regardless of the EL's log index.
-// receiptsAvailable is false when the EL doesn't support eth_getBlockReceipts (remembered so it
-// isn't re-attempted), in which case the caller has no authoritative source for the block.
+// receiptsAvailable is false when the EL can't authoritatively serve the block: it doesn't
+// support eth_getBlockReceipts (remembered so it isn't re-attempted), or its receipt store is
+// unreliable for the block (zero receipts where logs are evidenced).
 func (ec *ExecutionClient) BlockContractLogs(ctx context.Context, block uint64) ([]ethtypes.Log, bool, error) {
 	if ec.receiptsUnsupported.Load() {
 		return nil, false, nil
@@ -264,6 +282,14 @@ func (ec *ExecutionClient) BlockContractLogs(ctx context.Context, block uint64) 
 		if isRPCMethodNotFoundError(err) {
 			ec.receiptsUnsupported.Store(true)
 			ec.logger.Info("execution client does not support eth_getBlockReceipts; background verification can't authoritatively check blocks on it")
+			return nil, false, nil
+		}
+		if errors.Is(err, errInconsistentEmptyReceipts) {
+			// No authoritative source: report unavailable so the caller parks (or fails over
+			// under MultiClient) rather than reading a broken receipt store as an empty block
+			// and resyncing on it.
+			ec.logger.Warn("block returned zero receipts though it was expected to hold logs; no authoritative source for it",
+				fields.BlockNumber(block))
 			return nil, false, nil
 		}
 		return nil, false, fmt.Errorf("fetch receipts for block %d: %w", block, err)

--- a/eth/executionclient/bloom.go
+++ b/eth/executionclient/bloom.go
@@ -15,73 +15,109 @@ import (
 	"github.com/ssvlabs/ssv/observability/log/fields"
 )
 
-// verifyLogsWithBloom cross-checks the logs returned by FilterLogs against each block's
-// bloom filter. Blocks that returned no logs but whose bloom filter matches the contract
-// address are retried individually to recover potentially dropped events (a known Geth bug).
+// verifyLogCompleteness cross-checks the logs returned by FilterLogs against each block's
+// bloom filter and recovers events the EL silently omitted. Without it, an incomplete
+// eth_getLogs response would permanently skip the affected blocks' events.
+//
+// eth_getLogs is served from the EL's derived log index, which — unlike block headers and
+// receipts — is not consensus-verified and is not guaranteed complete relative to a block's
+// actual logs. Storage checksums protect byte-integrity, not completeness: an index that is
+// still building (snap sync), pruned, mid-rebuild, or buggy can return fewer logs than a
+// block holds, with no error (e.g. the geth log-index bug in #2722). This is defense-in-depth
+// from any EL/version — it anchors completeness to consensus-committed data (header blooms,
+// which have no false negatives, plus receipts) instead of trusting that index.
+//
+// It runs in stages, cheapest first:
+//
+//  1. Fetch the headers of all blocks that returned no logs (one batched request) and test
+//     each bloom against the contract address. Blooms are consensus-verified and have no
+//     false negatives, so a non-matching bloom proves the block is genuinely empty.
+//  2. Re-request each remaining suspect block with a single-block query (all sent as one
+//     batched request). This recovers intermittent per-request drops (observed with geth).
+//  3. Resolve suspects that still return nothing via eth_getBlockReceipts. Receipts come
+//     from the EL's receipt store rather than its log index, so they settle the ambiguity
+//     decisively: either they contain the events a broken log index will never return
+//     (recovered directly from the receipts), or they prove the bloom hit was a false
+//     positive. ELs without eth_getBlockReceipts fall back to timed single-block retries.
+//
+// This is the inline verification path (streaming, and the resync-repair). Optimistic
+// historical sync skips it and is checked afterwards by the background verifier, which reuses
+// the same recovery via VerifyLogs.
 //
 // This is a block-level check only — it assumes all-or-nothing drops (an entire block's
 // logs are missing). Partial drops (some logs present, some missing within the same block)
 // have not been observed and are not handled here.
-func (ec *ExecutionClient) verifyLogsWithBloom(ctx context.Context, logs []ethtypes.Log, fromBlock, toBlock uint64) ([]ethtypes.Log, error) {
+func (ec *ExecutionClient) verifyLogCompleteness(ctx context.Context, logs []ethtypes.Log, fromBlock, toBlock uint64) ([]ethtypes.Log, error) {
 	// Build a set of blocks that already have logs in the result.
 	blocksWithLogs := make(map[uint64]bool)
 	for i := range logs {
 		blocksWithLogs[logs[i].BlockNumber] = true
 	}
 
-	recovered := false
+	emptyBlocks := make([]uint64, 0, toBlock-fromBlock+1)
 	for blockNum := fromBlock; blockNum <= toBlock; blockNum++ {
-		if blocksWithLogs[blockNum] {
-			continue // block already has logs, nothing to verify
+		if !blocksWithLogs[blockNum] {
+			emptyBlocks = append(emptyBlocks, blockNum)
 		}
+	}
+	if len(emptyBlocks) == 0 {
+		return logs, nil
+	}
 
-		header, err := ec.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNum))
-		if err != nil {
-			return nil, fmt.Errorf("bloom check: fetch header for block %d: %w", blockNum, err)
+	start := time.Now()
+	headers, err := ec.client.HeadersByNumbers(ctx, emptyBlocks)
+	recordRequest(ctx, ec.logger, "HeadersByNumbers", ec, time.Since(start), err)
+	if err != nil {
+		return nil, fmt.Errorf("completeness check: fetch headers for blocks %d-%d: %w", fromBlock, toBlock, err)
+	}
+
+	suspects := make([]uint64, 0, len(emptyBlocks))
+	for i, header := range headers {
+		if header.Bloom.Test(ec.contractAddress.Bytes()) {
+			suspects = append(suspects, emptyBlocks[i])
 		}
+	}
+	if len(suspects) == 0 {
+		return logs, nil
+	}
 
-		if !header.Bloom.Test(ec.contractAddress.Bytes()) {
-			continue // bloom says no SSV events in this block — genuine empty
-		}
+	// Bloom matched but FilterLogs returned nothing. This is inconclusive on its own: it
+	// happens routinely as a benign bloom false positive (the filter is probabilistic and
+	// other logs in the block can set the contract's bits), and only occasionally because
+	// the EL actually dropped logs. We therefore log it at debug and let the stages below
+	// decide — a successful recovery is what gets promoted to a warning.
+	ec.logger.Debug("bloom matched contract for blocks the EL returned no logs for, re-requesting to confirm",
+		zap.Uint64s("blocks", suspects),
+		zap.String("contract", ec.contractAddress.Hex()),
+	)
 
-		// Bloom matched but FilterLogs returned nothing. This is inconclusive on its
-		// own: it happens routinely as a benign bloom false positive (the filter is
-		// probabilistic and other logs in the block can set the contract's bits), and
-		// only occasionally because the EL actually dropped logs. We therefore log it
-		// at debug and let the retry below decide — a successful recovery is what gets
-		// promoted to a warning.
-		ec.logger.Debug("bloom matched contract but EL returned no logs for block, retrying to confirm",
-			fields.BlockNumber(blockNum),
-			zap.String("contract", ec.contractAddress.Hex()),
-		)
+	start = time.Now()
+	suspectLogs, err := ec.client.SingleBlockLogs(ctx, ec.contractAddress, suspects)
+	recordRequest(ctx, ec.logger, "SingleBlockLogs", ec, time.Since(start), err)
+	if err != nil {
+		return nil, fmt.Errorf("completeness check: re-request logs for suspect blocks: %w", err)
+	}
 
-		blockLogs, err := ec.retryBlockLogs(ctx, blockNum)
-		if err != nil {
-			return nil, fmt.Errorf("bloom check: retry block %d logs: %w", blockNum, err)
-		}
-
-		if len(blockLogs) > 0 {
-			// The retry recovered logs the EL had omitted from the original response.
-			// The block bloom is consensus-verified, so these events are genuine and
-			// were dropped by the EL — this is not a bloom false positive. This is the
-			// actionable signal: the execution client returned incomplete logs, which
-			// would have been silently skipped without this cross-check.
-			ec.logger.Warn("recovered contract logs the execution client omitted on first request",
-				fields.BlockNumber(blockNum),
-				zap.Int("recovered_events", len(blockLogs)),
-				zap.String("contract", ec.contractAddress.Hex()),
-				zap.String("recommendation", "events were not lost, but the EL returned incomplete logs (e.g. known geth log-dropping bug) — consider updating or checking your execution client"),
-			)
-			recordBloomRecovery(ctx)
-			logs = append(logs, blockLogs...)
-			recovered = true
+	recovered := false
+	for i, blockLogs := range suspectLogs {
+		if len(blockLogs) == 0 {
+			blockLogs, err = ec.resolveSuspectBlock(ctx, suspects[i])
+			if err != nil {
+				return nil, err
+			}
+			if len(blockLogs) == 0 {
+				continue
+			}
 		} else {
-			// Bloom false positive — address was in bloom but no actual logs for our contract.
-			recordBloomFalsePositive(ctx)
+			ec.reportOmittedLogsRecovery(ctx, suspects[i], len(blockLogs))
 		}
+		logs = append(logs, blockLogs...)
+		recovered = true
 	}
 
 	// Re-sort if we appended recovered logs so downstream receives them in block/tx order.
+	// Match PackLogs' (block, tx) key exactly — it re-sorts afterwards, so any finer tiebreaker
+	// here would just be undone.
 	if recovered {
 		sort.Slice(logs, func(i, j int) bool {
 			if logs[i].BlockNumber != logs[j].BlockNumber {
@@ -92,6 +128,147 @@ func (ec *ExecutionClient) verifyLogsWithBloom(ctx context.Context, logs []ethty
 	}
 
 	return logs, nil
+}
+
+// resolveSuspectBlock settles a block whose bloom matches the contract but for which the
+// EL keeps returning no logs: either the bloom hit is a false positive, or the EL's log
+// index is persistently broken for that block. eth_getBlockReceipts distinguishes the two
+// (and directly yields the missing logs when it is the latter); ELs without the method fall
+// back to timed retries, which can only recover intermittent drops. Returns the recovered
+// logs, or nil when the block is presumed a false positive.
+func (ec *ExecutionClient) resolveSuspectBlock(ctx context.Context, blockNum uint64) ([]ethtypes.Log, error) {
+	if !ec.receiptsUnsupported.Load() {
+		blockLogs, err := ec.blockLogsFromReceipts(ctx, blockNum)
+		if err == nil {
+			if len(blockLogs) > 0 {
+				// The log index keeps omitting events that the block's receipts prove exist.
+				// Unlike a transient drop, this cannot be fixed by retrying eth_getLogs — any
+				// range query over this block is silently incomplete.
+				ec.logger.Warn("recovered contract logs from block receipts that the execution client's log index did not return",
+					fields.BlockNumber(blockNum),
+					zap.Int("recovered_events", len(blockLogs)),
+					zap.String("contract", ec.contractAddress.Hex()),
+					zap.String("recommendation", "the EL omits events from eth_getLogs responses that its own receipts contain — its log index may be incomplete or corrupt, consider resyncing or updating your execution client"),
+				)
+				recordBloomReceiptsRecovery(ctx)
+			} else {
+				// Receipts confirm the block holds no contract events — bloom false positive.
+				recordBloomFalsePositive(ctx)
+			}
+			return blockLogs, nil
+		}
+		if !isRPCMethodNotFoundError(err) {
+			return nil, fmt.Errorf("completeness check: fetch receipts for block %d: %w", blockNum, err)
+		}
+		ec.receiptsUnsupported.Store(true)
+		ec.logger.Info("execution client does not support eth_getBlockReceipts, falling back to timed log re-requests for suspect blocks")
+	}
+
+	blockLogs, err := ec.retryBlockLogs(ctx, blockNum)
+	if err != nil {
+		return nil, fmt.Errorf("completeness check: retry block %d logs: %w", blockNum, err)
+	}
+	if len(blockLogs) > 0 {
+		ec.reportOmittedLogsRecovery(ctx, blockNum, len(blockLogs))
+	} else {
+		// Presumed bloom false positive — the address was in the bloom, but the EL never
+		// produced logs for it and receipts were unavailable to prove it either way.
+		recordBloomFalsePositive(ctx)
+	}
+	return blockLogs, nil
+}
+
+// reportOmittedLogsRecovery logs and counts the recovery of logs the EL omitted from an
+// eth_getLogs response but returned on a re-request (an intermittent drop). The block
+// bloom is consensus-verified, so the recovered events are genuine — the EL returned an
+// incomplete response that would have been silently accepted without the cross-check.
+func (ec *ExecutionClient) reportOmittedLogsRecovery(ctx context.Context, blockNum uint64, recoveredEvents int) {
+	ec.logger.Warn("recovered contract logs the execution client omitted on first request",
+		fields.BlockNumber(blockNum),
+		zap.Int("recovered_events", recoveredEvents),
+		zap.String("contract", ec.contractAddress.Hex()),
+		zap.String("recommendation", "events were not lost, but the EL returned incomplete logs (e.g. known geth log-dropping bug) — consider updating or checking your execution client"),
+	)
+	recordBloomRecovery(ctx)
+}
+
+// VerifyLogs fetches the contract's logs for [fromBlock, toBlock] and returns them verified
+// complete — running the exact same bloom/receipts completeness check as the inline path, so
+// only genuinely-omitted logs trigger receipts recovery (and the accurate recovery logging
+// and metrics). It is the background verifier's per-chunk operation for a range that was
+// synced optimistically. Returned BlockLogs are complete and ordered.
+func (ec *ExecutionClient) VerifyLogs(ctx context.Context, fromBlock, toBlock uint64) ([]BlockLogs, error) {
+	if fromBlock > toBlock {
+		return nil, ErrBadInput
+	}
+
+	logs, err := ec.subdivideLogFetch(ctx, ethereum.FilterQuery{
+		Addresses: []ethcommon.Address{ec.contractAddress},
+		FromBlock: new(big.Int).SetUint64(fromBlock),
+		ToBlock:   new(big.Int).SetUint64(toBlock),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("verify logs [%d,%d]: fetch: %w", fromBlock, toBlock, err)
+	}
+
+	logs, err = ec.verifyLogCompleteness(ctx, logs, fromBlock, toBlock)
+	if err != nil {
+		return nil, fmt.Errorf("verify logs [%d,%d]: completeness check: %w", fromBlock, toBlock, err)
+	}
+
+	validLogs := make([]ethtypes.Log, 0, len(logs))
+	for _, log := range logs {
+		if log.Removed {
+			continue // reorg'd log; not expected below the follow distance, skip defensively
+		}
+		validLogs = append(validLogs, log)
+	}
+
+	return PackLogs(validLogs), nil
+}
+
+// blockLogsFromReceipts fetches the given block's transaction receipts and extracts the
+// logs emitted by the contract.
+func (ec *ExecutionClient) blockLogsFromReceipts(ctx context.Context, blockNum uint64) ([]ethtypes.Log, error) {
+	start := time.Now()
+	receipts, err := ec.client.BlockReceipts(ctx, blockNum)
+	recordRequest(ctx, ec.logger, "BlockReceipts", ec, time.Since(start), err)
+	if err != nil {
+		return nil, err
+	}
+
+	var logs []ethtypes.Log
+	for _, receipt := range receipts {
+		if receipt == nil {
+			continue
+		}
+		for _, log := range receipt.Logs {
+			if log != nil && log.Address == ec.contractAddress {
+				logs = append(logs, *log)
+			}
+		}
+	}
+	return logs, nil
+}
+
+// BlockContractLogs returns the contract's logs for a block derived from the block's receipts —
+// the index-independent source of truth, so it's authoritative regardless of the EL's log index.
+// receiptsAvailable is false when the EL doesn't support eth_getBlockReceipts (remembered so it
+// isn't re-attempted), in which case the caller has no authoritative source for the block.
+func (ec *ExecutionClient) BlockContractLogs(ctx context.Context, block uint64) ([]ethtypes.Log, bool, error) {
+	if ec.receiptsUnsupported.Load() {
+		return nil, false, nil
+	}
+	logs, err := ec.blockLogsFromReceipts(ctx, block)
+	if err != nil {
+		if isRPCMethodNotFoundError(err) {
+			ec.receiptsUnsupported.Store(true)
+			ec.logger.Info("execution client does not support eth_getBlockReceipts; background verification can't authoritatively check blocks on it")
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("fetch receipts for block %d: %w", block, err)
+	}
+	return logs, true, nil
 }
 
 // retryBlockLogs retries FilterLogs for a single block up to DefaultBloomRetryAttempts times
@@ -117,8 +294,8 @@ func (ec *ExecutionClient) retryBlockLogs(ctx context.Context, blockNumber uint6
 
 		logs, err := ec.FilterLogs(ctx, query)
 		if err != nil {
-			// Transient RPC failure the retry usually absorbs. The final attempt returns
-			// this error, which the streaming retry loop logs at error level — so debug here.
+			// Transient RPC failure the retry usually absorbs; only the final attempt's
+			// error propagates to the caller, which logs it — so debug here.
 			ec.logger.Debug("bloom retry: FilterLogs failed",
 				fields.BlockNumber(blockNumber),
 				zap.Int("attempt", attempt),

--- a/eth/executionclient/bloom_test.go
+++ b/eth/executionclient/bloom_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -15,15 +14,129 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
 
-const ethGetLogsMethod = "eth_getLogs"
+const (
+	ethGetLogsMethod          = "eth_getLogs"
+	ethGetBlockByNumberMethod = "eth_getBlockByNumber"
+	ethGetBlockReceiptsMethod = "eth_getBlockReceipts"
+)
 
-// TestBloomCrossCheck_RecoversMissingLogs verifies that the bloom filter cross-check
-// detects and recovers events that the EL silently dropped (simulates the Geth bug).
+// jsonrpcMessage is a minimal JSON-RPC 2.0 envelope used by the test proxy.
+type jsonrpcMessage struct {
+	Version string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   json.RawMessage `json:"error,omitempty"`
+}
+
+// forwardFunc relays a single JSON-RPC request to the real backend and returns its response.
+type forwardFunc func(req jsonrpcMessage) jsonrpcMessage
+
+// newRPCProxy serves JSON-RPC over HTTP in front of the given backend handler, routing
+// every request — including each element of a batch request — through handle. The handler
+// may respond itself (returning a message whose ID is filled in by the proxy), forward the
+// request via the provided forwardFunc and tamper with the response, or return nil to
+// forward the request untouched.
+func newRPCProxy(t *testing.T, base http.Handler, handle func(req jsonrpcMessage, forward forwardFunc) *jsonrpcMessage) *httptest.Server {
+	forward := func(req jsonrpcMessage) jsonrpcMessage {
+		body, err := json.Marshal(req)
+		require.NoError(t, err)
+		httpReq := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+		httpReq.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		base.ServeHTTP(rec, httpReq)
+		var resp jsonrpcMessage
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		return resp
+	}
+
+	serve := func(req jsonrpcMessage) jsonrpcMessage {
+		if resp := handle(req, forward); resp != nil {
+			resp.Version = "2.0"
+			resp.ID = req.ID
+			return *resp
+		}
+		return forward(req)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+
+		if bytes.HasPrefix(bytes.TrimSpace(raw), []byte("[")) {
+			var reqs []jsonrpcMessage
+			require.NoError(t, json.Unmarshal(raw, &reqs))
+			resps := make([]jsonrpcMessage, 0, len(reqs))
+			for _, req := range reqs {
+				resps = append(resps, serve(req))
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(resps))
+			return
+		}
+
+		var req jsonrpcMessage
+		require.NoError(t, json.Unmarshal(raw, &req))
+		require.NoError(t, json.NewEncoder(w).Encode(serve(req)))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// getLogsRange extracts the block range of an eth_getLogs request.
+func getLogsRange(t *testing.T, params json.RawMessage) (from, to uint64) {
+	var filters []map[string]any
+	require.NoError(t, json.Unmarshal(params, &filters))
+	require.NotEmpty(t, filters)
+	fromHex, _ := filters[0]["fromBlock"].(string)
+	toHex, _ := filters[0]["toBlock"].(string)
+	from, err := hexutil.DecodeUint64(fromHex)
+	require.NoError(t, err)
+	to, err = hexutil.DecodeUint64(toHex)
+	require.NoError(t, err)
+	return from, to
+}
+
+// dropLogsForBlock removes all logs of the given block from an eth_getLogs result.
+func dropLogsForBlock(t *testing.T, result json.RawMessage, blockNumber uint64) json.RawMessage {
+	var logs []map[string]any
+	require.NoError(t, json.Unmarshal(result, &logs))
+	kept := make([]map[string]any, 0, len(logs))
+	for _, logEntry := range logs {
+		num, err := hexutil.DecodeUint64(logEntry["blockNumber"].(string))
+		require.NoError(t, err)
+		if num != blockNumber {
+			kept = append(kept, logEntry)
+		}
+	}
+	out, err := json.Marshal(kept)
+	require.NoError(t, err)
+	return out
+}
+
+// requestedBlock extracts the block number argument of an eth_getBlockByNumber or
+// eth_getBlockReceipts request.
+func requestedBlock(t *testing.T, params json.RawMessage) uint64 {
+	var args []any
+	require.NoError(t, json.Unmarshal(params, &args))
+	require.NotEmpty(t, args)
+	numHex, ok := args[0].(string)
+	require.True(t, ok)
+	num, err := hexutil.DecodeUint64(numHex)
+	require.NoError(t, err)
+	return num
+}
+
+// TestBloomCrossCheck_RecoversMissingLogs verifies that the completeness check detects
+// and recovers events the EL dropped from a range query but returns on a single-block
+// re-request (simulates the intermittent Geth bug).
 func TestBloomCrossCheck_RecoversMissingLogs(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
@@ -36,64 +149,26 @@ func TestBloomCrossCheck_RecoversMissingLogs(t *testing.T) {
 	err = env.createBlocksWithLogs(contract, totalBlocks, 0)
 	require.NoError(t, err)
 
-	// Set up a proxy that drops logs for one specific block.
 	rpcSrv, _ := env.sim.Node().RPCHandler()
-	base := http.Handler(rpcSrv)
 
 	// The contract deploy is block 1, then transactions are blocks 2..6.
-	// We'll drop logs for block 4.
+	// We'll drop logs for block 4 from wide queries; single-block re-requests
+	// pass through to the real backend and return the truth.
 	const dropBlock uint64 = 4
-	var filterCallCount atomic.Int32
+	var getLogsCalls atomic.Int32
 
-	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		raw, _ := io.ReadAll(r.Body)
-		var req map[string]any
-		_ = json.Unmarshal(raw, &req)
-
-		if req["method"] == ethGetLogsMethod {
-			filterCallCount.Add(1)
-
-			flt := req["params"].([]any)[0].(map[string]any)
-			from, _ := strconv.ParseInt(strings.TrimPrefix(flt["fromBlock"].(string), "0x"), 16, 64)
-			to, _ := strconv.ParseInt(strings.TrimPrefix(flt["toBlock"].(string), "0x"), 16, 64)
-
-			// If this is a wide query (not a single-block retry), intercept and filter out the dropped block.
-			if uint64(to-from) > 0 {
-				// Forward to real backend
-				r.Body = io.NopCloser(bytes.NewReader(raw))
-				rec := httptest.NewRecorder()
-				base.ServeHTTP(rec, r)
-
-				// Parse the response and remove logs from dropBlock.
-				var resp map[string]any
-				_ = json.Unmarshal(rec.Body.Bytes(), &resp)
-
-				if result, ok := resp["result"].([]any); ok {
-					filtered := make([]any, 0, len(result))
-					for _, entry := range result {
-						logEntry := entry.(map[string]any)
-						blockHex := logEntry["blockNumber"].(string)
-						blockNum, _ := strconv.ParseInt(strings.TrimPrefix(blockHex, "0x"), 16, 64)
-						if uint64(blockNum) != dropBlock {
-							filtered = append(filtered, entry)
-						}
-					}
-					resp["result"] = filtered
-				}
-
-				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode(resp)
-				return
-			}
-			// Single-block retry queries pass through to real backend.
+	srv := newRPCProxy(t, rpcSrv, func(req jsonrpcMessage, forward forwardFunc) *jsonrpcMessage {
+		if req.Method != ethGetLogsMethod {
+			return nil
 		}
-
-		r.Body = io.NopCloser(bytes.NewReader(raw))
-		base.ServeHTTP(w, r)
+		getLogsCalls.Add(1)
+		if from, to := getLogsRange(t, req.Params); from == to {
+			return nil // single-block re-request — answer truthfully
+		}
+		resp := forward(req)
+		resp.Result = dropLogsForBlock(t, resp.Result, dropBlock)
+		return &resp
 	})
-
-	srv := httptest.NewServer(wrapped)
-	t.Cleanup(srv.Close)
 
 	client, err := New(t.Context(), srv.URL, env.contractAddr,
 		WithLogger(logger),
@@ -101,7 +176,6 @@ func TestBloomCrossCheck_RecoversMissingLogs(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, client.Close()) })
 
-	// Use fetchLogsInBatches directly with verifyBloom=true (FetchHistoricalLogs skips bloom checks).
 	currentBlock, err := client.client.BlockNumber(t.Context())
 	require.NoError(t, err)
 
@@ -114,16 +188,265 @@ func TestBloomCrossCheck_RecoversMissingLogs(t *testing.T) {
 	require.NoError(t, <-errCh)
 
 	// We should have recovered the dropped block's log, so all 5 events are present.
-	require.Equal(t, totalBlocks, len(allLogs), "bloom cross-check should recover the dropped log")
+	require.Equal(t, totalBlocks, len(allLogs), "completeness check should recover the dropped log")
 
-	// The proxy should have been called more than once for eth_getLogs:
-	// 1 initial wide query + at least 1 single-block retry.
-	require.Greater(t, filterCallCount.Load(), int32(1), "expected at least one retry for bloom mismatch")
+	// The proxy should have seen more than one eth_getLogs:
+	// 1 initial wide query + at least 1 single-block re-request.
+	require.Greater(t, getLogsCalls.Load(), int32(1), "expected at least one re-request for the suspect block")
+}
+
+// TestFetchHistoricalLogs_RecoversDroppedLogs verifies that the historical sync path —
+// the one that runs on every node startup — recovers events the EL dropped from a range
+// query. This is the regression test for silently losing registry events during
+// historical sync (#2990).
+func TestFetchHistoricalLogs_RecoversDroppedLogs(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	env := setupTestEnv(t, 10*time.Second)
+	contract, err := env.deployCallableContract()
+	require.NoError(t, err)
+
+	// Contract deploy is block 1, event blocks are 2..6, then FollowDistance padding
+	// blocks so the historical fetch window covers all event blocks.
+	const totalBlocks = 5
+	err = env.createBlocksWithLogs(contract, totalBlocks, 0)
+	require.NoError(t, err)
+	for i := 0; i < FollowDistance; i++ {
+		env.sim.Commit()
+	}
+
+	rpcSrv, _ := env.sim.Node().RPCHandler()
+
+	const dropBlock uint64 = 4
+	srv := newRPCProxy(t, rpcSrv, func(req jsonrpcMessage, forward forwardFunc) *jsonrpcMessage {
+		if req.Method != ethGetLogsMethod {
+			return nil
+		}
+		if from, to := getLogsRange(t, req.Params); from == to {
+			return nil
+		}
+		resp := forward(req)
+		resp.Result = dropLogsForBlock(t, resp.Result, dropBlock)
+		return &resp
+	})
+
+	client, err := New(t.Context(), srv.URL, env.contractAddr,
+		WithLogger(logger),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	logsCh, errsCh, err := client.FetchHistoricalLogs(t.Context(), 0, true)
+	require.NoError(t, err)
+
+	allLogs := make([]ethtypes.Log, 0, totalBlocks)
+	for block := range logsCh {
+		allLogs = append(allLogs, block.Logs...)
+	}
+	require.NoError(t, <-errsCh)
+
+	require.Equal(t, totalBlocks, len(allLogs), "historical sync should recover the dropped log")
+	recoveredDropped := false
+	for _, logEntry := range allLogs {
+		if logEntry.BlockNumber == dropBlock {
+			recoveredDropped = true
+		}
+	}
+	require.True(t, recoveredDropped, "the dropped block's event should be present")
+}
+
+// TestReceiptsCrossCheck_RecoversPersistentlyDroppedLogs verifies that when the EL never
+// returns a block's logs from eth_getLogs (e.g. a broken log index) — so re-requests
+// cannot recover them — the events are recovered from the block's receipts.
+func TestReceiptsCrossCheck_RecoversPersistentlyDroppedLogs(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	env := setupTestEnv(t, 10*time.Second)
+	contract, err := env.deployCallableContract()
+	require.NoError(t, err)
+
+	const totalBlocks = 5
+	err = env.createBlocksWithLogs(contract, totalBlocks, 0)
+	require.NoError(t, err)
+
+	rpcSrv, _ := env.sim.Node().RPCHandler()
+
+	// Drop block 4's logs from every eth_getLogs response, wide or single-block,
+	// simulating a persistently broken log index. Receipts pass through untouched.
+	const dropBlock uint64 = 4
+	var receiptsCalls atomic.Int32
+
+	srv := newRPCProxy(t, rpcSrv, func(req jsonrpcMessage, forward forwardFunc) *jsonrpcMessage {
+		switch req.Method {
+		case ethGetLogsMethod:
+			resp := forward(req)
+			resp.Result = dropLogsForBlock(t, resp.Result, dropBlock)
+			return &resp
+		case ethGetBlockReceiptsMethod:
+			receiptsCalls.Add(1)
+		}
+		return nil
+	})
+
+	client, err := New(t.Context(), srv.URL, env.contractAddr,
+		WithLogger(logger),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	currentBlock, err := client.client.BlockNumber(t.Context())
+	require.NoError(t, err)
+
+	logsCh, errCh := client.fetchLogsInBatches(t.Context(), 0, currentBlock, true)
+
+	allLogs := make([]ethtypes.Log, 0, totalBlocks)
+	for block := range logsCh {
+		allLogs = append(allLogs, block.Logs...)
+	}
+	require.NoError(t, <-errCh)
+
+	require.Equal(t, totalBlocks, len(allLogs), "receipts cross-check should recover the persistently dropped log")
+	recoveredDropped := false
+	for _, logEntry := range allLogs {
+		if logEntry.BlockNumber == dropBlock {
+			recoveredDropped = true
+			require.Equal(t, env.contractAddr, logEntry.Address)
+		}
+	}
+	require.True(t, recoveredDropped, "the dropped block's event should be recovered from receipts")
+	require.GreaterOrEqual(t, receiptsCalls.Load(), int32(1), "expected a receipts fetch for the suspect block")
+	require.False(t, client.receiptsUnsupported.Load())
+}
+
+// TestReceiptsUnsupported_FallsBackToTimedRetry verifies that when the EL does not
+// support eth_getBlockReceipts, suspect blocks are resolved with timed single-block
+// retries (the pre-receipts behavior), and the lack of support is remembered.
+func TestReceiptsUnsupported_FallsBackToTimedRetry(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	env := setupTestEnv(t, 15*time.Second)
+	contract, err := env.deployCallableContract()
+	require.NoError(t, err)
+
+	const totalBlocks = 5
+	err = env.createBlocksWithLogs(contract, totalBlocks, 0)
+	require.NoError(t, err)
+
+	rpcSrv, _ := env.sim.Node().RPCHandler()
+
+	// Drop block 4's logs from wide queries and from the first two single-block
+	// requests, then start telling the truth — so only a delayed retry recovers it.
+	// Receipts are rejected as an unsupported method.
+	const dropBlock uint64 = 4
+	var singleBlockCalls atomic.Int32
+
+	srv := newRPCProxy(t, rpcSrv, func(req jsonrpcMessage, forward forwardFunc) *jsonrpcMessage {
+		switch req.Method {
+		case ethGetLogsMethod:
+			from, to := getLogsRange(t, req.Params)
+			if from == to {
+				if from == dropBlock && singleBlockCalls.Add(1) <= 2 {
+					return &jsonrpcMessage{Result: json.RawMessage(`[]`)}
+				}
+				return nil
+			}
+			resp := forward(req)
+			resp.Result = dropLogsForBlock(t, resp.Result, dropBlock)
+			return &resp
+		case ethGetBlockReceiptsMethod:
+			return &jsonrpcMessage{Error: json.RawMessage(`{"code":-32601,"message":"the method eth_getBlockReceipts does not exist/is not available"}`)}
+		}
+		return nil
+	})
+
+	client, err := New(t.Context(), srv.URL, env.contractAddr,
+		WithLogger(logger),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	currentBlock, err := client.client.BlockNumber(t.Context())
+	require.NoError(t, err)
+
+	logsCh, errCh := client.fetchLogsInBatches(t.Context(), 0, currentBlock, true)
+
+	allLogs := make([]ethtypes.Log, 0, totalBlocks)
+	for block := range logsCh {
+		allLogs = append(allLogs, block.Logs...)
+	}
+	require.NoError(t, <-errCh)
+
+	require.Equal(t, totalBlocks, len(allLogs), "timed retry fallback should recover the dropped log")
+	require.True(t, client.receiptsUnsupported.Load(), "unsupported eth_getBlockReceipts should be remembered")
+}
+
+// TestBloomFalsePositive_ConfirmedByReceipts verifies that a block whose bloom matches
+// the contract without holding any of its events (a bloom false positive) is confirmed
+// empty via receipts without injecting spurious logs or failing the fetch.
+func TestBloomFalsePositive_ConfirmedByReceipts(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	env := setupTestEnv(t, 10*time.Second)
+	contract, err := env.deployCallableContract()
+	require.NoError(t, err)
+
+	// Blocks 2, 3 have events; block 4 is empty.
+	const totalBlocks = 2
+	err = env.createBlocksWithLogs(contract, totalBlocks, 0)
+	require.NoError(t, err)
+	env.sim.Commit()
+
+	rpcSrv, _ := env.sim.Node().RPCHandler()
+
+	// Force block 4's bloom to match everything, making it a guaranteed false positive.
+	const falsePositiveBlock uint64 = 4
+	var receiptsCalls atomic.Int32
+	saturatedBloom := "0x" + strings.Repeat("ff", 256)
+
+	srv := newRPCProxy(t, rpcSrv, func(req jsonrpcMessage, forward forwardFunc) *jsonrpcMessage {
+		switch req.Method {
+		case ethGetBlockByNumberMethod:
+			if requestedBlock(t, req.Params) != falsePositiveBlock {
+				return nil
+			}
+			resp := forward(req)
+			var header map[string]any
+			require.NoError(t, json.Unmarshal(resp.Result, &header))
+			header["logsBloom"] = saturatedBloom
+			raw, err := json.Marshal(header)
+			require.NoError(t, err)
+			resp.Result = raw
+			return &resp
+		case ethGetBlockReceiptsMethod:
+			receiptsCalls.Add(1)
+		}
+		return nil
+	})
+
+	client, err := New(t.Context(), srv.URL, env.contractAddr,
+		WithLogger(logger),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	currentBlock, err := client.client.BlockNumber(t.Context())
+	require.NoError(t, err)
+
+	logsCh, errCh := client.fetchLogsInBatches(t.Context(), 0, currentBlock, true)
+
+	allLogs := make([]ethtypes.Log, 0, totalBlocks)
+	for block := range logsCh {
+		allLogs = append(allLogs, block.Logs...)
+	}
+	require.NoError(t, <-errCh)
+
+	require.Equal(t, totalBlocks, len(allLogs), "a bloom false positive should not inject or drop logs")
+	require.GreaterOrEqual(t, receiptsCalls.Load(), int32(1), "the false positive should have been confirmed via receipts")
 }
 
 // TestBloomCrossCheck_NoFalseRecovery verifies that when no logs are dropped
-// (all blocks genuinely have no events or already have logs), the bloom check
-// does not inject spurious events.
+// (all blocks genuinely have no events or already have logs), the completeness
+// check does not inject spurious events.
 func TestBloomCrossCheck_NoFalseRecovery(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
@@ -141,7 +464,6 @@ func TestBloomCrossCheck_NoFalseRecovery(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Use fetchLogsInBatches directly with verifyBloom=true to actually exercise bloom checks.
 	currentBlock, err := env.client.client.BlockNumber(t.Context())
 	require.NoError(t, err)
 
@@ -156,9 +478,9 @@ func TestBloomCrossCheck_NoFalseRecovery(t *testing.T) {
 	require.Equal(t, totalBlocks, len(allLogs), "should get exactly the expected number of logs")
 }
 
-// TestVerifyLogsWithBloom_EmptyRange verifies that bloom verification handles
+// TestVerifyLogCompleteness_EmptyRange verifies that the completeness check handles
 // an empty log slice for a range where no events exist.
-func TestVerifyLogsWithBloom_EmptyRange(t *testing.T) {
+func TestVerifyLogCompleteness_EmptyRange(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
 	env := setupTestEnv(t, 5*time.Second)
@@ -175,15 +497,16 @@ func TestVerifyLogsWithBloom_EmptyRange(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Call verifyLogsWithBloom directly with empty logs.
-	result, err := env.client.verifyLogsWithBloom(env.ctx, nil, 2, 6)
+	// Call verifyLogCompleteness directly with empty logs.
+	result, err := env.client.verifyLogCompleteness(env.ctx, nil, 2, 6)
 	require.NoError(t, err)
-	require.Empty(t, result, "empty blocks should produce no logs even after bloom check")
+	require.Empty(t, result, "empty blocks should produce no logs even after the completeness check")
 }
 
-// TestBloomCrossCheck_RetryExhausted verifies that when retries fail with RPC errors,
-// the error propagates and no partial data is emitted.
-func TestBloomCrossCheck_RetryExhausted(t *testing.T) {
+// TestBloomCrossCheck_ResolutionErrorPropagates verifies that when the suspect-block
+// re-request keeps failing with RPC errors, the error propagates and no partial data
+// is emitted.
+func TestBloomCrossCheck_ResolutionErrorPropagates(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
 	env := setupTestEnv(t, 10*time.Second)
@@ -207,62 +530,26 @@ func TestBloomCrossCheck_RetryExhausted(t *testing.T) {
 		env.sim.Commit()
 	}
 
-	// Proxy: drop logs for block 3 on wide queries, and return HTTP 500 for single-block retries of block 3.
 	rpcSrv, _ := env.sim.Node().RPCHandler()
-	base := http.Handler(rpcSrv)
 
+	// Drop block 3's logs from wide queries, and fail every single-block request for it.
 	const dropBlock uint64 = 3
 
-	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		raw, _ := io.ReadAll(r.Body)
-		var req map[string]any
-		_ = json.Unmarshal(raw, &req)
-
-		if req["method"] == ethGetLogsMethod {
-			flt := req["params"].([]any)[0].(map[string]any)
-			from, _ := strconv.ParseInt(strings.TrimPrefix(flt["fromBlock"].(string), "0x"), 16, 64)
-			to, _ := strconv.ParseInt(strings.TrimPrefix(flt["toBlock"].(string), "0x"), 16, 64)
-
-			if uint64(from) == dropBlock && uint64(to) == dropBlock {
-				// Single-block retry — return error.
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-				return
-			}
-
-			if uint64(to-from) > 0 {
-				// Wide query — drop logs for dropBlock.
-				r.Body = io.NopCloser(bytes.NewReader(raw))
-				rec := httptest.NewRecorder()
-				base.ServeHTTP(rec, r)
-
-				var resp map[string]any
-				_ = json.Unmarshal(rec.Body.Bytes(), &resp)
-
-				if result, ok := resp["result"].([]any); ok {
-					filtered := make([]any, 0, len(result))
-					for _, entry := range result {
-						logEntry := entry.(map[string]any)
-						blockHex := logEntry["blockNumber"].(string)
-						blockNum, _ := strconv.ParseInt(strings.TrimPrefix(blockHex, "0x"), 16, 64)
-						if uint64(blockNum) != dropBlock {
-							filtered = append(filtered, entry)
-						}
-					}
-					resp["result"] = filtered
-				}
-
-				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode(resp)
-				return
-			}
+	srv := newRPCProxy(t, rpcSrv, func(req jsonrpcMessage, forward forwardFunc) *jsonrpcMessage {
+		if req.Method != ethGetLogsMethod {
+			return nil
 		}
-
-		r.Body = io.NopCloser(bytes.NewReader(raw))
-		base.ServeHTTP(w, r)
+		from, to := getLogsRange(t, req.Params)
+		if from == dropBlock && to == dropBlock {
+			return &jsonrpcMessage{Error: json.RawMessage(`{"code":-32000,"message":"internal error"}`)}
+		}
+		if from != to {
+			resp := forward(req)
+			resp.Result = dropLogsForBlock(t, resp.Result, dropBlock)
+			return &resp
+		}
+		return nil
 	})
-
-	srv := httptest.NewServer(wrapped)
-	t.Cleanup(srv.Close)
 
 	client, err := New(t.Context(), srv.URL, contractAddr,
 		WithLogger(logger),
@@ -270,7 +557,6 @@ func TestBloomCrossCheck_RetryExhausted(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, client.Close()) })
 
-	// Use fetchLogsInBatches directly with verifyBloom=true (FetchHistoricalLogs skips bloom checks).
 	currentBlock, err := client.client.BlockNumber(t.Context())
 	require.NoError(t, err)
 
@@ -281,12 +567,12 @@ func TestBloomCrossCheck_RetryExhausted(t *testing.T) {
 	}
 
 	err = <-errCh
-	require.Error(t, err, "should propagate retry failure as error")
+	require.Error(t, err, "should propagate the re-request failure as an error")
 }
 
-// TestVerifyLogsWithBloom_BlocksWithExistingLogs verifies that blocks
-// that already have logs are not re-checked via header fetch.
-func TestVerifyLogsWithBloom_BlocksWithExistingLogs(t *testing.T) {
+// TestVerifyLogCompleteness_BlocksWithExistingLogs verifies that blocks that already
+// have logs are not re-checked via header fetch.
+func TestVerifyLogCompleteness_BlocksWithExistingLogs(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
 	env := setupTestEnv(t, 5*time.Second)
@@ -297,26 +583,16 @@ func TestVerifyLogsWithBloom_BlocksWithExistingLogs(t *testing.T) {
 	err = env.createBlocksWithLogs(contract, totalBlocks, 0)
 	require.NoError(t, err)
 
-	// Track HeaderByNumber calls via proxy.
+	// Track header fetches (batched or not) via proxy.
 	rpcSrv, _ := env.sim.Node().RPCHandler()
-	base := http.Handler(rpcSrv)
 	var headerCalls atomic.Int32
 
-	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		raw, _ := io.ReadAll(r.Body)
-		var req map[string]any
-		_ = json.Unmarshal(raw, &req)
-
-		if req["method"] == "eth_getBlockByNumber" {
+	srv := newRPCProxy(t, rpcSrv, func(req jsonrpcMessage, forward forwardFunc) *jsonrpcMessage {
+		if req.Method == ethGetBlockByNumberMethod {
 			headerCalls.Add(1)
 		}
-
-		r.Body = io.NopCloser(bytes.NewReader(raw))
-		base.ServeHTTP(w, r)
+		return nil
 	})
-
-	srv := httptest.NewServer(wrapped)
-	t.Cleanup(srv.Close)
 
 	client, err := New(t.Context(), srv.URL, env.contractAddr,
 		WithLogger(logger),
@@ -332,10 +608,176 @@ func TestVerifyLogsWithBloom_BlocksWithExistingLogs(t *testing.T) {
 	}
 
 	headerCalls.Store(0)
-	result, err := client.verifyLogsWithBloom(t.Context(), fakeLogs, 2, 4)
+	result, err := client.verifyLogCompleteness(t.Context(), fakeLogs, 2, 4)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(result))
 
 	// No headers should have been fetched since all blocks already had logs.
 	require.Equal(t, int32(0), headerCalls.Load(), "should not fetch headers for blocks that already have logs")
+}
+
+// TestVerifyLogs_RecoversViaReceipts verifies the background verifier's per-chunk verification:
+// it returns a block's logs from receipts even when eth_getLogs persistently omits them,
+// and screens empty blocks by bloom so it doesn't fetch receipts for every block.
+func TestVerifyLogs_RecoversViaReceipts(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	env := setupTestEnv(t, 10*time.Second)
+	contract, err := env.deployCallableContract()
+	require.NoError(t, err)
+
+	const totalBlocks = 5
+	err = env.createBlocksWithLogs(contract, totalBlocks, 0)
+	require.NoError(t, err)
+
+	rpcSrv, _ := env.sim.Node().RPCHandler()
+
+	// Drop block 4's logs from every eth_getLogs response (persistent log-index breakage);
+	// receipts pass through untouched.
+	const dropBlock uint64 = 4
+	var receiptsCalls atomic.Int32
+
+	srv := newRPCProxy(t, rpcSrv, func(req jsonrpcMessage, forward forwardFunc) *jsonrpcMessage {
+		switch req.Method {
+		case ethGetLogsMethod:
+			resp := forward(req)
+			resp.Result = dropLogsForBlock(t, resp.Result, dropBlock)
+			return &resp
+		case ethGetBlockReceiptsMethod:
+			receiptsCalls.Add(1)
+		}
+		return nil
+	})
+
+	client, err := New(t.Context(), srv.URL, env.contractAddr, WithLogger(logger))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	currentBlock, err := client.client.BlockNumber(t.Context())
+	require.NoError(t, err)
+
+	blockLogs, err := client.VerifyLogs(t.Context(), 0, currentBlock)
+	require.NoError(t, err)
+
+	total := 0
+	foundDropped := false
+	for _, bl := range blockLogs {
+		total += len(bl.Logs)
+		if bl.BlockNumber == dropBlock {
+			foundDropped = true
+		}
+	}
+	require.Equal(t, totalBlocks, total, "VerifyLogs should return every block's logs, including the getLogs-dropped one")
+	require.True(t, foundDropped, "the dropped block's logs must be recovered from receipts")
+	// Receipts are fetched only for bloom-positive blocks, not every block in the range.
+	require.LessOrEqual(t, receiptsCalls.Load(), int32(totalBlocks+1))
+	require.GreaterOrEqual(t, receiptsCalls.Load(), int32(1))
+}
+
+// newBatchRejectingProxy fronts base but rejects JSON-RPC batch (array) requests with an HTTP
+// error while forwarding single requests untouched — simulating a provider that disables
+// batching, to exercise the sequential fallback in HeadersByNumbers / SingleBlockLogs.
+func newBatchRejectingProxy(t *testing.T, base http.Handler) *httptest.Server {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		if bytes.HasPrefix(bytes.TrimSpace(raw), []byte("[")) {
+			http.Error(w, "batch requests are disabled", http.StatusBadRequest)
+			return
+		}
+		r.Body = io.NopCloser(bytes.NewReader(raw))
+		base.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestHeadersByNumbers_FallsBackWhenBatchRejected(t *testing.T) {
+	env := setupTestEnv(t, 10*time.Second)
+	for i := 0; i < 5; i++ {
+		env.sim.Commit()
+	}
+
+	rpcSrv, _ := env.sim.Node().RPCHandler()
+	srv := newBatchRejectingProxy(t, rpcSrv)
+
+	client, err := New(t.Context(), srv.URL, env.contractAddr, WithLogger(zaptest.NewLogger(t)))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	// The batch is rejected, so this must recover every header via sequential fallback.
+	blocks := []uint64{1, 2, 3}
+	headers, err := client.client.HeadersByNumbers(t.Context(), blocks)
+	require.NoError(t, err)
+	require.Len(t, headers, len(blocks))
+	for i, h := range headers {
+		require.NotNil(t, h)
+		require.Equal(t, blocks[i], h.Number.Uint64())
+	}
+}
+
+func TestSingleBlockLogs_FallsBackWhenBatchRejected(t *testing.T) {
+	env := setupTestEnv(t, 10*time.Second)
+	contract, err := env.deployCallableContract()
+	require.NoError(t, err)
+	// Contract deploy is block 1; these create event blocks 2..4, one contract log each.
+	require.NoError(t, env.createBlocksWithLogs(contract, 3, 0))
+
+	rpcSrv, _ := env.sim.Node().RPCHandler()
+	srv := newBatchRejectingProxy(t, rpcSrv)
+
+	client, err := New(t.Context(), srv.URL, env.contractAddr, WithLogger(zaptest.NewLogger(t)))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	// The batch is rejected, so each block's logs must come via sequential FilterLogs fallback.
+	blocks := []uint64{1, 2, 3, 4}
+	perBlock, err := client.client.SingleBlockLogs(t.Context(), env.contractAddr, blocks)
+	require.NoError(t, err)
+	require.Len(t, perBlock, len(blocks))
+
+	total := 0
+	for _, logs := range perBlock {
+		total += len(logs)
+	}
+	require.Equal(t, 3, total, "one contract log recovered per event block (2..4), none for the deploy block")
+	require.Len(t, perBlock[1], 1) // block 2
+	require.Len(t, perBlock[2], 1) // block 3
+	require.Len(t, perBlock[3], 1) // block 4
+}
+
+func TestBatchingUnsupportedIsRemembered(t *testing.T) {
+	env := setupTestEnv(t, 10*time.Second)
+	for i := 0; i < 5; i++ {
+		env.sim.Commit()
+	}
+	rpcSrv, _ := env.sim.Node().RPCHandler()
+
+	// Reject every batch (array) request, counting the attempts; forward singles.
+	var batchAttempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		if bytes.HasPrefix(bytes.TrimSpace(raw), []byte("[")) {
+			batchAttempts.Add(1)
+			http.Error(w, "batch requests are disabled", http.StatusBadRequest)
+			return
+		}
+		r.Body = io.NopCloser(bytes.NewReader(raw))
+		rpcSrv.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := New(t.Context(), srv.URL, env.contractAddr, WithLogger(zaptest.NewLogger(t)))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	// First call attempts a batch once, fails wholesale, recovers sequentially, and remembers.
+	_, err = client.client.HeadersByNumbers(t.Context(), []uint64{1, 2, 3})
+	require.NoError(t, err)
+	// Second call must not attempt a batch again — it goes straight to sequential.
+	_, err = client.client.HeadersByNumbers(t.Context(), []uint64{1, 2, 3})
+	require.NoError(t, err)
+
+	require.Equal(t, int32(1), batchAttempts.Load(), "batching should be attempted once then remembered as unsupported")
 }

--- a/eth/executionclient/errors.go
+++ b/eth/executionclient/errors.go
@@ -26,10 +26,12 @@ const (
 	// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md
 	errCodeQueryLimit = -32005
 
-	// errCodeMethodNotFound is the standard JSON-RPC code for a method the server
-	// does not support.
+	// errCodeMethodNotFound and errCodeMethodNotSupported both indicate the server will not serve
+	// the requested method (both defined by EIP-1474); ELs use one or the other for a method they
+	// lack, e.g. eth_getBlockReceipts.
 	// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md
-	errCodeMethodNotFound = -32601
+	errCodeMethodNotFound     = -32601
+	errCodeMethodNotSupported = -32004
 )
 
 // isRPCQueryLimitError checks if the provided error is a query limit error.
@@ -69,7 +71,8 @@ func isSubdividableLogFetchError(err error) bool {
 func isRPCMethodNotFoundError(err error) bool {
 	var rpcErr rpc.Error
 	if errors.As(err, &rpcErr) {
-		return rpcErr.ErrorCode() == errCodeMethodNotFound
+		code := rpcErr.ErrorCode()
+		return code == errCodeMethodNotFound || code == errCodeMethodNotSupported
 	}
 
 	return false

--- a/eth/executionclient/errors.go
+++ b/eth/executionclient/errors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -39,6 +40,28 @@ func isRPCQueryLimitError(err error) bool {
 	}
 
 	return false
+}
+
+// isRPCResponseTooLargeError reports whether err indicates the response exceeded a transport or
+// provider size limit — a websocket read limit, an HTTP body cap, and the like — as opposed to the
+// -32005 query-limit code.
+func isRPCResponseTooLargeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "read limit exceeded") || // gorilla/websocket
+		strings.Contains(msg, "response too large") ||
+		strings.Contains(msg, "message too big") ||
+		strings.Contains(msg, "request entity too large") // HTTP 413
+}
+
+// isSubdividableLogFetchError reports whether a failed range eth_getLogs is likely to succeed once
+// the range is split: a query-limit code and a response-size limit both shrink under subdivision.
+// Any other error (connection failure, cancellation, a genuine RPC fault) is not subdividable and
+// surfaces immediately.
+func isSubdividableLogFetchError(err error) bool {
+	return isRPCQueryLimitError(err) || isRPCResponseTooLargeError(err)
 }
 
 // isRPCMethodNotFoundError checks if the provided error indicates the server does not

--- a/eth/executionclient/errors.go
+++ b/eth/executionclient/errors.go
@@ -24,6 +24,11 @@ const (
 	// errCodeQueryLimit refers to request exceeding the defined limit
 	// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md
 	errCodeQueryLimit = -32005
+
+	// errCodeMethodNotFound is the standard JSON-RPC code for a method the server
+	// does not support.
+	// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md
+	errCodeMethodNotFound = -32601
 )
 
 // isRPCQueryLimitError checks if the provided error is a query limit error.
@@ -31,6 +36,17 @@ func isRPCQueryLimitError(err error) bool {
 	var rpcErr rpc.Error
 	if errors.As(err, &rpcErr) {
 		return rpcErr.ErrorCode() == errCodeQueryLimit
+	}
+
+	return false
+}
+
+// isRPCMethodNotFoundError checks if the provided error indicates the server does not
+// support the requested RPC method.
+func isRPCMethodNotFoundError(err error) bool {
+	var rpcErr rpc.Error
+	if errors.As(err, &rpcErr) {
+		return rpcErr.ErrorCode() == errCodeMethodNotFound
 	}
 
 	return false

--- a/eth/executionclient/errors_test.go
+++ b/eth/executionclient/errors_test.go
@@ -18,6 +18,25 @@ type stubRPCError struct {
 func (e stubRPCError) Error() string  { return e.msg }
 func (e stubRPCError) ErrorCode() int { return e.code }
 
+func TestIsRPCMethodNotFoundError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"method not found -32601", stubRPCError{code: errCodeMethodNotFound, msg: "not found"}, true},
+		{"method not supported -32004", stubRPCError{code: errCodeMethodNotSupported, msg: "not supported"}, true},
+		{"query limit -32005 is not method-not-found", stubRPCError{code: errCodeQueryLimit, msg: "limit"}, false},
+		{"plain error", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isRPCMethodNotFoundError(tc.err))
+		})
+	}
+}
+
 func TestIsSubdividableLogFetchError(t *testing.T) {
 	cases := []struct {
 		name string

--- a/eth/executionclient/errors_test.go
+++ b/eth/executionclient/errors_test.go
@@ -1,0 +1,40 @@
+package executionclient
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stubRPCError implements rpc.Error so the JSON-RPC error-code predicates can be exercised without
+// a live server.
+type stubRPCError struct {
+	code int
+	msg  string
+}
+
+func (e stubRPCError) Error() string  { return e.msg }
+func (e stubRPCError) ErrorCode() int { return e.code }
+
+func TestIsSubdividableLogFetchError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"query-limit code -32005", stubRPCError{code: errCodeQueryLimit, msg: "limit exceeded"}, true},
+		{"websocket read limit", errors.New("websocket: read limit exceeded"), true},
+		{"response too large (wrapped)", fmt.Errorf("get logs: %w", errors.New("response too large")), true},
+		{"http 413", errors.New("413 Request Entity Too Large"), true},
+		{"method not found -32601 is not subdividable", stubRPCError{code: errCodeMethodNotFound, msg: "no method"}, false},
+		{"plain connection error is not subdividable", errors.New("connection refused"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isSubdividableLogFetchError(tc.err))
+		})
+	}
+}

--- a/eth/executionclient/eth_client.go
+++ b/eth/executionclient/eth_client.go
@@ -82,16 +82,24 @@ func (c *ethClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]e
 	return c.client.FilterLogs(reqCtx, q)
 }
 
-// HeadersByNumbers fetches the headers for the given block numbers with a single batched
-// eth_getBlockByNumber request. Elements that the batch could not serve (some RPC servers
-// restrict or disable batching, wholesale or per element) are recovered with sequential
-// fetches. Returned headers are ordered to match blockNumbers.
-func (c *ethClient) HeadersByNumbers(ctx context.Context, blockNumbers []uint64) ([]*ethtypes.Header, error) {
+// batchedByBlock issues one RPC per block number, batched maxRPCBatchSize at a time, writing
+// results in blockNumbers order. Elements a batch could not serve (some RPC servers restrict or
+// disable batching, wholesale or per element) are recovered with sequential fetchOne calls.
+// makeElem builds the batch element writing into the given result slot; served reports whether
+// the slot was actually filled, since a batch can "succeed" with a JSON null that leaves it empty.
+func batchedByBlock[T any](
+	ctx context.Context,
+	c *ethClient,
+	blockNumbers []uint64,
+	makeElem func(blockNumber uint64, result *T) rpc.BatchElem,
+	served func(result T) bool,
+	fetchOne func(ctx context.Context, blockNumber uint64) (T, error),
+) ([]T, error) {
 	if len(blockNumbers) == 0 {
 		return nil, nil
 	}
 
-	headers := make([]*ethtypes.Header, len(blockNumbers))
+	results := make([]T, len(blockNumbers))
 	// Split into bounded windows so a wide request stays within providers' batch limits.
 	for start := 0; start < len(blockNumbers); start += maxRPCBatchSize {
 		end := min(start+maxRPCBatchSize, len(blockNumbers))
@@ -103,11 +111,7 @@ func (c *ethClient) HeadersByNumbers(ctx context.Context, blockNumbers []uint64)
 		if attemptedBatch {
 			batch = make([]rpc.BatchElem, len(window))
 			for i, blockNumber := range window {
-				batch[i] = rpc.BatchElem{
-					Method: "eth_getBlockByNumber",
-					Args:   []any{hexutil.EncodeUint64(blockNumber), false},
-					Result: &headers[start+i],
-				}
+				batch[i] = makeElem(blockNumber, &results[start+i])
 			}
 
 			reqCtx, cancel := context.WithTimeout(ctx, c.reqTimeout)
@@ -117,27 +121,27 @@ func (c *ethClient) HeadersByNumbers(ctx context.Context, blockNumbers []uint64)
 
 		for i, blockNumber := range window {
 			idx := start + i
-			if attemptedBatch && batchErr == nil && batch[i].Error == nil && headers[idx] != nil {
+			if attemptedBatch && batchErr == nil && batch[i].Error == nil && served(results[idx]) {
 				continue
 			}
-			header, err := c.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNumber))
+			result, err := fetchOne(ctx, blockNumber)
 			if err != nil {
-				return nil, fmt.Errorf("get header for block %d: %w", blockNumber, err)
+				return nil, err
 			}
-			headers[idx] = header
+			results[idx] = result
 		}
 
 		c.rememberBatchingUnsupported(attemptedBatch, batchErr)
 	}
 
-	return headers, nil
+	return results, nil
 }
 
 // rememberBatchingUnsupported latches batchingUnsupported when a batch failed wholesale yet the
-// sequential fallback (run just above) recovered — distinguishing a provider that rejects batching
-// from a general outage, where the sequential calls would have failed too. Timeouts and
-// cancellations are excluded: they mean slow or interrupted, not unsupported, so a batch-only
-// timeout can't wrongly pin a batching-capable provider to sequential. One-way, reset on reconnect.
+// sequential fallback recovered — distinguishing a provider that rejects batching from a general
+// outage, where the sequential calls would have failed too. Timeouts and cancellations are
+// excluded: they mean slow or interrupted, not unsupported, so a batch-only timeout can't wrongly
+// pin a batching-capable provider to sequential. One-way, reset on reconnect.
 func (c *ethClient) rememberBatchingUnsupported(attemptedBatch bool, batchErr error) {
 	if !attemptedBatch || batchErr == nil {
 		return
@@ -151,48 +155,46 @@ func (c *ethClient) rememberBatchingUnsupported(attemptedBatch bool, batchErr er
 	}
 }
 
-// SingleBlockLogs fetches, for each of the given blocks, the logs emitted by the given
-// address, using a single batched eth_getLogs request with one single-block query per
-// block. Elements the batch could not serve are recovered with sequential FilterLogs
-// calls. Returned log slices are ordered to match blockNumbers.
+// HeadersByNumbers fetches the headers for the given block numbers with batched
+// eth_getBlockByNumber requests, recovering unserved elements with sequential fetches.
+// Returned headers are ordered to match blockNumbers.
+func (c *ethClient) HeadersByNumbers(ctx context.Context, blockNumbers []uint64) ([]*ethtypes.Header, error) {
+	return batchedByBlock(ctx, c, blockNumbers,
+		func(blockNumber uint64, result **ethtypes.Header) rpc.BatchElem {
+			return rpc.BatchElem{
+				Method: "eth_getBlockByNumber",
+				Args:   []any{hexutil.EncodeUint64(blockNumber), false},
+				Result: result,
+			}
+		},
+		func(header *ethtypes.Header) bool { return header != nil },
+		func(ctx context.Context, blockNumber uint64) (*ethtypes.Header, error) {
+			header, err := c.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNumber))
+			if err != nil {
+				return nil, fmt.Errorf("get header for block %d: %w", blockNumber, err)
+			}
+			return header, nil
+		})
+}
+
+// SingleBlockLogs fetches, for each of the given blocks, the logs emitted by the given address,
+// using batched eth_getLogs requests with one single-block query per block, recovering unserved
+// elements with sequential FilterLogs calls. Returned log slices are ordered to match blockNumbers.
 func (c *ethClient) SingleBlockLogs(ctx context.Context, address ethcommon.Address, blockNumbers []uint64) ([][]ethtypes.Log, error) {
-	if len(blockNumbers) == 0 {
-		return nil, nil
-	}
-
-	blockLogs := make([][]ethtypes.Log, len(blockNumbers))
-	// Split into bounded windows so a wide request stays within providers' batch limits.
-	for start := 0; start < len(blockNumbers); start += maxRPCBatchSize {
-		end := min(start+maxRPCBatchSize, len(blockNumbers))
-		window := blockNumbers[start:end]
-
-		attemptedBatch := !c.batchingUnsupported.Load()
-		var batch []rpc.BatchElem
-		var batchErr error
-		if attemptedBatch {
-			batch = make([]rpc.BatchElem, len(window))
-			for i, blockNumber := range window {
-				batch[i] = rpc.BatchElem{
-					Method: "eth_getLogs",
-					Args: []any{map[string]any{
-						"address":   address,
-						"fromBlock": hexutil.EncodeUint64(blockNumber),
-						"toBlock":   hexutil.EncodeUint64(blockNumber),
-					}},
-					Result: &blockLogs[start+i],
-				}
+	return batchedByBlock(ctx, c, blockNumbers,
+		func(blockNumber uint64, result *[]ethtypes.Log) rpc.BatchElem {
+			return rpc.BatchElem{
+				Method: "eth_getLogs",
+				Args: []any{map[string]any{
+					"address":   address,
+					"fromBlock": hexutil.EncodeUint64(blockNumber),
+					"toBlock":   hexutil.EncodeUint64(blockNumber),
+				}},
+				Result: result,
 			}
-
-			reqCtx, cancel := context.WithTimeout(ctx, c.reqTimeout)
-			batchErr = c.client.Client().BatchCallContext(reqCtx, batch)
-			cancel()
-		}
-
-		for i, blockNumber := range window {
-			idx := start + i
-			if attemptedBatch && batchErr == nil && batch[i].Error == nil {
-				continue
-			}
+		},
+		func([]ethtypes.Log) bool { return true }, // no logs is a served result (an empty block)
+		func(ctx context.Context, blockNumber uint64) ([]ethtypes.Log, error) {
 			logs, err := c.FilterLogs(ctx, ethereum.FilterQuery{
 				Addresses: []ethcommon.Address{address},
 				FromBlock: new(big.Int).SetUint64(blockNumber),
@@ -201,13 +203,8 @@ func (c *ethClient) SingleBlockLogs(ctx context.Context, address ethcommon.Addre
 			if err != nil {
 				return nil, fmt.Errorf("get logs for block %d: %w", blockNumber, err)
 			}
-			blockLogs[idx] = logs
-		}
-
-		c.rememberBatchingUnsupported(attemptedBatch, batchErr)
-	}
-
-	return blockLogs, nil
+			return logs, nil
+		})
 }
 
 // BlockReceipts fetches all transaction receipts of the given block via eth_getBlockReceipts.

--- a/eth/executionclient/eth_client.go
+++ b/eth/executionclient/eth_client.go
@@ -2,6 +2,7 @@ package executionclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync/atomic"
@@ -132,12 +133,19 @@ func (c *ethClient) HeadersByNumbers(ctx context.Context, blockNumbers []uint64)
 	return headers, nil
 }
 
-// rememberBatchingUnsupported latches batchingUnsupported when a batch failed wholesale but the
-// sequential fallback (which ran to completion above, since we reached here) recovered — that
-// distinguishes a provider that rejects batching from a general outage (where the sequential
-// calls would have errored out first). It's a one-way, best-effort memo reset on reconnect.
+// rememberBatchingUnsupported latches batchingUnsupported when a batch failed wholesale yet the
+// sequential fallback (run just above) recovered — distinguishing a provider that rejects batching
+// from a general outage, where the sequential calls would have failed too. Timeouts and
+// cancellations are excluded: they mean slow or interrupted, not unsupported, so a batch-only
+// timeout can't wrongly pin a batching-capable provider to sequential. One-way, reset on reconnect.
 func (c *ethClient) rememberBatchingUnsupported(attemptedBatch bool, batchErr error) {
-	if attemptedBatch && batchErr != nil && c.batchingUnsupported.CompareAndSwap(false, true) {
+	if !attemptedBatch || batchErr == nil {
+		return
+	}
+	if errors.Is(batchErr, context.DeadlineExceeded) || errors.Is(batchErr, context.Canceled) {
+		return
+	}
+	if c.batchingUnsupported.CompareAndSwap(false, true) {
 		c.logger.Warn("execution client rejected a batched request; falling back to sequential requests for the rest of this connection",
 			zap.Error(batchErr))
 	}

--- a/eth/executionclient/eth_client.go
+++ b/eth/executionclient/eth_client.go
@@ -2,27 +2,46 @@ package executionclient
 
 import (
 	"context"
+	"fmt"
 	"math/big"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"go.uber.org/zap"
 )
+
+// maxRPCBatchSize bounds how many elements a single batched RPC request carries. Verification
+// chunks can be thousands of blocks wide, but many hosted providers cap JSON-RPC batches
+// (commonly around 100), so keeping each batch small means an over-limit request degrades to a
+// few smaller batches rather than one wholesale rejection.
+const maxRPCBatchSize = 100
 
 // ethClient is a wrapper around ethclient.Client to add a default timeout for every call we
 // make with ethclient.Client. This allows us to manage timeouts for ethclient.Client in one
 // place such that we don't accidentally forget to set a timeout for some ethclient.Client call.
 type ethClient struct {
 	client *ethclient.Client
+	logger *zap.Logger
 
 	// reqTimeout specifies the default timeout to be used with every ethclient.Client call.
 	reqTimeout time.Duration
+
+	// batchingUnsupported remembers that a batched request failed wholesale (yet the sequential
+	// fallback succeeded), i.e. the provider rejects batching, so subsequent calls skip the
+	// doomed batch and go straight to sequential requests.
+	batchingUnsupported atomic.Bool
 }
 
-func newEthClient(client *ethclient.Client, reqTimeout time.Duration) *ethClient {
+func newEthClient(client *ethclient.Client, reqTimeout time.Duration, logger *zap.Logger) *ethClient {
 	return &ethClient{
 		client:     client,
+		logger:     logger,
 		reqTimeout: reqTimeout,
 	}
 }
@@ -60,6 +79,136 @@ func (c *ethClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]e
 	defer cancel()
 
 	return c.client.FilterLogs(reqCtx, q)
+}
+
+// HeadersByNumbers fetches the headers for the given block numbers with a single batched
+// eth_getBlockByNumber request. Elements that the batch could not serve (some RPC servers
+// restrict or disable batching, wholesale or per element) are recovered with sequential
+// fetches. Returned headers are ordered to match blockNumbers.
+func (c *ethClient) HeadersByNumbers(ctx context.Context, blockNumbers []uint64) ([]*ethtypes.Header, error) {
+	if len(blockNumbers) == 0 {
+		return nil, nil
+	}
+
+	headers := make([]*ethtypes.Header, len(blockNumbers))
+	// Split into bounded windows so a wide request stays within providers' batch limits.
+	for start := 0; start < len(blockNumbers); start += maxRPCBatchSize {
+		end := min(start+maxRPCBatchSize, len(blockNumbers))
+		window := blockNumbers[start:end]
+
+		attemptedBatch := !c.batchingUnsupported.Load()
+		var batch []rpc.BatchElem
+		var batchErr error
+		if attemptedBatch {
+			batch = make([]rpc.BatchElem, len(window))
+			for i, blockNumber := range window {
+				batch[i] = rpc.BatchElem{
+					Method: "eth_getBlockByNumber",
+					Args:   []any{hexutil.EncodeUint64(blockNumber), false},
+					Result: &headers[start+i],
+				}
+			}
+
+			reqCtx, cancel := context.WithTimeout(ctx, c.reqTimeout)
+			batchErr = c.client.Client().BatchCallContext(reqCtx, batch)
+			cancel()
+		}
+
+		for i, blockNumber := range window {
+			idx := start + i
+			if attemptedBatch && batchErr == nil && batch[i].Error == nil && headers[idx] != nil {
+				continue
+			}
+			header, err := c.HeaderByNumber(ctx, new(big.Int).SetUint64(blockNumber))
+			if err != nil {
+				return nil, fmt.Errorf("get header for block %d: %w", blockNumber, err)
+			}
+			headers[idx] = header
+		}
+
+		c.rememberBatchingUnsupported(attemptedBatch, batchErr)
+	}
+
+	return headers, nil
+}
+
+// rememberBatchingUnsupported latches batchingUnsupported when a batch failed wholesale but the
+// sequential fallback (which ran to completion above, since we reached here) recovered — that
+// distinguishes a provider that rejects batching from a general outage (where the sequential
+// calls would have errored out first). It's a one-way, best-effort memo reset on reconnect.
+func (c *ethClient) rememberBatchingUnsupported(attemptedBatch bool, batchErr error) {
+	if attemptedBatch && batchErr != nil && c.batchingUnsupported.CompareAndSwap(false, true) {
+		c.logger.Warn("execution client rejected a batched request; falling back to sequential requests for the rest of this connection",
+			zap.Error(batchErr))
+	}
+}
+
+// SingleBlockLogs fetches, for each of the given blocks, the logs emitted by the given
+// address, using a single batched eth_getLogs request with one single-block query per
+// block. Elements the batch could not serve are recovered with sequential FilterLogs
+// calls. Returned log slices are ordered to match blockNumbers.
+func (c *ethClient) SingleBlockLogs(ctx context.Context, address ethcommon.Address, blockNumbers []uint64) ([][]ethtypes.Log, error) {
+	if len(blockNumbers) == 0 {
+		return nil, nil
+	}
+
+	blockLogs := make([][]ethtypes.Log, len(blockNumbers))
+	// Split into bounded windows so a wide request stays within providers' batch limits.
+	for start := 0; start < len(blockNumbers); start += maxRPCBatchSize {
+		end := min(start+maxRPCBatchSize, len(blockNumbers))
+		window := blockNumbers[start:end]
+
+		attemptedBatch := !c.batchingUnsupported.Load()
+		var batch []rpc.BatchElem
+		var batchErr error
+		if attemptedBatch {
+			batch = make([]rpc.BatchElem, len(window))
+			for i, blockNumber := range window {
+				batch[i] = rpc.BatchElem{
+					Method: "eth_getLogs",
+					Args: []any{map[string]any{
+						"address":   address,
+						"fromBlock": hexutil.EncodeUint64(blockNumber),
+						"toBlock":   hexutil.EncodeUint64(blockNumber),
+					}},
+					Result: &blockLogs[start+i],
+				}
+			}
+
+			reqCtx, cancel := context.WithTimeout(ctx, c.reqTimeout)
+			batchErr = c.client.Client().BatchCallContext(reqCtx, batch)
+			cancel()
+		}
+
+		for i, blockNumber := range window {
+			idx := start + i
+			if attemptedBatch && batchErr == nil && batch[i].Error == nil {
+				continue
+			}
+			logs, err := c.FilterLogs(ctx, ethereum.FilterQuery{
+				Addresses: []ethcommon.Address{address},
+				FromBlock: new(big.Int).SetUint64(blockNumber),
+				ToBlock:   new(big.Int).SetUint64(blockNumber),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("get logs for block %d: %w", blockNumber, err)
+			}
+			blockLogs[idx] = logs
+		}
+
+		c.rememberBatchingUnsupported(attemptedBatch, batchErr)
+	}
+
+	return blockLogs, nil
+}
+
+// BlockReceipts fetches all transaction receipts of the given block via eth_getBlockReceipts.
+func (c *ethClient) BlockReceipts(ctx context.Context, blockNumber uint64) ([]*ethtypes.Receipt, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, c.reqTimeout)
+	defer cancel()
+
+	// #nosec G115 -- block numbers fit in int64
+	return c.client.BlockReceipts(reqCtx, rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(blockNumber)))
 }
 
 func (c *ethClient) SubscribeNewHead(ctx context.Context, heads chan *ethtypes.Header) (ethereum.Subscription, error) {

--- a/eth/executionclient/eth_client_test.go
+++ b/eth/executionclient/eth_client_test.go
@@ -1,0 +1,46 @@
+package executionclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ssvlabs/ssv/observability/log"
+)
+
+func TestRememberBatchingUnsupported(t *testing.T) {
+	newClient := func() *ethClient { return &ethClient{logger: log.TestLogger(t)} }
+
+	t.Run("latches on a substantive wholesale rejection", func(t *testing.T) {
+		c := newClient()
+		c.rememberBatchingUnsupported(true, errors.New("batch requests are not supported"))
+		require.True(t, c.batchingUnsupported.Load())
+	})
+
+	t.Run("does not latch on a batch timeout", func(t *testing.T) {
+		c := newClient()
+		// A slow-but-batching-capable provider whose batch hit the per-request timeout while the
+		// sequential fallback still succeeded must not be permanently downgraded to sequential.
+		c.rememberBatchingUnsupported(true, context.DeadlineExceeded)
+		require.False(t, c.batchingUnsupported.Load())
+		c.rememberBatchingUnsupported(true, fmt.Errorf("batch call: %w", context.DeadlineExceeded))
+		require.False(t, c.batchingUnsupported.Load())
+	})
+
+	t.Run("does not latch on cancellation", func(t *testing.T) {
+		c := newClient()
+		c.rememberBatchingUnsupported(true, context.Canceled)
+		require.False(t, c.batchingUnsupported.Load())
+	})
+
+	t.Run("does not latch without an attempted, failed batch", func(t *testing.T) {
+		c := newClient()
+		c.rememberBatchingUnsupported(false, errors.New("boom")) // no batch attempted
+		require.False(t, c.batchingUnsupported.Load())
+		c.rememberBatchingUnsupported(true, nil) // batch succeeded
+		require.False(t, c.batchingUnsupported.Load())
+	})
+}

--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -281,7 +281,7 @@ func (ec *ExecutionClient) subdivideLogFetch(ctx context.Context, q ethereum.Fil
 	}
 	err = ec.errSingleClient(fmt.Errorf("get filtered logs: %w", err), "eth_getLogs")
 
-	if isRPCQueryLimitError(err) {
+	if isSubdividableLogFetchError(err) {
 		if q.FromBlock == nil || q.ToBlock == nil {
 			return nil, err
 		}
@@ -294,9 +294,10 @@ func (ec *ExecutionClient) subdivideLogFetch(ctx context.Context, q ethereum.Fil
 			return nil, fmt.Errorf("insufficient blocks to subdivide (fromBlock: %d, toBlock: %d): %w", fromBlock, toBlock, err)
 		}
 
-		// Query-limit subdivision is an expected, self-healing fallback that recurses,
-		// so log at debug; a genuine failure to fetch surfaces as an error upstream.
-		ec.logger.Debug("execution client query limit exceeded, subdividing query",
+		// Range-limit subdivision (query-limit code or a response-size cap) is an expected,
+		// self-healing fallback that recurses, so log at debug; a genuine failure to fetch
+		// surfaces as an error upstream.
+		ec.logger.Debug("execution client rejected a wide log query, subdividing",
 			zap.String("method", "eth_getLogs"),
 			fields.FromBlock(fromBlock),
 			fields.ToBlock(toBlock),

--- a/eth/executionclient/execution_client.go
+++ b/eth/executionclient/execution_client.go
@@ -25,7 +25,9 @@ import (
 //go:generate go tool -modfile=../../tool.mod mockgen -package=executionclient -destination=./mocks.go -source=./execution_client.go
 
 type Provider interface {
-	FetchHistoricalLogs(ctx context.Context, fromBlock uint64) (logsCh <-chan BlockLogs, errsCh <-chan error, err error)
+	FetchHistoricalLogs(ctx context.Context, fromBlock uint64, verify bool) (logsCh <-chan BlockLogs, errsCh <-chan error, err error)
+	VerifyLogs(ctx context.Context, fromBlock, toBlock uint64) ([]BlockLogs, error)
+	BlockContractLogs(ctx context.Context, block uint64) (logs []ethtypes.Log, receiptsAvailable bool, err error)
 	StreamLogs(ctx context.Context, fromBlock uint64) (logsCh chan BlockLogs)
 	Filterer() (*contract.ContractFilterer, error)
 	HeaderByNumber(ctx context.Context, blockNumber *big.Int) (*ethtypes.Header, error)
@@ -65,6 +67,10 @@ type ExecutionClient struct {
 	// healthInvalidationInterval ensures we don't spam EL with health-check type requests too much.
 	healthInvalidationInterval time.Duration
 	lastHealthyTime            atomic.Int64
+
+	// receiptsUnsupported remembers that the EL rejected eth_getBlockReceipts, so log
+	// verification doesn't re-attempt the method on every suspect block.
+	receiptsUnsupported atomic.Bool
 }
 
 // New creates a new instance of ExecutionClient.
@@ -120,8 +126,11 @@ func (ec *ExecutionClient) Close() error {
 	return nil
 }
 
-// FetchHistoricalLogs retrieves historical logs emitted by the contract starting from fromBlock.
-func (ec *ExecutionClient) FetchHistoricalLogs(ctx context.Context, fromBlock uint64) (
+// FetchHistoricalLogs retrieves historical logs emitted by the contract starting from
+// fromBlock. When verify is false the logs are returned optimistically (plain getLogs, fast)
+// and their completeness is checked afterwards by the background verifier; when true, each
+// batch is verified for completeness inline (used by the resync-repair path).
+func (ec *ExecutionClient) FetchHistoricalLogs(ctx context.Context, fromBlock uint64, verify bool) (
 	logsCh <-chan BlockLogs,
 	errsCh <-chan error,
 	err error,
@@ -140,14 +149,18 @@ func (ec *ExecutionClient) FetchHistoricalLogs(ctx context.Context, fromBlock ui
 		return nil, nil, ErrNothingToSync
 	}
 
-	logsCh, errsCh = ec.fetchLogsInBatches(ctx, fromBlock, toBlock, false)
+	logsCh, errsCh = ec.fetchLogsInBatches(ctx, fromBlock, toBlock, verify)
 	return
 }
 
 // Calls FilterLogs multiple times (in batches) gradually sending the results on logCh to avoid fetching
 // an enormous number of events. If an error is encountered, the fetching terminates and the error is sent
 // on errCh. Both logCh and errCh are closed upon this function termination.
-func (ec *ExecutionClient) fetchLogsInBatches(ctx context.Context, startBlock, endBlock uint64, verifyBloom bool) (logCh chan BlockLogs, errCh chan error) {
+//
+// When verify is true, each batch's logs are cross-checked against block blooms (and receipts)
+// and any the EL omitted are recovered before the batch is emitted. When false, logs are
+// emitted as-is (optimistic); completeness is then established by the background verifier.
+func (ec *ExecutionClient) fetchLogsInBatches(ctx context.Context, startBlock, endBlock uint64, verify bool) (logCh chan BlockLogs, errCh chan error) {
 	// All errors are buffered so we don't block the execution of this func (waiting on the caller to
 	// handle the error before we can continue further) + it provides more flexibility for the caller
 	// allowing him to process logCh before continuing to checking the errCh channel.
@@ -189,11 +202,13 @@ func (ec *ExecutionClient) fetchLogsInBatches(ctx context.Context, startBlock, e
 				return
 			}
 
-			// Verify each block's logs against its bloom filter.
-			// Only enabled for streaming (near chain tip) where the Geth bug is most impactful.
-			// Skipped during historical sync to avoid ~200 extra header RPCs per batch.
-			if verifyBloom {
-				results, err = ec.verifyLogsWithBloom(ctx, results, fromBlock, toBlock)
+			// When verifying, cross-check each block's logs against its bloom filter and
+			// recover anything the EL silently dropped, before any BlockLogs is emitted
+			// (once emitted, a block's number becomes the marker and is never revisited).
+			// When optimistic, this is skipped for speed and the background verifier checks
+			// the range afterwards.
+			if verify {
+				results, err = ec.verifyLogCompleteness(ctx, results, fromBlock, toBlock)
 				if err != nil {
 					errCh <- err
 					return
@@ -538,7 +553,7 @@ func (ec *ExecutionClient) connect(ctx context.Context) error {
 		return ec.errSingleClient(fmt.Errorf("ethclient dial: %w", err), "dial")
 	}
 
-	ec.client = newEthClient(c, ec.reqTimeout)
+	ec.client = newEthClient(c, ec.reqTimeout, ec.logger)
 
 	return nil
 }

--- a/eth/executionclient/execution_client_test.go
+++ b/eth/executionclient/execution_client_test.go
@@ -186,7 +186,7 @@ func TestFetchHistoricalLogs(t *testing.T) {
 
 		// Fetch all logs history starting from block 0
 		fetchedLogs := make([]ethtypes.Log, 0, blocksWithLogsLength)
-		logs, fetchErrCh, err := env.client.FetchHistoricalLogs(env.ctx, 0)
+		logs, fetchErrCh, err := env.client.FetchHistoricalLogs(env.ctx, 0, false)
 		require.NoError(t, err)
 
 		for block := range logs {
@@ -219,7 +219,7 @@ func TestFetchHistoricalLogs(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		logs, fetchErrCh, err := env.client.FetchHistoricalLogs(env.ctx, 0)
+		logs, fetchErrCh, err := env.client.FetchHistoricalLogs(env.ctx, 0, false)
 		require.ErrorIs(t, err, ErrNothingToSync)
 		require.Nil(t, logs)
 		require.Nil(t, fetchErrCh)
@@ -248,7 +248,7 @@ func TestFetchHistoricalLogs(t *testing.T) {
 		// Set fromBlock to a value greater than the currentBlock - FollowDistance
 		fromBlock := currentBlock - FollowDistance + 10
 
-		logs, fetchErrCh, err := env.client.FetchHistoricalLogs(env.ctx, fromBlock)
+		logs, fetchErrCh, err := env.client.FetchHistoricalLogs(env.ctx, fromBlock, false)
 		require.ErrorIs(t, err, ErrNothingToSync)
 		require.Nil(t, logs)
 		require.Nil(t, fetchErrCh)
@@ -271,7 +271,7 @@ func TestFetchHistoricalLogs(t *testing.T) {
 		defer blockNumCancel()
 
 		// Fetch logs - should fail because BlockNumber returns an error
-		logs, fetchErrCh, err := env.client.FetchHistoricalLogs(blockNumCtx, 0)
+		logs, fetchErrCh, err := env.client.FetchHistoricalLogs(blockNumCtx, 0, false)
 		require.Error(t, err)
 		require.Nil(t, logs)
 		require.Nil(t, fetchErrCh)
@@ -685,21 +685,37 @@ func TestChainReorganizationLogs(t *testing.T) {
 		},
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req struct {
-			ID     json.RawMessage `json:"id"`
-			Method string          `json:"method"`
-		}
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		if err := json.Unmarshal(body, &req); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
+	// A zero logsBloom lets log verification prove the blocks without canned logs are
+	// genuinely empty, keeping this test focused on the reorg-handling branch.
+	zeroHash := "0x" + strings.Repeat("0", 64)
+	cannedHeader := map[string]any{
+		"parentHash":       zeroHash,
+		"sha3Uncles":       zeroHash,
+		"miner":            "0x" + strings.Repeat("0", 40),
+		"stateRoot":        zeroHash,
+		"transactionsRoot": zeroHash,
+		"receiptsRoot":     zeroHash,
+		"logsBloom":        "0x" + strings.Repeat("0", 512),
+		"difficulty":       "0x0",
+		"number":           "0x1",
+		"gasLimit":         "0x0",
+		"gasUsed":          "0x0",
+		"timestamp":        "0x0",
+		"extraData":        "0x",
+		"mixHash":          zeroHash,
+		"nonce":            "0x0000000000000000",
+	}
 
+	type rpcReq struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+	}
+	type rpcResp struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  any             `json:"result"`
+	}
+	makeResp := func(req rpcReq) rpcResp {
 		var result any
 		switch req.Method {
 		case "eth_getLogs":
@@ -708,16 +724,44 @@ func TestChainReorganizationLogs(t *testing.T) {
 			result = "0x1"
 		case "eth_blockNumber":
 			result = "0xa"
+		case "eth_getBlockByNumber":
+			result = cannedHeader
 		default:
 			result = nil
 		}
+		return rpcResp{"2.0", req.ID, result}
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(struct {
-			JSONRPC string          `json:"jsonrpc"`
-			ID      json.RawMessage `json:"id"`
-			Result  any             `json:"result"`
-		}{"2.0", req.ID, result}); err != nil {
+		if bytes.HasPrefix(bytes.TrimSpace(body), []byte("[")) {
+			var reqs []rpcReq
+			if err := json.Unmarshal(body, &reqs); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			resps := make([]rpcResp, 0, len(reqs))
+			for _, req := range reqs {
+				resps = append(resps, makeResp(req))
+			}
+			if err := json.NewEncoder(w).Encode(resps); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			return
+		}
+
+		var req rpcReq
+		if err := json.Unmarshal(body, &req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(makeResp(req)); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}))

--- a/eth/executionclient/logs.go
+++ b/eth/executionclient/logs.go
@@ -1,10 +1,40 @@
 package executionclient
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"sort"
 
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
+
+// BlockLogsDigest returns a deterministic digest of the given logs' in-block identities
+// (transaction index + log index). Because eth_getLogs can only ever return a subset of a
+// block's logs — it drops, never invents — a digest that matches the one recomputed from
+// authoritative data (receipts) proves the original response was complete. The background
+// verifier uses this to detect logs an optimistic sync silently missed.
+func BlockLogsDigest(logs []ethtypes.Log) []byte {
+	type id struct{ tx, idx uint }
+	ids := make([]id, len(logs))
+	for i, l := range logs {
+		ids[i] = id{tx: l.TxIndex, idx: l.Index}
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		if ids[i].tx != ids[j].tx {
+			return ids[i].tx < ids[j].tx
+		}
+		return ids[i].idx < ids[j].idx
+	})
+
+	h := sha256.New()
+	var buf [16]byte
+	for _, id := range ids {
+		binary.BigEndian.PutUint64(buf[:8], uint64(id.tx))
+		binary.BigEndian.PutUint64(buf[8:], uint64(id.idx))
+		_, _ = h.Write(buf[:])
+	}
+	return h.Sum(nil)
+}
 
 // BlockLogs holds a block's number and it's logs.
 type BlockLogs struct {

--- a/eth/executionclient/logs_test.go
+++ b/eth/executionclient/logs_test.go
@@ -83,3 +83,40 @@ func TestPackLogs(t *testing.T) {
 	assert.Equal(t, uint(0), result[0].Logs[0].TxIndex) // should be sorted
 	assert.Equal(t, uint(1), result[0].Logs[1].TxIndex)
 }
+
+func TestBlockLogsDigest(t *testing.T) {
+	logs := []types.Log{
+		{TxIndex: 0, Index: 0},
+		{TxIndex: 0, Index: 1},
+		{TxIndex: 2, Index: 5},
+	}
+
+	// Digesting is order-independent: it identifies logs by (TxIndex, Index), so the same set
+	// in any order yields the same digest.
+	shuffled := []types.Log{logs[2], logs[0], logs[1]}
+	assert.Equal(t, BlockLogsDigest(logs), BlockLogsDigest(shuffled))
+
+	// Dropping any log changes the digest — this is what lets the verifier detect a subset that
+	// an incomplete eth_getLogs response returned.
+	assert.NotEqual(t, BlockLogsDigest(logs), BlockLogsDigest(logs[:2]))
+
+	// Only the (TxIndex, Index) identity matters; other log fields don't affect the digest.
+	tagged := []types.Log{
+		{TxIndex: 0, Index: 0, BlockNumber: 99, Removed: true},
+		{TxIndex: 0, Index: 1},
+		{TxIndex: 2, Index: 5},
+	}
+	assert.Equal(t, BlockLogsDigest(logs), BlockLogsDigest(tagged))
+
+	// A different identity yields a different digest.
+	moved := []types.Log{
+		{TxIndex: 0, Index: 0},
+		{TxIndex: 0, Index: 1},
+		{TxIndex: 2, Index: 6}, // was Index 5
+	}
+	assert.NotEqual(t, BlockLogsDigest(logs), BlockLogsDigest(moved))
+
+	// Empty/no logs is stable and distinct from any non-empty set.
+	assert.Equal(t, BlockLogsDigest(nil), BlockLogsDigest([]types.Log{}))
+	assert.NotEqual(t, BlockLogsDigest(nil), BlockLogsDigest(logs))
+}

--- a/eth/executionclient/mocks.go
+++ b/eth/executionclient/mocks.go
@@ -44,6 +44,22 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 	return m.recorder
 }
 
+// BlockContractLogs mocks base method.
+func (m *MockProvider) BlockContractLogs(ctx context.Context, block uint64) ([]types.Log, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlockContractLogs", ctx, block)
+	ret0, _ := ret[0].([]types.Log)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// BlockContractLogs indicates an expected call of BlockContractLogs.
+func (mr *MockProviderMockRecorder) BlockContractLogs(ctx, block any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockContractLogs", reflect.TypeOf((*MockProvider)(nil).BlockContractLogs), ctx, block)
+}
+
 // ChainID mocks base method.
 func (m *MockProvider) ChainID(ctx context.Context) (*big.Int, error) {
 	m.ctrl.T.Helper()
@@ -74,9 +90,9 @@ func (mr *MockProviderMockRecorder) Close() *gomock.Call {
 }
 
 // FetchHistoricalLogs mocks base method.
-func (m *MockProvider) FetchHistoricalLogs(ctx context.Context, fromBlock uint64) (<-chan BlockLogs, <-chan error, error) {
+func (m *MockProvider) FetchHistoricalLogs(ctx context.Context, fromBlock uint64, verify bool) (<-chan BlockLogs, <-chan error, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchHistoricalLogs", ctx, fromBlock)
+	ret := m.ctrl.Call(m, "FetchHistoricalLogs", ctx, fromBlock, verify)
 	ret0, _ := ret[0].(<-chan BlockLogs)
 	ret1, _ := ret[1].(<-chan error)
 	ret2, _ := ret[2].(error)
@@ -84,9 +100,9 @@ func (m *MockProvider) FetchHistoricalLogs(ctx context.Context, fromBlock uint64
 }
 
 // FetchHistoricalLogs indicates an expected call of FetchHistoricalLogs.
-func (mr *MockProviderMockRecorder) FetchHistoricalLogs(ctx, fromBlock any) *gomock.Call {
+func (mr *MockProviderMockRecorder) FetchHistoricalLogs(ctx, fromBlock, verify any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchHistoricalLogs", reflect.TypeOf((*MockProvider)(nil).FetchHistoricalLogs), ctx, fromBlock)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchHistoricalLogs", reflect.TypeOf((*MockProvider)(nil).FetchHistoricalLogs), ctx, fromBlock, verify)
 }
 
 // FilterLogs mocks base method.
@@ -177,6 +193,21 @@ func (mr *MockProviderMockRecorder) SubscribeFilterLogs(ctx, q, ch any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeFilterLogs", reflect.TypeOf((*MockProvider)(nil).SubscribeFilterLogs), ctx, q, ch)
 }
 
+// VerifyLogs mocks base method.
+func (m *MockProvider) VerifyLogs(ctx context.Context, fromBlock, toBlock uint64) ([]BlockLogs, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyLogs", ctx, fromBlock, toBlock)
+	ret0, _ := ret[0].([]BlockLogs)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VerifyLogs indicates an expected call of VerifyLogs.
+func (mr *MockProviderMockRecorder) VerifyLogs(ctx, fromBlock, toBlock any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyLogs", reflect.TypeOf((*MockProvider)(nil).VerifyLogs), ctx, fromBlock, toBlock)
+}
+
 // MockSingleClientProvider is a mock of SingleClientProvider interface.
 type MockSingleClientProvider struct {
 	ctrl     *gomock.Controller
@@ -199,6 +230,22 @@ func NewMockSingleClientProvider(ctrl *gomock.Controller) *MockSingleClientProvi
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSingleClientProvider) EXPECT() *MockSingleClientProviderMockRecorder {
 	return m.recorder
+}
+
+// BlockContractLogs mocks base method.
+func (m *MockSingleClientProvider) BlockContractLogs(ctx context.Context, block uint64) ([]types.Log, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlockContractLogs", ctx, block)
+	ret0, _ := ret[0].([]types.Log)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// BlockContractLogs indicates an expected call of BlockContractLogs.
+func (mr *MockSingleClientProviderMockRecorder) BlockContractLogs(ctx, block any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockContractLogs", reflect.TypeOf((*MockSingleClientProvider)(nil).BlockContractLogs), ctx, block)
 }
 
 // ChainID mocks base method.
@@ -231,9 +278,9 @@ func (mr *MockSingleClientProviderMockRecorder) Close() *gomock.Call {
 }
 
 // FetchHistoricalLogs mocks base method.
-func (m *MockSingleClientProvider) FetchHistoricalLogs(ctx context.Context, fromBlock uint64) (<-chan BlockLogs, <-chan error, error) {
+func (m *MockSingleClientProvider) FetchHistoricalLogs(ctx context.Context, fromBlock uint64, verify bool) (<-chan BlockLogs, <-chan error, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchHistoricalLogs", ctx, fromBlock)
+	ret := m.ctrl.Call(m, "FetchHistoricalLogs", ctx, fromBlock, verify)
 	ret0, _ := ret[0].(<-chan BlockLogs)
 	ret1, _ := ret[1].(<-chan error)
 	ret2, _ := ret[2].(error)
@@ -241,9 +288,9 @@ func (m *MockSingleClientProvider) FetchHistoricalLogs(ctx context.Context, from
 }
 
 // FetchHistoricalLogs indicates an expected call of FetchHistoricalLogs.
-func (mr *MockSingleClientProviderMockRecorder) FetchHistoricalLogs(ctx, fromBlock any) *gomock.Call {
+func (mr *MockSingleClientProviderMockRecorder) FetchHistoricalLogs(ctx, fromBlock, verify any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchHistoricalLogs", reflect.TypeOf((*MockSingleClientProvider)(nil).FetchHistoricalLogs), ctx, fromBlock)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchHistoricalLogs", reflect.TypeOf((*MockSingleClientProvider)(nil).FetchHistoricalLogs), ctx, fromBlock, verify)
 }
 
 // FilterLogs mocks base method.
@@ -347,6 +394,21 @@ func (m *MockSingleClientProvider) SyncProgress(ctx context.Context) (*ethereum.
 func (mr *MockSingleClientProviderMockRecorder) SyncProgress(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncProgress", reflect.TypeOf((*MockSingleClientProvider)(nil).SyncProgress), ctx)
+}
+
+// VerifyLogs mocks base method.
+func (m *MockSingleClientProvider) VerifyLogs(ctx context.Context, fromBlock, toBlock uint64) ([]BlockLogs, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyLogs", ctx, fromBlock, toBlock)
+	ret0, _ := ret[0].([]BlockLogs)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VerifyLogs indicates an expected call of VerifyLogs.
+func (mr *MockSingleClientProviderMockRecorder) VerifyLogs(ctx, fromBlock, toBlock any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyLogs", reflect.TypeOf((*MockSingleClientProvider)(nil).VerifyLogs), ctx, fromBlock, toBlock)
 }
 
 // streamLogsToChan mocks base method.

--- a/eth/executionclient/multi_client.go
+++ b/eth/executionclient/multi_client.go
@@ -186,12 +186,12 @@ func (mc *MultiClient) assertSameChainID(chainID *big.Int) (*big.Int, bool) {
 // FetchHistoricalLogs retrieves historical logs emitted by the Ethereum SSV contract(s) starting at fromBlock.
 // It delegates the FetchHistoricalLogs call to clients MultiClient is configured with until one of them manages
 // to serve it without an error.
-func (mc *MultiClient) FetchHistoricalLogs(ctx context.Context, fromBlock uint64) (<-chan BlockLogs, <-chan error, error) {
+func (mc *MultiClient) FetchHistoricalLogs(ctx context.Context, fromBlock uint64, verify bool) (<-chan BlockLogs, <-chan error, error) {
 	var logCh <-chan BlockLogs
 	var errCh <-chan error
 
 	f := func(client SingleClientProvider) (any, error) {
-		singleLogsCh, singleErrCh, err := client.FetchHistoricalLogs(ctx, fromBlock)
+		singleLogsCh, singleErrCh, err := client.FetchHistoricalLogs(ctx, fromBlock, verify)
 		if err != nil {
 			return nil, err
 		}
@@ -207,6 +207,53 @@ func (mc *MultiClient) FetchHistoricalLogs(ctx context.Context, fromBlock uint64
 	}
 
 	return logCh, errCh, nil
+}
+
+// VerifyLogs returns the contract's logs for [fromBlock, toBlock] verified complete against
+// block blooms and receipts (used by the background verifier). It is delegated across the
+// configured clients until one serves it without an error.
+func (mc *MultiClient) VerifyLogs(ctx context.Context, fromBlock, toBlock uint64) ([]BlockLogs, error) {
+	var blockLogs []BlockLogs
+
+	f := func(client SingleClientProvider) (any, error) {
+		logs, err := client.VerifyLogs(ctx, fromBlock, toBlock)
+		if err != nil {
+			return nil, err
+		}
+		blockLogs = logs
+		return nil, nil
+	}
+
+	if _, err := mc.call(contextWithMethod(ctx, "VerifyLogs"), f); err != nil {
+		return nil, err
+	}
+
+	return blockLogs, nil
+}
+
+// BlockContractLogs returns the contract's logs for a block from its receipts (authoritative,
+// used by the background verifier to resolve a disagreeing block). It is delegated to the
+// configured clients until one serves it without an error. If the serving client doesn't support
+// eth_getBlockReceipts it reports receiptsAvailable=false; a later call may route to a client
+// that does, so a parked range can still be verified on a subsequent pass.
+func (mc *MultiClient) BlockContractLogs(ctx context.Context, block uint64) ([]ethtypes.Log, bool, error) {
+	var logs []ethtypes.Log
+	var receiptsAvailable bool
+
+	f := func(client SingleClientProvider) (any, error) {
+		l, available, err := client.BlockContractLogs(ctx, block)
+		if err != nil {
+			return nil, err
+		}
+		logs, receiptsAvailable = l, available
+		return nil, nil
+	}
+
+	if _, err := mc.call(contextWithMethod(ctx, "BlockContractLogs"), f); err != nil {
+		return nil, false, err
+	}
+
+	return logs, receiptsAvailable, nil
 }
 
 // StreamLogs subscribes to events emitted by the Ethereum SSV contract(s) starting at fromBlock.

--- a/eth/executionclient/multi_client.go
+++ b/eth/executionclient/multi_client.go
@@ -231,29 +231,43 @@ func (mc *MultiClient) VerifyLogs(ctx context.Context, fromBlock, toBlock uint64
 	return blockLogs, nil
 }
 
-// BlockContractLogs returns the contract's logs for a block from its receipts (authoritative,
-// used by the background verifier to resolve a disagreeing block). It is delegated to the
-// configured clients until one serves it without an error. If the serving client doesn't support
-// eth_getBlockReceipts it reports receiptsAvailable=false; a later call may route to a client
-// that does, so a parked range can still be verified on a subsequent pass.
+// errReceiptsUnavailable signals, inside BlockContractLogs' failover, that a client couldn't serve
+// eth_getBlockReceipts, so mc.call should move on to a sibling that might. It never leaves the method.
+var errReceiptsUnavailable = errors.New("eth_getBlockReceipts unavailable on this client")
+
+// BlockContractLogs returns the contract's logs for a block from its receipts (authoritative, used
+// by the background verifier to resolve a disagreeing block). It tries the configured clients in
+// turn: the first that serves receipts wins (and routing pins to it). It reports
+// receiptsAvailable=false only when every reachable, healthy client lacks eth_getBlockReceipts; if a
+// client instead errors or is unhealthy, that surfaces as an error so the verifier retries (it may
+// have receipts once recovered) rather than parking the range on one client's gap.
 func (mc *MultiClient) BlockContractLogs(ctx context.Context, block uint64) ([]ethtypes.Log, bool, error) {
 	var logs []ethtypes.Log
-	var receiptsAvailable bool
+	unavailable := 0
 
 	f := func(client SingleClientProvider) (any, error) {
 		l, available, err := client.BlockContractLogs(ctx, block)
 		if err != nil {
 			return nil, err
 		}
-		logs, receiptsAvailable = l, available
+		if !available {
+			unavailable++
+			return nil, errReceiptsUnavailable // fail over to a client that can serve receipts
+		}
+		logs = l
 		return nil, nil
 	}
 
 	if _, err := mc.call(contextWithMethod(ctx, "BlockContractLogs"), f); err != nil {
+		// Every reachable, healthy client lacked receipts → report unavailable (the verifier parks).
+		// Otherwise some client errored or was unhealthy → surface it so the verifier retries.
+		if unavailable == len(mc.clients) {
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 
-	return logs, receiptsAvailable, nil
+	return logs, true, nil
 }
 
 // StreamLogs subscribes to events emitted by the Ethereum SSV contract(s) starting at fromBlock.

--- a/eth/executionclient/multi_client_test.go
+++ b/eth/executionclient/multi_client_test.go
@@ -162,8 +162,8 @@ func TestMultiClient_FetchHistoricalLogs(t *testing.T) {
 
 	mockClient.
 		EXPECT().
-		FetchHistoricalLogs(gomock.Any(), uint64(100)).
-		DoAndReturn(func(ctx context.Context, fromBlock uint64) (<-chan BlockLogs, <-chan error, error) {
+		FetchHistoricalLogs(gomock.Any(), uint64(100), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, fromBlock uint64, verify bool) (<-chan BlockLogs, <-chan error, error) {
 			go func() {
 				logCh <- BlockLogs{BlockNumber: 100}
 				close(logCh)
@@ -189,7 +189,7 @@ func TestMultiClient_FetchHistoricalLogs(t *testing.T) {
 		closed:      make(chan struct{}),
 	}
 
-	logs, errs, err := mc.FetchHistoricalLogs(ctx, 100)
+	logs, errs, err := mc.FetchHistoricalLogs(ctx, 100, false)
 	require.NoError(t, err)
 	require.NotNil(t, logs)
 	require.NotNil(t, errs)
@@ -218,13 +218,13 @@ func TestMultiClient_FetchHistoricalLogs_AllClientsNothingToSync(t *testing.T) {
 
 	mockClient1.
 		EXPECT().
-		FetchHistoricalLogs(gomock.Any(), uint64(100)).
+		FetchHistoricalLogs(gomock.Any(), uint64(100), gomock.Any()).
 		Return((<-chan BlockLogs)(nil), (<-chan error)(nil), ErrNothingToSync).
 		Times(1)
 
 	mockClient2.
 		EXPECT().
-		FetchHistoricalLogs(gomock.Any(), uint64(100)).
+		FetchHistoricalLogs(gomock.Any(), uint64(100), gomock.Any()).
 		Return((<-chan BlockLogs)(nil), (<-chan error)(nil), ErrNothingToSync).
 		Times(1)
 
@@ -248,7 +248,7 @@ func TestMultiClient_FetchHistoricalLogs_AllClientsNothingToSync(t *testing.T) {
 		closed:      make(chan struct{}),
 	}
 
-	logs, errs, err := mc.FetchHistoricalLogs(ctx, 100)
+	logs, errs, err := mc.FetchHistoricalLogs(ctx, 100, false)
 	require.Error(t, err)
 	require.ErrorContains(t, err, ErrNothingToSync.Error())
 	require.Nil(t, logs)
@@ -267,7 +267,7 @@ func TestMultiClient_FetchHistoricalLogs_MixedErrors(t *testing.T) {
 
 	mockClient1.
 		EXPECT().
-		FetchHistoricalLogs(gomock.Any(), uint64(100)).
+		FetchHistoricalLogs(gomock.Any(), uint64(100), gomock.Any()).
 		Return((<-chan BlockLogs)(nil), (<-chan error)(nil), fmt.Errorf("unexpected error")).
 		Times(1)
 
@@ -279,7 +279,7 @@ func TestMultiClient_FetchHistoricalLogs_MixedErrors(t *testing.T) {
 
 	mockClient2.
 		EXPECT().
-		FetchHistoricalLogs(gomock.Any(), uint64(100)).
+		FetchHistoricalLogs(gomock.Any(), uint64(100), gomock.Any()).
 		Return((<-chan BlockLogs)(nil), (<-chan error)(nil), ErrNothingToSync).
 		Times(1)
 
@@ -297,7 +297,7 @@ func TestMultiClient_FetchHistoricalLogs_MixedErrors(t *testing.T) {
 		closed:      make(chan struct{}),
 	}
 
-	logs, errs, err := mc.FetchHistoricalLogs(ctx, 100)
+	logs, errs, err := mc.FetchHistoricalLogs(ctx, 100, false)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "all clients failed")
 	require.Nil(t, logs)

--- a/eth/executionclient/multi_client_test.go
+++ b/eth/executionclient/multi_client_test.go
@@ -1362,6 +1362,71 @@ func TestMultiClient_Call_AllClientsFail(t *testing.T) {
 	require.Contains(t, err.Error(), "all clients failed")
 }
 
+func TestMultiClient_BlockContractLogs_ReceiptsFailover(t *testing.T) {
+	const block = uint64(2_746_590)
+	wantLogs := []ethtypes.Log{{BlockNumber: block, Index: 0}}
+
+	newClients := func(t *testing.T, ctrl *gomock.Controller) (*MockSingleClientProvider, *MockSingleClientProvider, *MultiClient) {
+		c1 := NewMockSingleClientProvider(ctrl)
+		c2 := NewMockSingleClientProvider(ctrl)
+		c1.EXPECT().Healthy(gomock.Any()).Return(nil).AnyTimes()
+		c2.EXPECT().Healthy(gomock.Any()).Return(nil).AnyTimes()
+		mc := &MultiClient{
+			clientAddrs: []string{"mockNode1", "mockNode2"},
+			clients:     []SingleClientProvider{c1, c2},
+			clientsMu:   make([]sync.Mutex, 2),
+			logger:      log.TestLogger(t),
+			closed:      make(chan struct{}),
+		}
+		return c1, c2, mc
+	}
+
+	t.Run("fails over to a client that has receipts", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		c1, c2, mc := newClients(t, ctrl)
+
+		// Client 1 lacks eth_getBlockReceipts; client 2 serves them.
+		c1.EXPECT().BlockContractLogs(gomock.Any(), block).Return(nil, false, nil).Times(1)
+		c2.EXPECT().BlockContractLogs(gomock.Any(), block).Return(wantLogs, true, nil).Times(1)
+
+		logs, available, err := mc.BlockContractLogs(t.Context(), block)
+		require.NoError(t, err)
+		require.True(t, available)
+		require.Equal(t, wantLogs, logs)
+		require.Equal(t, int64(1), mc.currentClientIndex.Load(), "routing pins to the receipts-capable client")
+	})
+
+	t.Run("reports unavailable (parks, no error) only when every client lacks receipts", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		c1, c2, mc := newClients(t, ctrl)
+
+		c1.EXPECT().BlockContractLogs(gomock.Any(), block).Return(nil, false, nil).Times(1)
+		c2.EXPECT().BlockContractLogs(gomock.Any(), block).Return(nil, false, nil).Times(1)
+
+		logs, available, err := mc.BlockContractLogs(t.Context(), block)
+		require.NoError(t, err)
+		require.False(t, available)
+		require.Nil(t, logs)
+	})
+
+	t.Run("surfaces an error (does not park) when a client fails while another lacks receipts", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		c1, c2, mc := newClients(t, ctrl)
+
+		// Client 1 errors (it may serve receipts once recovered); client 2 lacks receipts. The
+		// verifier must retry, not park on client 2's gap.
+		c1.EXPECT().BlockContractLogs(gomock.Any(), block).Return(nil, false, errors.New("boom")).Times(1)
+		c2.EXPECT().BlockContractLogs(gomock.Any(), block).Return(nil, false, nil).Times(1)
+
+		_, available, err := mc.BlockContractLogs(t.Context(), block)
+		require.Error(t, err)
+		require.False(t, available)
+	})
+}
+
 // dummySubscription is a stub implementing ethereum.Subscription.
 type dummySubscription struct{}
 

--- a/eth/executionclient/observability.go
+++ b/eth/executionclient/observability.go
@@ -251,6 +251,12 @@ func recordBloomRecovery(ctx context.Context) {
 	bloomCheckCounter.Add(ctx, 1, metric.WithAttributes(bloomOutcomeAttribute("recovery")))
 }
 
+// recordBloomReceiptsRecovery counts events recovered from block receipts after the EL's
+// log index persistently omitted them from eth_getLogs responses.
+func recordBloomReceiptsRecovery(ctx context.Context) {
+	bloomCheckCounter.Add(ctx, 1, metric.WithAttributes(bloomOutcomeAttribute("receipts_recovery")))
+}
+
 func recordBloomFalsePositive(ctx context.Context) {
 	bloomCheckCounter.Add(ctx, 1, metric.WithAttributes(bloomOutcomeAttribute("false_positive")))
 }

--- a/operator/storage/storage.go
+++ b/operator/storage/storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/ethereum/go-ethereum/common"
@@ -35,6 +36,25 @@ type Storage interface {
 
 	SaveLastProcessedBlock(rw basedb.ReadWriter, offset *big.Int) error
 	GetLastProcessedBlock(r basedb.Reader) (*big.Int, bool, error)
+
+	// Background-verification state (see the verifier in eth/eventsyncer): ranges synced
+	// optimistically that await verification, per-block log digests to verify them against,
+	// and a flag requesting a full resync when a miss is found.
+	SaveUnverifiedRange(rw basedb.ReadWriter, r UnverifiedRange) error
+	ListUnverifiedRanges(r basedb.Reader) ([]UnverifiedRange, error)
+	DeleteUnverifiedRange(rw basedb.ReadWriter, from uint64) error
+	SaveBlockLogDigest(rw basedb.ReadWriter, block uint64, digest []byte) error
+	GetBlockLogDigest(r basedb.Reader, block uint64) ([]byte, bool, error)
+	DeleteBlockLogDigest(rw basedb.ReadWriter, block uint64) error
+	SetResyncRequired(rw basedb.ReadWriter) error
+	IsResyncRequired(r basedb.Reader) (bool, error)
+	ClearResyncRequired(rw basedb.ReadWriter) error
+	SetResyncInProgress(rw basedb.ReadWriter) error
+	IsResyncInProgress(r basedb.Reader) (bool, error)
+	ClearResyncInProgress(rw basedb.ReadWriter) error
+	SetLastResyncTime(rw basedb.ReadWriter, t time.Time) error
+	GetLastResyncTime(r basedb.Reader) (time.Time, bool, error)
+	DropVerificationJournal() error
 
 	GetConfig(rw basedb.ReadWriter) (*ConfigLock, bool, error)
 	SaveConfig(rw basedb.ReadWriter, config *ConfigLock) error

--- a/operator/storage/verification.go
+++ b/operator/storage/verification.go
@@ -1,0 +1,171 @@
+package storage
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/ssvlabs/ssv/storage/basedb"
+)
+
+// Background-verification state (see the verifier in eth/eventsyncer):
+//   - unverifiedRangePrefix journals block ranges synced optimistically (getLogs only, no
+//     completeness check) that await verification against chain data.
+//   - blockLogDigestPrefix stores, per block, a digest of the contract logs the optimistic
+//     sync received there; the verifier recomputes it from receipts and compares.
+//   - resyncRequiredKey, when set, tells the node at startup to drop registry state and
+//     resync from scratch with inline verification (the verifier sets it on a detected miss).
+//   - resyncInProgressKey, when set, means a resync already dropped state and is rebuilding, so
+//     an interrupted repair resumes from the last-processed marker instead of dropping again.
+//   - lastResyncKey stores when a resync was last flagged, to rate-limit auto-repair.
+var (
+	unverifiedRangePrefix = []byte("operator/unverified-range/")
+	blockLogDigestPrefix  = []byte("operator/block-log-digest/")
+	resyncRequiredKey     = []byte("resync-required")
+	resyncInProgressKey   = []byte("resync-in-progress")
+	lastResyncKey         = []byte("last-resync-unix")
+)
+
+// UnverifiedRange is a journalled block range awaiting background verification. Cursor is the
+// next block to verify; the range is fully verified (and removed) once Cursor exceeds To.
+type UnverifiedRange struct {
+	From   uint64 `json:"from"`
+	To     uint64 `json:"to"`
+	Cursor uint64 `json:"cursor"`
+}
+
+func beUint64(n uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, n)
+	return b
+}
+
+// SaveUnverifiedRange upserts a range (keyed by From), used both to enqueue a range and to
+// persist verification cursor progress.
+func (s *storage) SaveUnverifiedRange(rw basedb.ReadWriter, r UnverifiedRange) error {
+	b, err := json.Marshal(r)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	return s.db.Using(rw).Set(unverifiedRangePrefix, beUint64(r.From), b)
+}
+
+// ListUnverifiedRanges returns all ranges awaiting verification, ordered by From block.
+func (s *storage) ListUnverifiedRanges(r basedb.Reader) ([]UnverifiedRange, error) {
+	var ranges []UnverifiedRange
+	err := s.db.UsingReader(r).GetAll(unverifiedRangePrefix, func(_ int, obj basedb.Obj) error {
+		var ur UnverifiedRange
+		if err := json.Unmarshal(obj.Value, &ur); err != nil {
+			return fmt.Errorf("unmarshal: %w", err)
+		}
+		ranges = append(ranges, ur)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("db: %w", err)
+	}
+	return ranges, nil
+}
+
+// DeleteUnverifiedRange removes a fully-verified range from the journal.
+func (s *storage) DeleteUnverifiedRange(rw basedb.ReadWriter, from uint64) error {
+	return s.db.Using(rw).Delete(unverifiedRangePrefix, beUint64(from))
+}
+
+// SaveBlockLogDigest records the digest of the contract logs received for a block during an
+// optimistic sync (written in the same transaction that advances the last-processed marker).
+func (s *storage) SaveBlockLogDigest(rw basedb.ReadWriter, block uint64, digest []byte) error {
+	return s.db.Using(rw).Set(blockLogDigestPrefix, beUint64(block), digest)
+}
+
+// GetBlockLogDigest returns the recorded digest for a block, or found=false if none (which
+// the verifier treats as "the optimistic sync saw no logs there").
+func (s *storage) GetBlockLogDigest(r basedb.Reader, block uint64) ([]byte, bool, error) {
+	obj, found, err := s.db.UsingReader(r).Get(blockLogDigestPrefix, beUint64(block))
+	if err != nil {
+		return nil, false, err
+	}
+	if !found {
+		return nil, false, nil
+	}
+	return obj.Value, true, nil
+}
+
+// DeleteBlockLogDigest removes a block's digest once the verifier has checked it.
+func (s *storage) DeleteBlockLogDigest(rw basedb.ReadWriter, block uint64) error {
+	return s.db.Using(rw).Delete(blockLogDigestPrefix, beUint64(block))
+}
+
+// SetResyncRequired marks that the node must drop registry state and resync from scratch
+// (with inline verification) on its next start.
+func (s *storage) SetResyncRequired(rw basedb.ReadWriter) error {
+	return s.db.Using(rw).Set(OperatorStoragePrefix, resyncRequiredKey, []byte{1})
+}
+
+// IsResyncRequired reports whether a full resync has been requested.
+func (s *storage) IsResyncRequired(r basedb.Reader) (bool, error) {
+	_, found, err := s.db.UsingReader(r).Get(OperatorStoragePrefix, resyncRequiredKey)
+	if err != nil {
+		return false, err
+	}
+	return found, nil
+}
+
+// DropVerificationJournal clears the background-verification journal: pending ranges and block
+// digests. It deliberately leaves the resync flags untouched — the resync repair drops the
+// journal before rebuilding, but keeps its flags until the verified resync completes.
+func (s *storage) DropVerificationJournal() error {
+	if err := s.db.DropPrefix(unverifiedRangePrefix); err != nil {
+		return fmt.Errorf("drop unverified ranges: %w", err)
+	}
+	if err := s.db.DropPrefix(blockLogDigestPrefix); err != nil {
+		return fmt.Errorf("drop block-log digests: %w", err)
+	}
+	return nil
+}
+
+// ClearResyncRequired clears the resync-required flag, called once a verified resync has
+// completed so the next start is a normal boot.
+func (s *storage) ClearResyncRequired(rw basedb.ReadWriter) error {
+	return s.db.Using(rw).Delete(OperatorStoragePrefix, resyncRequiredKey)
+}
+
+// SetResyncInProgress marks that a resync has dropped registry state and is rebuilding it, so an
+// interrupted repair resumes from the last-processed marker instead of dropping again.
+func (s *storage) SetResyncInProgress(rw basedb.ReadWriter) error {
+	return s.db.Using(rw).Set(OperatorStoragePrefix, resyncInProgressKey, []byte{1})
+}
+
+// IsResyncInProgress reports whether a resync has already dropped state and is mid-rebuild.
+func (s *storage) IsResyncInProgress(r basedb.Reader) (bool, error) {
+	_, found, err := s.db.UsingReader(r).Get(OperatorStoragePrefix, resyncInProgressKey)
+	if err != nil {
+		return false, err
+	}
+	return found, nil
+}
+
+// ClearResyncInProgress clears the resync-in-progress flag once the verified resync completes.
+func (s *storage) ClearResyncInProgress(rw basedb.ReadWriter) error {
+	return s.db.Using(rw).Delete(OperatorStoragePrefix, resyncInProgressKey)
+}
+
+// SetLastResyncTime records when a resync was last flagged, used to rate-limit auto-repair.
+func (s *storage) SetLastResyncTime(rw basedb.ReadWriter, t time.Time) error {
+	// #nosec G115 -- unix seconds fit in uint64 well past any realistic time
+	return s.db.Using(rw).Set(OperatorStoragePrefix, lastResyncKey, beUint64(uint64(t.Unix())))
+}
+
+// GetLastResyncTime returns when a resync was last flagged, or found=false if never.
+func (s *storage) GetLastResyncTime(r basedb.Reader) (time.Time, bool, error) {
+	obj, found, err := s.db.UsingReader(r).Get(OperatorStoragePrefix, lastResyncKey)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	if !found {
+		return time.Time{}, false, nil
+	}
+	// #nosec G115 -- value was written from a unix timestamp
+	return time.Unix(int64(binary.BigEndian.Uint64(obj.Value)), 0), true, nil
+}

--- a/operator/storage/verification_test.go
+++ b/operator/storage/verification_test.go
@@ -1,0 +1,150 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ssvlabs/ssv/observability/log"
+	kv "github.com/ssvlabs/ssv/storage/badger"
+	"github.com/ssvlabs/ssv/storage/basedb"
+)
+
+func newTestStorage(t *testing.T) *storage {
+	db, err := kv.NewInMemory(log.TestLogger(t), basedb.Options{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return &storage{db: db}
+}
+
+func TestUnverifiedRanges(t *testing.T) {
+	s := newTestStorage(t)
+
+	// Empty to start.
+	ranges, err := s.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Empty(t, ranges)
+
+	// Saved ranges come back ordered by From, regardless of insertion order.
+	require.NoError(t, s.SaveUnverifiedRange(nil, UnverifiedRange{From: 100, To: 200, Cursor: 100}))
+	require.NoError(t, s.SaveUnverifiedRange(nil, UnverifiedRange{From: 10, To: 20, Cursor: 15}))
+	ranges, err = s.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Equal(t, []UnverifiedRange{
+		{From: 10, To: 20, Cursor: 15},
+		{From: 100, To: 200, Cursor: 100},
+	}, ranges)
+
+	// Saving a range with an existing From upserts it (used to persist cursor progress).
+	require.NoError(t, s.SaveUnverifiedRange(nil, UnverifiedRange{From: 10, To: 20, Cursor: 18}))
+	ranges, err = s.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Len(t, ranges, 2)
+	require.Equal(t, uint64(18), ranges[0].Cursor)
+
+	// Deleting removes just that range.
+	require.NoError(t, s.DeleteUnverifiedRange(nil, 10))
+	ranges, err = s.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Equal(t, []UnverifiedRange{{From: 100, To: 200, Cursor: 100}}, ranges)
+}
+
+func TestBlockLogDigests(t *testing.T) {
+	s := newTestStorage(t)
+
+	// Absent digest reports found=false (the verifier reads this as "no logs seen there").
+	_, found, err := s.GetBlockLogDigest(nil, 42)
+	require.NoError(t, err)
+	require.False(t, found)
+
+	digest := []byte("some-32-byte-digest-placeholder!")
+	require.NoError(t, s.SaveBlockLogDigest(nil, 42, digest))
+
+	got, found, err := s.GetBlockLogDigest(nil, 42)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, digest, got)
+
+	require.NoError(t, s.DeleteBlockLogDigest(nil, 42))
+	_, found, err = s.GetBlockLogDigest(nil, 42)
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func TestResyncRequiredFlag(t *testing.T) {
+	s := newTestStorage(t)
+
+	set, err := s.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.False(t, set)
+
+	require.NoError(t, s.SetResyncRequired(nil))
+	set, err = s.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.True(t, set)
+}
+
+func TestResyncInProgressFlag(t *testing.T) {
+	s := newTestStorage(t)
+
+	set, err := s.IsResyncInProgress(nil)
+	require.NoError(t, err)
+	require.False(t, set)
+
+	require.NoError(t, s.SetResyncInProgress(nil))
+	set, err = s.IsResyncInProgress(nil)
+	require.NoError(t, err)
+	require.True(t, set)
+
+	require.NoError(t, s.ClearResyncInProgress(nil))
+	set, err = s.IsResyncInProgress(nil)
+	require.NoError(t, err)
+	require.False(t, set)
+}
+
+func TestLastResyncTime(t *testing.T) {
+	s := newTestStorage(t)
+
+	_, found, err := s.GetLastResyncTime(nil)
+	require.NoError(t, err)
+	require.False(t, found)
+
+	now := time.Now().Truncate(time.Second)
+	require.NoError(t, s.SetLastResyncTime(nil, now))
+
+	got, found, err := s.GetLastResyncTime(nil)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, now.Unix(), got.Unix())
+}
+
+func TestDropVerificationJournal(t *testing.T) {
+	s := newTestStorage(t)
+
+	require.NoError(t, s.SaveUnverifiedRange(nil, UnverifiedRange{From: 1, To: 9, Cursor: 1}))
+	require.NoError(t, s.SaveBlockLogDigest(nil, 5, []byte("digest")))
+	require.NoError(t, s.SetResyncRequired(nil))
+
+	require.NoError(t, s.DropVerificationJournal())
+
+	// Ranges and digests are gone...
+	ranges, err := s.ListUnverifiedRanges(nil)
+	require.NoError(t, err)
+	require.Empty(t, ranges)
+
+	_, found, err := s.GetBlockLogDigest(nil, 5)
+	require.NoError(t, err)
+	require.False(t, found)
+
+	// ...but the resync flag is deliberately left set (cleared only after a verified resync).
+	set, err := s.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.True(t, set)
+
+	// ClearResyncRequired clears it.
+	require.NoError(t, s.ClearResyncRequired(nil))
+	set, err = s.IsResyncRequired(nil)
+	require.NoError(t, err)
+	require.False(t, set)
+}


### PR DESCRIPTION
Closes #2990.

## TL;DR

- `eth_getLogs` is served from the EL's **derived, non-consensus log index**, which can silently return fewer logs than a block holds; historical sync trusted it, so registry events could be lost permanently and invisibly (#2990).
- Now: restart catch-ups (up to ~a week of blocks) are **verified inline** at boot; large cold syncs run **optimistically** and are verified **in the background** against per-block digests, with disagreements settled by receipts — the index-independent source of truth.
- A receipts-confirmed miss triggers an **automatic drop-and-resync** on the next start — resumable if interrupted, rate-limited against loops.
- **No config changes, no DB migration.** Ops: `ssv.event_syncer.verify.misses` and `.parked` should stay 0; a confirmed miss shows up as a loud warning + self-restart into a rebuild.

## Problem

Historical registry-event sync reads logs via `eth_getLogs`. The log index serving it can return fewer logs than a block actually holds — while still building (snap sync), pruned, mid-rebuild, or buggy (e.g. the geth log-index bug) — with no error. Because the sync advanced its last-processed marker regardless, events dropped this way were **silently and permanently lost**.

A [field analysis of an affected node](https://github.com/ssvlabs/ssv/issues/2990#issuecomment-5339378358) (full-keyspace diff of the drifted DB against a canonical resync) confirmed the blast radius: a dropped window loses **whatever registry events it contained** — operator registrations, fee-recipient updates, owner-nonce bumps, cluster liquidations — not just the `OperatorAdded` events the issue was first noticed by.

Verifying every block inline (header bloom + receipts) is too costly to run across a full cold sync on the startup critical path (see [Costs](#costs-why-the-split)), so the work is split into an optimistic hot path plus background verification with an automatic, guarded repair.

## How it works

**1. Optimistic hot path** — the historical sync goes optimistic only when it's large: a cold sync from the registry offset, or a very prolonged catch-up. A normal restart catch-up (up to `maxInlineVerifyCatchUp` = 50k blocks ≈ a week) is instead bloom-checked **inline**, so the node starts with guaranteed-complete state and no window. On the optimistic path, `eth_getLogs` is used plain (fast), and for each non-empty block the handler records a digest of the logs it received — sha256 over each log's `(TxIndex, Index)` — and extends an "unverified range", **in the same transaction that advances the marker**, so a hard crash can't leave a processed block outside the range the verifier will later check.

**2. Background verifier** — off the startup critical path (concurrent with ongoing sync), each journalled range is re-fetched (`VerifyLogs`) and compared, block by block, to the recorded digests. On a disagreement it **resolves the block against receipts** and flags a resync only when receipts confirm the sync genuinely missed events (`eth_getLogs` can only ever return a subset, so a recorded digest short of receipts is provably a miss). When the verify-time fetch merely blipped (or a different EL under `MultiClient` returned less), receipts vindicate the recorded digest and the block is retired clean. If there is no authoritative source for the block, the range is **parked** — left pending and visible on `pending_ranges`, re-checked on the next start — rather than resynced on unauthoritative evidence or retired as verified. "No authoritative source" covers an EL without `eth_getBlockReceipts` (under `MultiClient` the receipts resolution first fails over across clients, so one client's gap doesn't park a mixed fleet) and a **self-inconsistent** response: zero receipts for a block evidenced to hold logs is a broken receipt store, never proof the block is empty. Progress is persisted per chunk (resumable), and transient failures retry in-process with capped backoff.

**3. Repair** — registry events are order-dependent and carry per-owner nonces, so a detected miss **cannot be patched in place**. The verifier persists a resync flag and returns a sentinel that terminates the node; the next start drops registry state and resyncs from the registry offset with **inline** verification. The repair is **resumable** (a `resync-in-progress` marker means an interrupted repair resumes from the last-processed marker — its progress was inline-verified — instead of re-dropping) and **rate-limited** (`defaultResyncCooldown` = 6h: further confirmed misses within the window are parked and logged, not acted on, so a common-mode EL fault can't fatal+wipe+resync a large fraction of the operator set in a loop).

## Guarantees

- On the optimistic path, the marker never advances past a block the verifier won't later check (journaling is atomic with the marker).
- A resync is triggered only by a receipts-confirmed miss — never on unauthoritative evidence; unresolvable disagreements park the range visibly instead of retiring it as verified.
- Repairs are resumable and rate-limited.
- Near-head streaming stays inline-verified exactly as before; it journals nothing and needs no background pass.

**Residual blind spot:** if the sync **and** the verify-time re-fetch drop the *same* logs, the digests agree and receipts are never consulted — an identical double-drop goes undetected. Resolving every block against receipts would close it but is far more expensive, and the partial within-block drop it guards against has not been observed.

## Operator impact

- **No config changes, no migration.** New storage keys under the `operator/` prefix (unverified ranges, per-block digests, resync flags), absent on existing databases and created on demand. Downgrade-safe: older versions ignore the new keys; ranges synced by an older version are simply not verified (the pre-fix status quo).
- **Normal boots are unchanged**: catch-ups up to `maxInlineVerifyCatchUp` are verified inline in minutes (see Costs), so there is no unverified window after ordinary restarts.
- **Cold sync**: startup speed stays ~pre-fix; the background verifier then re-reads the synced range **while the node is already running** — expect a few hours of extra EL traffic (see Costs) and `pending_ranges > 0` until it finishes. During that window a missed `Added` under-serves (a validator whose data isn't present simply doesn't start, then starts once reconciled), while a missed liquidation/removal briefly over-serves (duties keep running that should have stopped — field-observed, never slashing-relevant) until verification catches it.
- **On a confirmed miss**: a warning ("background verification found the optimistic sync missed registry events; a full resync will run on the next start"), then the node terminates with `registry resync required`; the next start drops registry state and rebuilds with inline verification — validator downtime for the duration of the rebuild.
- **The repair is slashing-safe.** `DropRegistryData` never touches signer/slashing-protection storage, and the resync's replayed `AddShare` is idempotent over the key manager's existing accounts and only ever *bumps* slashing protection. Field-corroborated: the drifted node's post-resync slashing values had strictly advanced.
- **Pre-existing drift is not retroactively detected.** Syncs performed by pre-fix versions journalled nothing, so this PR cannot verify them after the fact. A node suspected of historical drift needs a one-time manual resync — and note that an operator-table diff understates the damage: fee recipients, nonces and liquidation flags can be stale too (see the field report).
- **Alerting**: `ssv.event_syncer.verify.misses` and `ssv.event_syncer.verify.parked` should stay at zero. `parked > 0` → the EL can't authoritatively verify a block (usually missing `eth_getBlockReceipts`) — investigate the EL. `suppressed > 0` → a repair is being deferred by the rate limit. `pending_ranges` / `cursor` show verification progress. Genuine receipts recoveries count on the existing `ssv.el.bloom.checks` metric.

## Costs (why the split)

Measured on real infra (local Besu/hoodi + two mainnet block samples via public RPC), using the same bloom-filter test the fix uses:

| measurement | hoodi | mainnet (2023 blocks) | mainnet (2024 blocks) |
|---|---|---|---|
| bloom false-positive rate (empty block flagged → drives a receipts fetch) | 0.018% | 3.99% | 5.00% |
| header payload (`getBlockByNumber(false)`, incl. tx-hash list) | 5.4 KB | 12.5 KB | 18.5 KB |
| `getBlockReceipts` payload | 77 KB | 417 KB | 457 KB |

Two cost drivers: an **O(N) header/bloom screen** (one header per empty block, regardless of FP rate) and **O(FP) receipts** (bloom-positive-empty blocks). Projected:

- **Restart catch-up (every boot, the common path):** trivial — even a week of downtime (~50k blocks) is <1 GB headers + ~1 GB receipts in minutes, so full inline verification is effectively free.
- **Mainnet cold sync (~8.2M blocks from the sync offset, once per node lifetime):** header screen ≈ **~120 GB / ~1–2 h**, receipts ≈ **~160 GB / ~1–2 h** — data-volume-dominated and local-EL-bound.

So verifying every block inline across a cold sync would add ~1–2 h to the startup critical path. Hence the split: **≤ threshold** verifies fully inline (effectively free); **> threshold** goes optimistic and moves the unavoidable verification off the critical path into the background — startup stays ~pre-fix speed while the gap is still *closed* (eventually), not skipped.

## Review guide

Suggested reading order:

1. [`operator/storage/verification.go`](https://github.com/ssvlabs/ssv/blob/fix/2990-historical-log-verification/operator/storage/verification.go) — journal + flags storage
2. [`eth/executionclient/logs.go`](https://github.com/ssvlabs/ssv/blob/fix/2990-historical-log-verification/eth/executionclient/logs.go) — the per-block digest
3. [`eth/eventhandler/event_handler.go`](https://github.com/ssvlabs/ssv/blob/fix/2990-historical-log-verification/eth/eventhandler/event_handler.go) — same-transaction journaling
4. [`eth/eventsyncer/verifier.go`](https://github.com/ssvlabs/ssv/blob/fix/2990-historical-log-verification/eth/eventsyncer/verifier.go) — digest comparison, receipts resolution, park/rate-limit
5. [`cli/operator/eventsync.go`](https://github.com/ssvlabs/ssv/blob/fix/2990-historical-log-verification/cli/operator/eventsync.go) — boot wiring: inline/optimistic split + resumable repair
6. [`eth/executionclient/bloom.go`](https://github.com/ssvlabs/ssv/blob/fix/2990-historical-log-verification/eth/executionclient/bloom.go) — bloom→re-request→receipts completeness check, `VerifyLogs`, `BlockContractLogs`
7. [`eth/executionclient/eth_client.go`](https://github.com/ssvlabs/ssv/blob/fix/2990-historical-log-verification/eth/executionclient/eth_client.go) — bounded batched RPC with sequential fallback

The rest of the diff is mostly mechanical: the two regenerated mock files, and test files updated for the new parameter on `SyncHistory` / `FetchHistoricalLogs` / `HandleBlockEventsStream`.

## Also included

- **Offset-0 journaling fix.** The journal signal is a `*uint64`, not a `0` sentinel, so a network with `RegistrySyncOffset == 0` (local-testnet, custom YAML) journals instead of silently disabling verification.
- **Bounded batched RPC.** `HeadersByNumbers`/`SingleBlockLogs` cap each batch (~100, matching common hosted-provider limits) with per-element sequential fallback, and remember a provider that rejects batching wholesale (latched only when the sequential fallback succeeds — and never on a batch timeout/cancellation — so neither an outage nor a slow provider false-latches).
- **Receipts self-consistency guard.** Zero receipts for a block evidenced to hold logs is treated as an unreliable receipt store (park / fall back to re-requests), never as an authoritative empty block; and `-32004` ("method not supported", EIP-1474) is recognized alongside `-32601` when detecting a missing `eth_getBlockReceipts`.
- **Response-size-aware subdivision.** `subdivideLogFetch` also splits on response-size failures (websocket read limit, HTTP 413, "response too large"), not just the `-32005` query-limit code, so a wide verify chunk can't wedge the verifier in a no-progress retry loop.
- **Staleness-guard underflow fix.** `ensureBlockAboveThreshold` compared in unsigned space; a large staleness threshold wrapped the cast and flagged every block as too old. Now compared in signed space.

## Accepted tradeoffs (feedback welcome)

- **Unverified window** on the optimistic path only (cold sync, or a very prolonged catch-up) until the background pass clears it — for a fresh cold sync, potentially hours. The window cuts both ways (missed additions under-serve, missed liquidations/removals over-serve; see Operator impact), but normal restarts avoid it entirely, and it's strictly better than the status quo, where a miss was permanent and silent.
- **Resync blast radius.** A confirmed miss costs a full `DropRegistryData` + resync-from-offset (validator downtime for the rebuild). Misses should be rare (EL bug/corruption only), a full rebuild is the only correct remedy given the nonce ordering, and the repair is resumable + rate-limited to bound the cost. A surgical replay-from-affected-block is deliberately left as follow-up.

## Testing

- **Unit** — digest properties (order-independence, subset ⇒ different digest); storage journal/flag/timestamp round-trips; verifier state machine (clean range, receipts-confirmed missing-digest and subset misses, receipts-vindicated verify-time drop, park-on-no-receipts, rate-limit suppression, cursor resume, chunking, retry wrapper); handler journaling (per-block digest + range on the optimistic path, offset-0, range journalled up to the last processed block even when the stream aborts); boot resync preparation (first-attempt drop + mark-in-progress, resume-from-marker when already in progress); batch-error → sequential fallback and the batching-unsupported memo.
- **Integration** — the full miss → flag → drop → verified resync → clear loop with the real handler + storage and a mocked EL.
- **End-to-end against a real go-ethereum RPC stack** (simulated backend + an HTTP proxy that induces the incomplete `eth_getLogs`) — exercises the real `ExecutionClient` (bloom/receipts/batching), not mocks: (a) healthy EL verifies clean with no false resync; (b) a persistently-dropped block is silently missed by the optimistic sync, recovered from receipts by the background verifier, and repaired by the resync so the DB ends complete — the #2990 loop; (c) an unresolvable disagreement with `eth_getBlockReceipts` unavailable parks the range instead of resyncing; (d) the field report's full blast radius — a dropped block carrying a fee-recipient update, a cluster liquidation and an owner-nonce bump drifts all three and the repair restores them, with the verified resync replaying `ValidatorAdded` over the key manager's existing share account; (e) an empty-receipts response parks (no false resync) and the parked range retires clean once receipts return.
- The existing `eth_getLogs`-drop recovery regression test for #2990 is retained.
- `go build ./...`, pinned `golangci-lint` (0 issues), and `-race` runs of the affected packages pass.

## End-to-end validation on real Besu

Beyond the in-process E2E above, the fix was validated end-to-end against a **real, external EL** exhibiting genuine on-disk log-index corruption — the actual #2990 mechanism, not a simulated drop. This harness is intentionally **not** committed / CI-run (it needs an external synced node); the methodology is recorded here so it can be reproduced.

**Rig.** Besu (hoodi, snap sync) + Lighthouse (hoodi, checkpoint sync), synced past block 2,746,590 — where operator 542 registered on the hoodi SSV contract `0xc07B3E9671f884FDa67E1e7D43d952E0e1369fd8`.

**Fault injection.** Besu serves `eth_getLogs` from per-block log-bloom cache files (`caches/logBloom-<segment>.cache`, 256 bytes/block, no checksums). Zeroing operator 542's slot — segment `2746590 / 100000 = 27`, offset `(2746590 % 100000) * 256 = 11,927,040`, 256 bytes — makes Besu **silently** return incomplete logs for that block while its receipts stay intact. Verified directly against the running node: `eth_getLogs` at block 2,746,590 dropped from **2 logs to 0** (no error), while `eth_getBlockReceipts` still returned both.

**Result.** Driving the real `ExecutionClient → EventSyncer → EventHandler → BadgerDB` pipeline against the corrupted node reproduced the full loop:
1. optimistic `SyncHistory` silently missed operator 542 — #2990;
2. the background verifier recovered the block from receipts, logged the operator-actionable warning (`recovered contract logs from block receipts that the execution client's log index did not return … consider resyncing`), and flagged a resync;
3. the drop + verified resync recovered operator 542.

Confirms the detect→repair path works against a real EL with a genuinely corrupt log index, not just a simulated one.

## Out of scope / follow-up

- Surgical replay-from-affected-block instead of full resync on a confirmed miss. Per the field data, nonce reconciliation is the hard part: a missed event can leave a *lower* persisted nonce, so a replay must reconcile per-owner nonces, not just insert events.
- A config opt-out for auto-repair (the rate-limit is in; a hard off-switch is not).
- Closing the identical-double-drop blind spot (see Guarantees) would require resolving every block against receipts — far more expensive, not observed in practice.

