### PR TITLE
eth/executionclient: order packed logs by logIndex within a transaction

### DIFF
--- a/eth/executionclient/bloom.go
+++ b/eth/executionclient/bloom.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"sort"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -81,14 +80,9 @@ func (ec *ExecutionClient) verifyLogsWithBloom(ctx context.Context, logs []ethty
 		}
 	}
 
-	// Re-sort if we appended recovered logs so downstream receives them in block/tx order.
+	// Appending recovered logs above leaves the slice unsorted, so re-sort before returning.
 	if recovered {
-		sort.Slice(logs, func(i, j int) bool {
-			if logs[i].BlockNumber != logs[j].BlockNumber {
-				return logs[i].BlockNumber < logs[j].BlockNumber
-			}
-			return logs[i].TxIndex < logs[j].TxIndex
-		})
+		sortLogsCanonical(logs)
 	}
 
 	return logs, nil

--- a/eth/executionclient/logs.go
+++ b/eth/executionclient/logs.go
@@ -6,20 +6,21 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
-// BlockLogs holds a block's number and it's logs.
+// BlockLogs holds a block's number and its logs.
 type BlockLogs struct {
 	BlockNumber uint64
 	Logs        []ethtypes.Log
 }
 
-// PackLogs packs logs into []BlockLogs by their block number.
-func PackLogs(logs []ethtypes.Log) []BlockLogs {
-	// Sort into canonical on-chain order. The Index (logIndex) tiebreaker is what keeps logs
-	// emitted by the same transaction in order: sort.Slice is not stable, and a single tx can
-	// emit multiple order-dependent registry events (e.g. bulkRegisterValidator emits one
-	// ValidatorAdded per validator, each bumping the owner's nonce), which the handler must
-	// process in order. Without it, same-tx logs could be reordered and valid registrations
-	// silently rejected on a nonce mismatch.
+// sortLogsCanonical sorts logs in place into canonical on-chain order: block number, then
+// transaction index, then log index. The log-index tiebreaker is what keeps logs from the
+// same transaction ordered — sort.Slice is not stable, and one transaction can emit several
+// order-dependent events (e.g. bulkRegisterValidator emits one ValidatorAdded per validator,
+// each bumping the owner's nonce); without it, same-tx logs can reorder and valid
+// registrations get silently rejected on a nonce mismatch. It is the only log-ordering
+// function in the package: route every raw-log sort through it (e.g. bloom recovery) so a
+// second, divergent comparator can't creep back in.
+func sortLogsCanonical(logs []ethtypes.Log) {
 	sort.Slice(logs, func(i, j int) bool {
 		if logs[i].BlockNumber != logs[j].BlockNumber {
 			return logs[i].BlockNumber < logs[j].BlockNumber
@@ -29,6 +30,11 @@ func PackLogs(logs []ethtypes.Log) []BlockLogs {
 		}
 		return logs[i].Index < logs[j].Index
 	})
+}
+
+// PackLogs packs logs into []BlockLogs by their block number.
+func PackLogs(logs []ethtypes.Log) []BlockLogs {
+	sortLogsCanonical(logs)
 
 	var all []BlockLogs
 	for _, log := range logs {

--- a/eth/executionclient/logs.go
+++ b/eth/executionclient/logs.go
@@ -14,12 +14,20 @@ type BlockLogs struct {
 
 // PackLogs packs logs into []BlockLogs by their block number.
 func PackLogs(logs []ethtypes.Log) []BlockLogs {
-	// Sort the logs by block number.
+	// Sort into canonical on-chain order. The Index (logIndex) tiebreaker is what keeps logs
+	// emitted by the same transaction in order: sort.Slice is not stable, and a single tx can
+	// emit multiple order-dependent registry events (e.g. bulkRegisterValidator emits one
+	// ValidatorAdded per validator, each bumping the owner's nonce), which the handler must
+	// process in order. Without it, same-tx logs could be reordered and valid registrations
+	// silently rejected on a nonce mismatch.
 	sort.Slice(logs, func(i, j int) bool {
-		if logs[i].BlockNumber == logs[j].BlockNumber {
+		if logs[i].BlockNumber != logs[j].BlockNumber {
+			return logs[i].BlockNumber < logs[j].BlockNumber
+		}
+		if logs[i].TxIndex != logs[j].TxIndex {
 			return logs[i].TxIndex < logs[j].TxIndex
 		}
-		return logs[i].BlockNumber < logs[j].BlockNumber
+		return logs[i].Index < logs[j].Index
 	})
 
 	var all []BlockLogs

--- a/eth/executionclient/logs_test.go
+++ b/eth/executionclient/logs_test.go
@@ -83,3 +83,26 @@ func TestPackLogs(t *testing.T) {
 	assert.Equal(t, uint(0), result[0].Logs[0].TxIndex) // should be sorted
 	assert.Equal(t, uint(1), result[0].Logs[1].TxIndex)
 }
+
+// TestPackLogsOrdersByLogIndexWithinTransaction covers logs emitted by the same transaction
+// (same TxIndex, distinct logIndex) — e.g. bulkRegisterValidator, whose per-owner nonces require
+// in-order processing. They must be packed in logIndex order, not left in the arbitrary order a
+// non-stable sort by (block, tx) would leave them. Input is deliberately shuffled.
+func TestPackLogsOrdersByLogIndexWithinTransaction(t *testing.T) {
+	logs := []types.Log{
+		{BlockNumber: 5, TxIndex: 2, Index: 11},
+		{BlockNumber: 5, TxIndex: 2, Index: 9},
+		{BlockNumber: 5, TxIndex: 0, Index: 3}, // earlier tx in the same block
+		{BlockNumber: 5, TxIndex: 2, Index: 10},
+	}
+
+	result := PackLogs(logs)
+	assert.Len(t, result, 1)
+	assert.Equal(t, uint64(5), result[0].BlockNumber)
+
+	gotIndexes := make([]uint, 0, len(result[0].Logs))
+	for _, l := range result[0].Logs {
+		gotIndexes = append(gotIndexes, l.Index)
+	}
+	assert.Equal(t, []uint{3, 9, 10, 11}, gotIndexes)
+}


### PR DESCRIPTION
## Summary

`PackLogs` sorted logs by `(block, txIndex)` using a non-stable `sort.Slice`, so logs emitted by the **same transaction** (same `txIndex`) were left in unspecified relative order.

A single transaction can emit multiple **order-dependent** registry events: `bulkRegisterValidator` emits one `ValidatorAdded` per validator, each bumping the owner's per-owner nonce. If those get packed out of `logIndex` order, the event handler's `GetNextNonce`/`BumpNonce` sequence no longer matches the events' signed nonces → `verifySignature` fails → `MalformedEventError` (and the nonce is still bumped), **silently rejecting otherwise-valid registrations**.

It's usually masked in practice — Go's `sort.Slice` is stable for small slices — but it's unsound and can surface with a larger batch or a runtime change.

## Fix

Add a `logIndex` (`Index`) tiebreaker so `PackLogs` sorts by `(block, txIndex, logIndex)` — `logIndex` is unique and monotonic within a block, so packing now preserves canonical on-chain order both across and within a transaction. Existing `(block, txIndex)` behavior is unchanged for logs in distinct transactions.

Regression test added with shuffled same-transaction logs.

Noticed during review of #2991.
