### PR TITLE
eth/eventhandler: classify remote-signer share decryption errors as malformed

### DIFF
--- a/eth/eventhandler/handlers.go
+++ b/eth/eventhandler/handlers.go
@@ -12,7 +12,7 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"go.uber.org/zap"
 
-	"github.com/ssvlabs/ssv/ssvsigner/ekm"
+	"github.com/ssvlabs/ssv/ssvsigner"
 
 	"github.com/ssvlabs/ssv/eth/contract"
 	"github.com/ssvlabs/ssv/observability/log/fields"
@@ -242,8 +242,8 @@ func (eh *EventHandler) handleShareCreation(
 
 	if share.BelongsToOperator(eh.operatorDataStore.GetOperatorID()) {
 		if err := eh.keyManager.AddShare(ctx, txn, encryptedKey, phase0.BLSPubKey(share.SharePubKey)); err != nil {
-			var shareDecryptionEKMError ekm.ShareDecryptionError
-			if errors.As(err, &shareDecryptionEKMError) {
+			var shareDecryptionError ssvsigner.ShareDecryptionError
+			if errors.As(err, &shareDecryptionError) {
 				return nil, &MalformedEventError{Err: err}
 			}
 			return nil, fmt.Errorf("could not add share encrypted key: %w", err)

--- a/eth/eventhandler/handlers_test.go
+++ b/eth/eventhandler/handlers_test.go
@@ -3,11 +3,12 @@ package eventhandler
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+
+	"github.com/ssvlabs/ssv/ssvsigner"
 
 	"github.com/ssvlabs/ssv/eth/contract"
 	"github.com/ssvlabs/ssv/networkconfig"
@@ -23,10 +24,8 @@ func TestHandleValidatorAddedUndecryptableShareIsMalformed(t *testing.T) {
 	ctx := context.Background()
 	logger := zaptest.NewLogger(t)
 
-	beaconConfig := *networkconfig.TestNetwork.Beacon
-	beaconConfig.GenesisTime = time.Now().Add(-32 * beaconConfig.SlotDuration)
 	netCfg := &networkconfig.Network{
-		Beacon: &beaconConfig,
+		Beacon: networkconfig.TestNetwork.Beacon,
 		SSV:    networkconfig.TestNetwork.SSV,
 	}
 
@@ -80,4 +79,8 @@ func TestHandleValidatorAddedUndecryptableShareIsMalformed(t *testing.T) {
 	var malformed *MalformedEventError
 	require.ErrorAs(t, err, &malformed,
 		"an undecryptable share must be classified as a malformed (skippable) event, not a fatal error")
+	// Pin the origin to the share-decryption branch, not one of the other MalformedEventError
+	// returns (signature, operator lookup, share length, ...).
+	var decErr ssvsigner.ShareDecryptionError
+	require.ErrorAs(t, err, &decErr, "the malformed event must originate from a ShareDecryptionError")
 }

--- a/eth/eventhandler/handlers_test.go
+++ b/eth/eventhandler/handlers_test.go
@@ -1,75 +1,85 @@
 package eventhandler
 
 import (
-	"errors"
-	"fmt"
+	"context"
 	"testing"
+	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 
-	"github.com/ssvlabs/ssv/ssvsigner"
+	"github.com/ssvlabs/ssv/eth/contract"
+	"github.com/ssvlabs/ssv/networkconfig"
+	registrystorage "github.com/ssvlabs/ssv/registry/storage"
 )
 
-func TestShareDecryptionError(t *testing.T) {
-	tt := []struct {
-		name           string
-		f              func() error
-		malformedEvent bool
-	}{
-		{
-			// LocalKeyManager.AddShare returns the error directly.
-			name: "local decryption error is malformed",
-			f: func() error {
-				err1 := fmt.Errorf("some error")
-				return ssvsigner.ShareDecryptionError{Err: fmt.Errorf("decrypt: %w", err1)}
-			},
-			malformedEvent: true,
-		},
-		{
-			// RemoteKeyManager.AddShare wraps the client's ShareDecryptionError with
-			// fmt.Errorf("add validator: %w", ...); errors.As must still classify the
-			// wrapped error as a decryption error.
-			name: "remote decryption error is malformed",
-			f: func() error {
-				clientErr := ssvsigner.ShareDecryptionError{Err: errors.New("decrypt: crypto/rsa: decryption error")}
-				return fmt.Errorf("add validator: %w", clientErr)
-			},
-			malformedEvent: true,
-		},
-		{
-			// A transport/other failure (not a share problem) must stay fatal so the node
-			// doesn't silently skip an event it failed to process.
-			name: "non-decryption error is fatal",
-			f: func() error {
-				e2 := fmt.Errorf("some error")
-				e1 := fmt.Errorf("request failed: %w", e2)
-				return fmt.Errorf("add validator: %w", e1)
-			},
-			malformedEvent: false,
-		},
+// TestHandleValidatorAddedUndecryptableShareIsMalformed drives the real
+// handleValidatorAdded -> handleShareCreation -> LocalKeyManager.AddShare path with a
+// ValidatorAdded event whose encrypted share cannot be decrypted: a valid owner/nonce
+// signature and correct lengths, but garbage ciphertext (the shape an attacker can submit).
+// The share belongs to this node's operator, so AddShare runs and fails with a
+// ShareDecryptionError, which the handler must classify as a MalformedEventError (logged and
+// skipped) rather than a fatal error that would crash-loop the node.
+func TestHandleValidatorAddedUndecryptableShareIsMalformed(t *testing.T) {
+	ctx := context.Background()
+	logger := zaptest.NewLogger(t)
+
+	beaconConfig := *networkconfig.TestNetwork.Beacon
+	beaconConfig.GenesisTime = time.Now().Add(-32 * beaconConfig.SlotDuration)
+	netCfg := &networkconfig.Network{
+		Beacon: &beaconConfig,
+		SSV:    networkconfig.TestNetwork.SSV,
 	}
 
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			// The implementation might be more optimal,
-			// but it's left purposely like this because it's close to the actual code.
+	ops, err := createOperators(4, 0)
+	require.NoError(t, err)
 
-			var resultErr error
-			var malformedEvent bool
+	// This node is operator ops[0]; setupEventHandler wires it as the self operator.
+	eh, _, err := setupEventHandler(t, ctx, logger, netCfg, ops[0], true)
+	require.NoError(t, err)
 
-			if err := tc.f(); err != nil {
-				var shareDecryptionError ssvsigner.ShareDecryptionError
-				if errors.As(err, &shareDecryptionError) {
-					resultErr = &MalformedEventError{Err: err}
-					malformedEvent = true
-				} else {
-					resultErr = fmt.Errorf("could not add share encrypted key: %w", err)
-					malformedEvent = false
-				}
-			}
-
-			require.Error(t, resultErr)
-			require.Equal(t, tc.malformedEvent, malformedEvent)
+	// validateOperators requires every committee operator to be registered.
+	operatorIDs := make([]uint64, len(ops))
+	for i, op := range ops {
+		pubKey, err := op.privateKey.Public().Base64()
+		require.NoError(t, err)
+		_, err = eh.nodeStorage.SaveOperatorData(nil, &registrystorage.OperatorData{
+			ID:           op.id,
+			PublicKey:    pubKey,
+			OwnerAddress: testAddr,
 		})
+		require.NoError(t, err)
+		operatorIDs[i] = op.id
 	}
+
+	validatorData, err := createNewValidator(ops)
+	require.NoError(t, err)
+
+	// A valid shares blob: correct signature over owner:nonce and correct lengths...
+	sharesData, err := generateSharesData(validatorData, ops, testAddr, 0)
+	require.NoError(t, err)
+	// ...then corrupt the encrypted-shares region (layout: sig | pubKeys | encShares) so the
+	// operator's share can't be decrypted. The signature covers only owner:nonce, so it stays valid.
+	encStart := phase0.SignatureLength + phase0.PublicKeyLength*len(ops)
+	for i := encStart; i < len(sharesData); i++ {
+		sharesData[i] = 0xFF
+	}
+
+	event := &contract.ContractValidatorAdded{
+		Owner:       testAddr,
+		OperatorIds: operatorIDs,
+		PublicKey:   validatorData.masterPubKey.Serialize(),
+		Shares:      sharesData,
+	}
+
+	txn := eh.nodeStorage.Begin()
+	defer txn.Discard()
+
+	_, err = eh.handleValidatorAdded(ctx, txn, event)
+	require.Error(t, err)
+
+	var malformed *MalformedEventError
+	require.ErrorAs(t, err, &malformed,
+		"an undecryptable share must be classified as a malformed (skippable) event, not a fatal error")
 }

--- a/eth/eventhandler/handlers_test.go
+++ b/eth/eventhandler/handlers_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ssvlabs/ssv/ssvsigner/ekm"
+	"github.com/ssvlabs/ssv/ssvsigner"
 )
 
 func TestShareDecryptionError(t *testing.T) {
@@ -17,16 +17,29 @@ func TestShareDecryptionError(t *testing.T) {
 		malformedEvent bool
 	}{
 		{
-			name: "malformed event",
+			// LocalKeyManager.AddShare returns the error directly.
+			name: "local decryption error is malformed",
 			f: func() error {
 				err1 := fmt.Errorf("some error")
-				return ekm.ShareDecryptionError{Err: fmt.Errorf("decrypt: %w", err1)}
+				return ssvsigner.ShareDecryptionError{Err: fmt.Errorf("decrypt: %w", err1)}
 			},
 			malformedEvent: true,
 		},
-
 		{
-			name: "no malformed event event",
+			// RemoteKeyManager.AddShare wraps the client's ShareDecryptionError with
+			// fmt.Errorf("add validator: %w", ...); errors.As must still classify the
+			// wrapped error as a decryption error.
+			name: "remote decryption error is malformed",
+			f: func() error {
+				clientErr := ssvsigner.ShareDecryptionError{Err: errors.New("decrypt: crypto/rsa: decryption error")}
+				return fmt.Errorf("add validator: %w", clientErr)
+			},
+			malformedEvent: true,
+		},
+		{
+			// A transport/other failure (not a share problem) must stay fatal so the node
+			// doesn't silently skip an event it failed to process.
+			name: "non-decryption error is fatal",
 			f: func() error {
 				e2 := fmt.Errorf("some error")
 				e1 := fmt.Errorf("request failed: %w", e2)
@@ -45,8 +58,8 @@ func TestShareDecryptionError(t *testing.T) {
 			var malformedEvent bool
 
 			if err := tc.f(); err != nil {
-				var shareDecryptionEKMError ekm.ShareDecryptionError
-				if errors.As(err, &shareDecryptionEKMError) {
+				var shareDecryptionError ssvsigner.ShareDecryptionError
+				if errors.As(err, &shareDecryptionError) {
 					resultErr = &MalformedEventError{Err: err}
 					malformedEvent = true
 				} else {

--- a/eth/eventhandler/handlers_test.go
+++ b/eth/eventhandler/handlers_test.go
@@ -14,13 +14,11 @@ import (
 	registrystorage "github.com/ssvlabs/ssv/registry/storage"
 )
 
-// TestHandleValidatorAddedUndecryptableShareIsMalformed drives the real
-// handleValidatorAdded -> handleShareCreation -> LocalKeyManager.AddShare path with a
-// ValidatorAdded event whose encrypted share cannot be decrypted: a valid owner/nonce
-// signature and correct lengths, but garbage ciphertext (the shape an attacker can submit).
-// The share belongs to this node's operator, so AddShare runs and fails with a
-// ShareDecryptionError, which the handler must classify as a MalformedEventError (logged and
-// skipped) rather than a fatal error that would crash-loop the node.
+// TestHandleValidatorAddedUndecryptableShareIsMalformed drives the real handleValidatorAdded ->
+// handleShareCreation -> LocalKeyManager.AddShare path with an event that has a valid owner/nonce
+// signature and correct lengths but an undecryptable share (what an attacker can submit). AddShare
+// must fail with a ShareDecryptionError that the handler classifies as a MalformedEventError
+// (skipped), not a fatal error that crash-loops the node.
 func TestHandleValidatorAddedUndecryptableShareIsMalformed(t *testing.T) {
 	ctx := context.Background()
 	logger := zaptest.NewLogger(t)

--- a/ssvsigner/CLAUDE.md
+++ b/ssvsigner/CLAUDE.md
@@ -156,9 +156,9 @@ BATCH_SIZE=20 \
 - Configuration is locked to prevent switching between local/remote signing
 
 ### Error Handling
-- Malformed shares (undecryptable/invalid) return HTTP 422; the node treats 422 as a skippable malformed registry event, so 422 is reserved exclusively for that case
+- Malformed shares (undecryptable/invalid) return HTTP 422, which the node treats as a skippable malformed event; 422 is reserved exclusively for that
 - Connection failures trigger retries with exponential backoff
-- Web3Signer failures all map to HTTP 500 (retryable); their upstream status is intentionally not forwarded, so an upstream/proxy 422 can't be misclassified as a malformed share
+- Web3Signer failures all map to HTTP 500 (retryable); the upstream status is intentionally not forwarded, so a proxy/upstream 422 can't be misclassified as a malformed share
 
 ### Performance Optimizations
 - Per-validator locking prevents concurrent signing conflicts

--- a/ssvsigner/CLAUDE.md
+++ b/ssvsigner/CLAUDE.md
@@ -156,9 +156,9 @@ BATCH_SIZE=20 \
 - Configuration is locked to prevent switching between local/remote signing
 
 ### Error Handling
-- Decryption errors return specific status for malformed shares
+- Malformed shares (undecryptable/invalid) return HTTP 422; the node treats 422 as a skippable malformed registry event, so 422 is reserved exclusively for that case
 - Connection failures trigger retries with exponential backoff
-- Web3Signer errors are propagated with original status codes
+- Web3Signer failures all map to HTTP 500 (retryable); their upstream status is intentionally not forwarded, so an upstream/proxy 422 can't be misclassified as a malformed share
 
 ### Performance Optimizations
 - Per-validator locking prevents concurrent signing conflicts

--- a/ssvsigner/CLAUDE.md
+++ b/ssvsigner/CLAUDE.md
@@ -157,7 +157,7 @@ BATCH_SIZE=20 \
 
 ### Error Handling
 - Malformed shares (undecryptable/invalid) return HTTP 422, which the node treats as a skippable malformed event; 422 is reserved exclusively for that
-- Connection failures trigger retries with exponential backoff
+- Connection/transport failures surface to the node as errors; the client itself does not retry
 - Web3Signer failures all map to HTTP 500 (retryable); the upstream status is intentionally not forwarded, so a proxy/upstream 422 can't be misclassified as a malformed share
 
 ### Performance Optimizations

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -125,9 +125,9 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (status
 		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
 		Fetch(ctx)
 
-	// A 422 means the signer rejected the share as undecryptable/invalid (a malformed share); wrap
-	// it as ShareDecryptionError so callers skip the event instead of failing. Keep the transport
-	// error and include the response body quoted (%q neutralizes control chars and reads fine empty).
+	// A 422 means the signer rejected the share as undecryptable/invalid (a malformed share); return
+	// it as a ShareDecryptionError so callers skip the event. Keep the transport error (%w) and the
+	// response body, quoted (%q handles an empty body and neutralizes control chars).
 	if requests.HasStatusErr(err, http.StatusUnprocessableEntity) {
 		return nil, ShareDecryptionError{Err: fmt.Errorf("%w (body: %q)", err, errStr)}
 	}

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -125,12 +125,10 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (status
 		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
 		Fetch(ctx)
 
-	// ssv-signer replies 422 only when a share cannot be decrypted or validated (a malformed
-	// share); other failures use different statuses and fall through to the retryable error
-	// below. Surface it as ShareDecryptionError so callers treat it as a malformed event.
+	// A 422 means the signer rejected the share as undecryptable/invalid (a malformed share); wrap
+	// it as ShareDecryptionError so callers skip the event instead of failing. Keep the transport
+	// err too, so a bodyless 422 (empty errStr) still carries context.
 	if requests.HasStatusErr(err, http.StatusUnprocessableEntity) {
-		// Keep the transport error too, so a bodyless 422 (empty errStr) still carries context
-		// instead of surfacing a bare "share decryption error: " for a permanently skipped event.
 		return nil, ShareDecryptionError{Err: fmt.Errorf("%s: %w", errStr, err)}
 	}
 

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -127,9 +127,9 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (status
 
 	// A 422 means the signer rejected the share as undecryptable/invalid (a malformed share); wrap
 	// it as ShareDecryptionError so callers skip the event instead of failing. Keep the transport
-	// err too, so a bodyless 422 (empty errStr) still carries context.
+	// error and include the response body quoted (%q neutralizes control chars and reads fine empty).
 	if requests.HasStatusErr(err, http.StatusUnprocessableEntity) {
-		return nil, ShareDecryptionError{Err: fmt.Errorf("%s: %w", errStr, err)}
+		return nil, ShareDecryptionError{Err: fmt.Errorf("%w (body: %q)", err, errStr)}
 	}
 
 	if err != nil {

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -130,7 +129,9 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (status
 	// share); other failures use different statuses and fall through to the retryable error
 	// below. Surface it as ShareDecryptionError so callers treat it as a malformed event.
 	if requests.HasStatusErr(err, http.StatusUnprocessableEntity) {
-		return nil, ShareDecryptionError{Err: errors.New(errStr)}
+		// Keep the transport error too, so a bodyless 422 (empty errStr) still carries context
+		// instead of surfacing a bare "share decryption error: " for a permanently skipped event.
+		return nil, ShareDecryptionError{Err: fmt.Errorf("%s: %w", errStr, err)}
 	}
 
 	if err != nil {

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -127,7 +127,7 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (status
 		Fetch(ctx)
 
 	if requests.HasStatusErr(err, http.StatusUnprocessableEntity) {
-		return nil, ShareDecryptionError(errors.New(errStr))
+		return nil, ShareDecryptionError{Err: errors.New(errStr)}
 	}
 
 	if err != nil {

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -126,6 +126,9 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (status
 		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
 		Fetch(ctx)
 
+	// ssv-signer replies 422 only when a share cannot be decrypted or validated (a malformed
+	// share); other failures use different statuses and fall through to the retryable error
+	// below. Surface it as ShareDecryptionError so callers treat it as a malformed event.
 	if requests.HasStatusErr(err, http.StatusUnprocessableEntity) {
 		return nil, ShareDecryptionError{Err: errors.New(errStr)}
 	}

--- a/ssvsigner/client_test.go
+++ b/ssvsigner/client_test.go
@@ -147,6 +147,18 @@ func (s *SSVSignerClientSuite) TestAddValidators() {
 			expectError:        true,
 		},
 		{
+			name: "BadRequest",
+			shares: []ShareKeys{
+				{
+					EncryptedPrivKey: []byte("encrypted"),
+					PubKey:           phase0.BLSPubKey{1, 2, 3},
+				},
+			},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   web3signer.ImportKeystoreResponse{},
+			expectError:        true,
+		},
+		{
 			name:               "NoShares",
 			shares:             []ShareKeys{},
 			expectedStatusCode: http.StatusOK,
@@ -243,9 +255,9 @@ func (s *SSVSignerClientSuite) TestAddValidators() {
 				assert.ErrorAs(t, err, &decryptErr, "Expected a ShareDecryptionError")
 			} else if tc.expectError {
 				// Only a 422 signals a malformed share. Any other failure (transport,
-				// 5xx, client-side validation) must not be classified as a decryption
+				// 4xx, 5xx, client-side validation) must not be classified as a decryption
 				// error, otherwise the node would silently skip an event it failed on.
-				assert.False(t, errors.As(err, &decryptErr),
+				assert.NotErrorAs(t, err, &decryptErr,
 					"non-422 error must not be classified as ShareDecryptionError")
 			}
 			assert.Equal(t, tc.expectStatuses, statuses)
@@ -1023,18 +1035,18 @@ func Test_ShareDecryptionError(t *testing.T) {
 	var customErr error = ShareDecryptionError{Err: inner}
 
 	var decErr ShareDecryptionError
-	require.True(t, errors.As(customErr, &decErr), "ShareDecryptionError should be matchable via errors.As")
+	require.ErrorAs(t, customErr, &decErr, "ShareDecryptionError should be matchable via errors.As")
 	require.Equal(t, inner, decErr.Err)
 	require.ErrorIs(t, customErr, inner, "Unwrap should expose the wrapped error")
 
 	// A plain error must not be classified as a ShareDecryptionError: errors.As must
 	// match the concrete type, not every error.
-	require.False(t, errors.As(errors.New("plain error"), &decErr),
+	require.NotErrorAs(t, errors.New("plain error"), &decErr,
 		"a plain error must not match ShareDecryptionError")
 
 	// It must still match after wrapping, mirroring RemoteKeyManager.AddShare.
 	wrapped := fmt.Errorf("add validator: %w", ShareDecryptionError{Err: inner})
-	require.True(t, errors.As(wrapped, &decErr), "a wrapped ShareDecryptionError should still match")
+	require.ErrorAs(t, wrapped, &decErr, "a wrapped ShareDecryptionError should still match")
 }
 
 func TestNewClient_TrimsTrailingSlashFromURL(t *testing.T) {

--- a/ssvsigner/client_test.go
+++ b/ssvsigner/client_test.go
@@ -254,9 +254,8 @@ func (s *SSVSignerClientSuite) TestAddValidators() {
 			if tc.isDecryptionError {
 				assert.ErrorAs(t, err, &decryptErr, "Expected a ShareDecryptionError")
 			} else if tc.expectError {
-				// Only a 422 signals a malformed share. Any other failure (transport,
-				// 4xx, 5xx, client-side validation) must not be classified as a decryption
-				// error, otherwise the node would silently skip an event it failed on.
+				// 422 is the only malformed-share signal; any other failure (transport, 4xx, 5xx,
+				// client-side validation) must not be classified as a decryption error.
 				assert.NotErrorAs(t, err, &decryptErr,
 					"non-422 error must not be classified as ShareDecryptionError")
 			}

--- a/ssvsigner/client_test.go
+++ b/ssvsigner/client_test.go
@@ -238,9 +238,15 @@ func (s *SSVSignerClientSuite) TestAddValidators() {
 
 			statuses, err := s.client.AddValidators(t.Context(), tc.shares...)
 			s.assertErrorResult(err, tc.expectError, tc.expectNoRequest, t)
+			var decryptErr ShareDecryptionError
 			if tc.isDecryptionError {
-				var decryptErr ShareDecryptionError
 				assert.ErrorAs(t, err, &decryptErr, "Expected a ShareDecryptionError")
+			} else if tc.expectError {
+				// Only a 422 signals a malformed share. Any other failure (transport,
+				// 5xx, client-side validation) must not be classified as a decryption
+				// error, otherwise the node would silently skip an event it failed on.
+				assert.False(t, errors.As(err, &decryptErr),
+					"non-422 error must not be classified as ShareDecryptionError")
 			}
 			assert.Equal(t, tc.expectStatuses, statuses)
 		})
@@ -1013,12 +1019,22 @@ func TestNew(t *testing.T) {
 func Test_ShareDecryptionError(t *testing.T) {
 	t.Parallel()
 
-	var customErr error = ShareDecryptionError(errors.New("test error"))
+	inner := errors.New("test error")
+	var customErr error = ShareDecryptionError{Err: inner}
 
-	var shareDecryptionError ShareDecryptionError
-	if !errors.As(customErr, &shareDecryptionError) {
-		t.Errorf("shareDecryptionError was expected to be a ShareDecryptionError")
-	}
+	var decErr ShareDecryptionError
+	require.True(t, errors.As(customErr, &decErr), "ShareDecryptionError should be matchable via errors.As")
+	require.Equal(t, inner, decErr.Err)
+	require.ErrorIs(t, customErr, inner, "Unwrap should expose the wrapped error")
+
+	// A plain error must not be classified as a ShareDecryptionError: errors.As must
+	// match the concrete type, not every error.
+	require.False(t, errors.As(errors.New("plain error"), &decErr),
+		"a plain error must not match ShareDecryptionError")
+
+	// It must still match after wrapping, mirroring RemoteKeyManager.AddShare.
+	wrapped := fmt.Errorf("add validator: %w", ShareDecryptionError{Err: inner})
+	require.True(t, errors.As(wrapped, &decErr), "a wrapped ShareDecryptionError should still match")
 }
 
 func TestNewClient_TrimsTrailingSlashFromURL(t *testing.T) {

--- a/ssvsigner/ekm/key_manager.go
+++ b/ssvsigner/ekm/key_manager.go
@@ -23,9 +23,8 @@ type KeyManager interface {
 	// due to absent or outdated protection data.
 	//
 	// If the share cannot be decrypted or validated, implementations MUST return an error that
-	// unwraps to ssvsigner.ShareDecryptionError (directly or wrapped). Callers rely on that type to
-	// classify the failure as a malformed, skippable registry event; without it the failure is
-	// treated as fatal and crash-loops registry sync on the offending block.
+	// unwraps to ssvsigner.ShareDecryptionError. Callers use it to classify the failure as a
+	// skippable malformed event; otherwise the failure is fatal and crash-loops registry sync.
 	AddShare(ctx context.Context, txn ReadWriteTxn, encryptedPrivKey []byte, pubKey phase0.BLSPubKey) error
 
 	// RemoveShare unregisters a validator share from the key manager and deletes its associated

--- a/ssvsigner/ekm/key_manager.go
+++ b/ssvsigner/ekm/key_manager.go
@@ -8,21 +8,6 @@ import (
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 )
 
-type ShareDecryptionError struct {
-	Err error
-}
-
-func (e ShareDecryptionError) Error() string {
-	if e.Err == nil {
-		return "share decryption error: nil"
-	}
-	return "share decryption error: " + e.Err.Error()
-}
-
-func (e ShareDecryptionError) Unwrap() error {
-	return e.Err
-}
-
 // KeyManager is the main interface for managing validator shares and performing slashing protection.
 // It embeds BeaconSigner (for signing beacon messages and checking whether attestation or beacon block are slashable)
 // and slashingProtector (for slashing checks and updates).

--- a/ssvsigner/ekm/key_manager.go
+++ b/ssvsigner/ekm/key_manager.go
@@ -21,6 +21,11 @@ type KeyManager interface {
 	// updating them only if they are missing or fall below a minimal safe threshold.
 	// This prevents the validator from signing messages that could be considered slashable
 	// due to absent or outdated protection data.
+	//
+	// If the share cannot be decrypted or validated, implementations MUST return an error that
+	// unwraps to ssvsigner.ShareDecryptionError (directly or wrapped). Callers rely on that type to
+	// classify the failure as a malformed, skippable registry event; without it the failure is
+	// treated as fatal and crash-loops registry sync on the offending block.
 	AddShare(ctx context.Context, txn ReadWriteTxn, encryptedPrivKey []byte, pubKey phase0.BLSPubKey) error
 
 	// RemoveShare unregisters a validator share from the key manager and deletes its associated

--- a/ssvsigner/ekm/key_manager.go
+++ b/ssvsigner/ekm/key_manager.go
@@ -23,8 +23,8 @@ type KeyManager interface {
 	// due to absent or outdated protection data.
 	//
 	// If the share cannot be decrypted or validated, implementations MUST return an error that
-	// unwraps to ssvsigner.ShareDecryptionError. Callers use it to classify the failure as a
-	// skippable malformed event; otherwise the failure is fatal and crash-loops registry sync.
+	// unwraps to a by-value ssvsigner.ShareDecryptionError. Callers use it to classify the failure
+	// as a skippable malformed event; otherwise the failure is fatal and crash-loops registry sync.
 	AddShare(ctx context.Context, txn ReadWriteTxn, encryptedPrivKey []byte, pubKey phase0.BLSPubKey) error
 
 	// RemoveShare unregisters a validator share from the key manager and deletes its associated

--- a/ssvsigner/ekm/local_key_manager.go
+++ b/ssvsigner/ekm/local_key_manager.go
@@ -30,6 +30,7 @@ import (
 
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 
+	"github.com/ssvlabs/ssv/ssvsigner"
 	"github.com/ssvlabs/ssv/ssvsigner/keys"
 )
 
@@ -288,16 +289,16 @@ func (km *LocalKeyManager) AddShare(
 
 	sharePrivKeyHex, err := km.operatorDecrypter.Decrypt(encryptedPrivKey)
 	if err != nil {
-		return ShareDecryptionError{Err: fmt.Errorf("decrypt: %w", err)}
+		return ssvsigner.ShareDecryptionError{Err: fmt.Errorf("decrypt: %w", err)}
 	}
 
 	sharePrivKey := &bls.SecretKey{}
 	if err := sharePrivKey.SetHexString(string(sharePrivKeyHex)); err != nil {
-		return ShareDecryptionError{Err: fmt.Errorf("decode hex: %w", err)}
+		return ssvsigner.ShareDecryptionError{Err: fmt.Errorf("decode hex: %w", err)}
 	}
 
 	if !bytes.Equal(sharePrivKey.GetPublicKey().Serialize(), pubKey[:]) {
-		return ShareDecryptionError{Err: errors.New("share private key does not match public key")}
+		return ssvsigner.ShareDecryptionError{Err: errors.New("share private key does not match public key")}
 	}
 
 	if err := km.slashingProtector.BumpSlashingProtectionTxn(txn, phase0.BLSPubKey(sharePrivKey.GetPublicKey().Serialize())); err != nil {

--- a/ssvsigner/ekm/remote_key_manager.go
+++ b/ssvsigner/ekm/remote_key_manager.go
@@ -129,7 +129,6 @@ func (km *RemoteKeyManager) AddShare(
 		}
 	}
 
-	// Bump only after the share is registered remotely.
 	if err := km.BumpSlashingProtection(txn, pubKey); err != nil {
 		return fmt.Errorf("could not bump slashing protection: %w", err)
 	}

--- a/ssvsigner/ekm/remote_key_manager.go
+++ b/ssvsigner/ekm/remote_key_manager.go
@@ -96,21 +96,19 @@ func (km *RemoteKeyManager) AddShare(
 	encryptedPrivKey []byte,
 	pubKey phase0.BLSPubKey,
 ) error {
-	if err := km.BumpSlashingProtection(txn, pubKey); err != nil {
-		return fmt.Errorf("could not bump slashing protection: %w", err)
-	}
-
 	shareKeys := ssvsigner.ShareKeys{
 		EncryptedPrivKey: hexutil.Bytes(encryptedPrivKey),
 		PubKey:           pubKey,
 	}
 
-	// AddValidators is idempotent: it doesn't fail if the same share already exists. That matters
-	// if the surrounding txn is rolled back after the share was saved remotely — the node crashes
-	// on the (non-malformed) error, re-runs the block, and re-adds the same share harmlessly.
-	// A malformed share is different: AddValidators returns an error below, the event handler
-	// classifies it as a malformed event and skips it without crashing, and nothing was saved
-	// remotely — so there is no syncer/signer inconsistency to reconcile.
+	// Register the share with the remote signer first, then bump local slashing protection below.
+	// A malformed share fails here and returns before the bump, so it leaves no orphan slashing
+	// rows — matching LocalKeyManager's validate-first order; the event handler classifies the
+	// ShareDecryptionError as a malformed event and skips it.
+	//
+	// AddValidators is idempotent: it doesn't fail if the same share already exists. So if the
+	// surrounding txn is rolled back after a successful add, the node crashes on the error, re-runs
+	// the block, and re-adds the same share harmlessly.
 	statuses, err := km.signerClient.AddValidators(ctx, shareKeys)
 	if err != nil {
 		return fmt.Errorf("add validator: %w", err)
@@ -133,6 +131,11 @@ func (km *RemoteKeyManager) AddShare(
 		default:
 			return fmt.Errorf("unexpected status %s", status)
 		}
+	}
+
+	// Only now, after the share is confirmed registered remotely, bump local slashing protection.
+	if err := km.BumpSlashingProtection(txn, pubKey); err != nil {
+		return fmt.Errorf("could not bump slashing protection: %w", err)
 	}
 
 	return nil

--- a/ssvsigner/ekm/remote_key_manager.go
+++ b/ssvsigner/ekm/remote_key_manager.go
@@ -105,11 +105,12 @@ func (km *RemoteKeyManager) AddShare(
 		PubKey:           pubKey,
 	}
 
-	// If txn gets rolled back after share is saved,
-	// there will be some inconsistency between syncer state and remote signer.
-	// However, syncer crashes node on an error and restarts the sync process from the failing block,
-	// so it will attempt to save the same share again, which won't be an issue
-	// because AddValidators doesn't fail if the same share exists.
+	// AddValidators is idempotent: it doesn't fail if the same share already exists. That matters
+	// if the surrounding txn is rolled back after the share was saved remotely — the node crashes
+	// on the (non-malformed) error, re-runs the block, and re-adds the same share harmlessly.
+	// A malformed share is different: AddValidators returns an error below, the event handler
+	// classifies it as a malformed event and skips it without crashing, and nothing was saved
+	// remotely — so there is no syncer/signer inconsistency to reconcile.
 	statuses, err := km.signerClient.AddValidators(ctx, shareKeys)
 	if err != nil {
 		return fmt.Errorf("add validator: %w", err)

--- a/ssvsigner/ekm/remote_key_manager.go
+++ b/ssvsigner/ekm/remote_key_manager.go
@@ -113,6 +113,7 @@ func (km *RemoteKeyManager) AddShare(
 	for _, status := range statuses {
 		switch status {
 		case web3signer.StatusImported:
+			// Imported successfully; nothing to do.
 
 		case web3signer.StatusDuplicated:
 			// A failed request does not guarantee that the keys were not added.

--- a/ssvsigner/ekm/remote_key_manager.go
+++ b/ssvsigner/ekm/remote_key_manager.go
@@ -101,14 +101,10 @@ func (km *RemoteKeyManager) AddShare(
 		PubKey:           pubKey,
 	}
 
-	// Register the share with the remote signer first, then bump local slashing protection below.
-	// A malformed share fails here and returns before the bump, so it leaves no orphan slashing
-	// rows — matching LocalKeyManager's validate-first order; the event handler classifies the
-	// ShareDecryptionError as a malformed event and skips it.
-	//
-	// AddValidators is idempotent: it doesn't fail if the same share already exists. So if the
-	// surrounding txn is rolled back after a successful add, the node crashes on the error, re-runs
-	// the block, and re-adds the same share harmlessly.
+	// Register the share remotely first, then bump slashing protection (below). A malformed share
+	// fails here and returns before the bump, leaving no orphan slashing rows — matching
+	// LocalKeyManager's validate-first order. AddValidators is idempotent, so if the txn is later
+	// rolled back the node crashes, re-runs the block, and re-adds the same share harmlessly.
 	statuses, err := km.signerClient.AddValidators(ctx, shareKeys)
 	if err != nil {
 		return fmt.Errorf("add validator: %w", err)
@@ -133,7 +129,7 @@ func (km *RemoteKeyManager) AddShare(
 		}
 	}
 
-	// Only now, after the share is confirmed registered remotely, bump local slashing protection.
+	// Bump only after the share is registered remotely.
 	if err := km.BumpSlashingProtection(txn, pubKey); err != nil {
 		return fmt.Errorf("could not bump slashing protection: %w", err)
 	}

--- a/ssvsigner/ekm/remote_key_manager_test.go
+++ b/ssvsigner/ekm/remote_key_manager_test.go
@@ -1177,6 +1177,7 @@ func (s *RemoteKeyManagerTestSuite) TestAddShareErrorCases() {
 
 		s.ErrorContains(err, "add validator")
 		clientMock.AssertExpectations(s.T())
+		slashingMock.AssertExpectations(s.T())
 	})
 
 	s.Run("ShareDecryptionError", func() {
@@ -1215,6 +1216,7 @@ func (s *RemoteKeyManagerTestSuite) TestAddShareErrorCases() {
 		var decErr ssvsigner.ShareDecryptionError
 		s.ErrorAs(err, &decErr)
 		clientMock.AssertExpectations(s.T())
+		slashingMock.AssertExpectations(s.T())
 	})
 
 	s.Run("BumpSlashingProtectionError", func() {

--- a/ssvsigner/ekm/remote_key_manager_test.go
+++ b/ssvsigner/ekm/remote_key_manager_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -1213,6 +1215,35 @@ func (s *RemoteKeyManagerTestSuite) TestAddShareErrorCases() {
 		var decErr ssvsigner.ShareDecryptionError
 		s.ErrorAs(err, &decErr)
 		clientMock.AssertExpectations(s.T())
+		slashingMock.AssertExpectations(s.T())
+	})
+
+	s.Run("ShareDecryptionError from real client 422", func() {
+		slashingMock := new(MockSlashingProtector)
+
+		// Drive a real ssv-signer 422 (empty body) through the real client, exercising the
+		// 422 -> ShareDecryptionError mapping and the AddShare wrap end to end (not a mock).
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+		}))
+		defer srv.Close()
+
+		rmTest := &RemoteKeyManager{
+			logger:            s.logger,
+			beaconConfig:      testNetCfg,
+			genesisRoot:       testNetCfg.GenesisValidatorsRoot,
+			signerClient:      ssvsigner.NewClient(srv.URL),
+			getOperatorId:     func() spectypes.OperatorID { return 1 },
+			operatorPubKey:    &MockOperatorPublicKey{},
+			slashingProtector: slashingMock,
+			signLocks:         map[signKey]*sync.RWMutex{},
+		}
+
+		err := rmTest.AddShare(s.T().Context(), nil, []byte("enc"), phase0.BLSPubKey{1, 2, 3})
+
+		// AddShare must preserve the ShareDecryptionError and, per the validate-first order, never bump.
+		var decErr ssvsigner.ShareDecryptionError
+		s.ErrorAs(err, &decErr)
 		slashingMock.AssertExpectations(s.T())
 	})
 

--- a/ssvsigner/ekm/remote_key_manager_test.go
+++ b/ssvsigner/ekm/remote_key_manager_test.go
@@ -1179,6 +1179,44 @@ func (s *RemoteKeyManagerTestSuite) TestAddShareErrorCases() {
 		clientMock.AssertExpectations(s.T())
 	})
 
+	s.Run("ShareDecryptionError", func() {
+		clientMock := new(MockRemoteSigner)
+		slashingMock := new(MockSlashingProtector)
+
+		rmTest := &RemoteKeyManager{
+			logger:            s.logger,
+			beaconConfig:      testNetCfg,
+			genesisRoot:       testNetCfg.GenesisValidatorsRoot,
+			signerClient:      clientMock,
+			getOperatorId:     func() spectypes.OperatorID { return 1 },
+			operatorPubKey:    &MockOperatorPublicKey{},
+			slashingProtector: slashingMock,
+			signLocks:         map[signKey]*sync.RWMutex{},
+		}
+
+		pubKey := phase0.BLSPubKey{1, 2, 3}
+		encShare := []byte("encrypted_share_data")
+
+		slashingMock.On("BumpSlashingProtectionTxn", nil, pubKey).Return(nil).Once()
+
+		// The signer rejects a malformed share with a 422, which ssvsigner.Client surfaces
+		// as a ShareDecryptionError.
+		clientMock.On("AddValidators", mock.Anything, ssvsigner.ShareKeys{
+			PubKey:           pubKey,
+			EncryptedPrivKey: encShare,
+		}).Return(nil, ssvsigner.ShareDecryptionError{
+			Err: errors.New("decrypt: crypto/rsa: decryption error"),
+		}).Once()
+
+		err := rmTest.AddShare(s.T().Context(), nil, encShare, pubKey)
+
+		// AddShare must surface this as a ShareDecryptionError (through its fmt.Errorf wrap)
+		// so the event handler classifies it as a malformed (skippable) event.
+		var decErr ssvsigner.ShareDecryptionError
+		s.ErrorAs(err, &decErr)
+		clientMock.AssertExpectations(s.T())
+	})
+
 	s.Run("BumpSlashingProtectionError", func() {
 		clientMock := new(MockRemoteSigner)
 		slashingMock := new(MockSlashingProtector)

--- a/ssvsigner/ekm/remote_key_manager_test.go
+++ b/ssvsigner/ekm/remote_key_manager_test.go
@@ -1166,8 +1166,7 @@ func (s *RemoteKeyManagerTestSuite) TestAddShareErrorCases() {
 		pubKey := phase0.BLSPubKey{1, 2, 3}
 		encShare := []byte("encrypted_share_data")
 
-		slashingMock.On("BumpSlashingProtectionTxn", nil, pubKey).Return(nil).Once()
-
+		// Bump runs only after AddValidators succeeds, so a signer error means it is never called.
 		clientMock.On("AddValidators", mock.Anything, ssvsigner.ShareKeys{
 			PubKey:           pubKey,
 			EncryptedPrivKey: encShare,
@@ -1198,10 +1197,8 @@ func (s *RemoteKeyManagerTestSuite) TestAddShareErrorCases() {
 		pubKey := phase0.BLSPubKey{1, 2, 3}
 		encShare := []byte("encrypted_share_data")
 
-		slashingMock.On("BumpSlashingProtectionTxn", nil, pubKey).Return(nil).Once()
-
 		// The signer rejects a malformed share with a 422, which ssvsigner.Client surfaces
-		// as a ShareDecryptionError.
+		// as a ShareDecryptionError. Bump runs only after a successful add, so it is never called.
 		clientMock.On("AddValidators", mock.Anything, ssvsigner.ShareKeys{
 			PubKey:           pubKey,
 			EncryptedPrivKey: encShare,
@@ -1237,6 +1234,13 @@ func (s *RemoteKeyManagerTestSuite) TestAddShareErrorCases() {
 		pubKey := phase0.BLSPubKey{1, 2, 3}
 		encShare := []byte("encrypted_share_data")
 
+		// Bump runs only after AddValidators succeeds, so the signer call must succeed here even
+		// though this case exercises the bump failure.
+		clientMock.On("AddValidators", mock.Anything, ssvsigner.ShareKeys{
+			PubKey:           pubKey,
+			EncryptedPrivKey: encShare,
+		}).Return([]web3signer.Status{web3signer.StatusImported}, nil).Once()
+
 		slashingMock.On("BumpSlashingProtectionTxn", nil, pubKey).Return(errors.New("bump slashing protection error")).Once()
 
 		err := rmTest.AddShare(context.Background(), nil, encShare, pubKey)
@@ -1264,8 +1268,8 @@ func (s *RemoteKeyManagerTestSuite) TestAddShareErrorCases() {
 		pubKey := phase0.BLSPubKey{1, 2, 3}
 		encShare := []byte("encrypted_share_data")
 
-		slashingMock.On("BumpSlashingProtectionTxn", nil, pubKey).Return(nil).Once()
-
+		// Bump runs only after all statuses are accepted, so an unexpected status means it is
+		// never called.
 		clientMock.On("AddValidators", mock.Anything, ssvsigner.ShareKeys{
 			PubKey:           pubKey,
 			EncryptedPrivKey: encShare,

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -192,10 +192,8 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 		// So, there's no need to store the password. We can just generate a random password for each keystore.
 		keystorePassword, err := s.generateRandomPassword(16)
 		if err != nil {
-			// A password-generation failure is an internal (transient) error, not a bad share,
-			// so reply 500 rather than 422. HTTP 422 from this endpoint is reserved for shares
-			// that cannot be decrypted/validated (see below): the node treats 422 as a malformed
-			// registry event and skips it, whereas other statuses are retried.
+			// Internal (transient) failure, not a bad share: reply 500 so the node retries
+			// rather than skips (see errMalformedShare for the 422/500 split).
 			logger.Warn("failed to generate random password", zap.Error(err))
 			s.writeJSONErr(
 				ctx,
@@ -212,10 +210,7 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 			keystorePassword,
 		)
 		if err != nil {
-			// Reply 422 only for a malformed share (errMalformedShare): the node treats 422 as a
-			// malformed registry event and skips it. Everything else defaults to 500 (retryable).
-			// Keeping 422 opt-in means a future untagged failure surfaces as a noisy crash-retry
-			// rather than a silent validator drop — the safe direction to fail.
+			// 422 only for a malformed share; anything else defaults to 500 (see errMalformedShare).
 			status := fasthttp.StatusInternalServerError
 			if errors.Is(err, errMalformedShare) {
 				status = fasthttp.StatusUnprocessableEntity
@@ -262,12 +257,11 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 	s.writeJSON(ctx, logger, resp)
 }
 
-// errMalformedShare tags the keystoreJSONFromEncryptedShare failures that mean the share itself
-// is bad (undecryptable, bad hex, invalid BLS key, or a pubkey mismatch). handleAddValidator
-// replies 422 for these, which the node treats as a malformed, skippable share. Every other
-// failure defaults to 500 (retryable): making 422 opt-in keeps the dangerous "silently skip"
-// path explicit, so an untagged internal error fails as a crash-retry instead of dropping a
-// valid validator.
+// errMalformedShare tags the keystoreJSONFromEncryptedShare failures caused by a bad share
+// (undecryptable, bad hex, invalid BLS key, or pubkey mismatch). handleAddValidator replies 422
+// for these — which the node skips as a malformed event — and 500 for everything else. Making 422
+// opt-in keeps the "silently skip" path explicit: an untagged internal failure crash-retries
+// instead of dropping a valid validator.
 var errMalformedShare = errors.New("malformed share")
 
 // keystoreJSONFromEncryptedShare doesn't pass errors through intentionally
@@ -296,8 +290,7 @@ func (s *Server) keystoreJSONFromEncryptedShare(
 		return "", fmt.Errorf("%w: derived public key does not match expected public key", errMalformedShare)
 	}
 
-	// Past this point the share itself is valid; the remaining failures are internal to the
-	// signer and stay untagged, so handleAddValidator replies 500 (retryable), not 422.
+	// The share is valid past this point; the remaining failures are internal (untagged) and get 500, not 422.
 	shareKeystore, err := keystore.GenerateShareKeystore(sharePrivBLS, sharePubKey, keystorePassword)
 	if err != nil {
 		return "", errors.New("generate share keystore")
@@ -534,9 +527,8 @@ func (s *Server) handleOperatorDecrypt(ctx *fasthttp.RequestCtx) {
 }
 
 func (s *Server) handleWeb3SignerErr(ctx *fasthttp.RequestCtx, logger *zap.Logger, resp any, err error) {
-	// Always report Web3Signer failures as 500. We deliberately do NOT forward Web3Signer's
-	// upstream status to the node: the node treats 422 as a malformed (skippable) share, so a
-	// forwarded upstream 422 would be misclassified. 500 keeps these failures on the retryable path.
+	// Report all Web3Signer failures as 500; we deliberately don't forward the upstream status,
+	// so a forwarded 422 can't be misclassified by the node as a malformed (skippable) share.
 	statusCode := fasthttp.StatusInternalServerError
 
 	logger.Error("web3signer request failed",

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -212,14 +212,19 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 			keystorePassword,
 		)
 		if err != nil {
-			// The share cannot be decrypted or validated (bad ciphertext, bad hex, or a
-			// pubkey mismatch). Reply 422 so the node classifies it as a malformed registry
-			// event (logged and skipped) instead of retrying it indefinitely.
+			// 422 means the share is malformed (bad ciphertext/hex/BLS/pubkey mismatch): the node
+			// classifies it as a malformed registry event and skips it. Internal failures raised
+			// after validation (keystore generation/marshalling, tagged errInternalKeystore) are
+			// not share problems, so reply 500 (retryable) for those instead.
+			status := fasthttp.StatusUnprocessableEntity
+			if errors.Is(err, errInternalKeystore) {
+				status = fasthttp.StatusInternalServerError
+			}
 			logger.Warn("failed to get keystore from encrypted share", zap.Error(err))
 			s.writeJSONErr(
 				ctx,
 				logger,
-				fasthttp.StatusUnprocessableEntity,
+				status,
 				fmt.Errorf("failed to get keystore from encrypted share index %d: %w", i, err),
 			)
 			return
@@ -257,6 +262,12 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 	s.writeJSON(ctx, logger, resp)
 }
 
+// errInternalKeystore tags failures in keystoreJSONFromEncryptedShare that occur after the
+// share has been validated (keystore generation or marshalling). These are internal signer
+// failures, not malformed shares, so handleAddValidator replies 500 (retryable) for them
+// rather than 422 (which the node treats as a malformed, skippable share).
+var errInternalKeystore = errors.New("internal keystore failure")
+
 // keystoreJSONFromEncryptedShare doesn't pass errors through intentionally
 // to prevent exposing information related to private key.
 func (s *Server) keystoreJSONFromEncryptedShare(
@@ -283,14 +294,16 @@ func (s *Server) keystoreJSONFromEncryptedShare(
 		return "", errors.New("derived public key does not match expected public key")
 	}
 
+	// Past this point the share itself is valid; the remaining failures are internal to the
+	// signer, so tag them with errInternalKeystore (see handleAddValidator's 500-vs-422 split).
 	shareKeystore, err := keystore.GenerateShareKeystore(sharePrivBLS, sharePubKey, keystorePassword)
 	if err != nil {
-		return "", fmt.Errorf("failed to generate share keystore")
+		return "", fmt.Errorf("%w: generate share keystore", errInternalKeystore)
 	}
 
 	keystoreJSON, err := json.Marshal(shareKeystore)
 	if err != nil {
-		return "", fmt.Errorf("marshal share keystore: %w", err)
+		return "", fmt.Errorf("%w: marshal share keystore", errInternalKeystore)
 	}
 
 	return string(keystoreJSON), nil
@@ -519,10 +532,10 @@ func (s *Server) handleOperatorDecrypt(ctx *fasthttp.RequestCtx) {
 }
 
 func (s *Server) handleWeb3SignerErr(ctx *fasthttp.RequestCtx, logger *zap.Logger, resp any, err error) {
+	// Always report Web3Signer failures as 500. We deliberately do NOT forward Web3Signer's
+	// upstream status to the node: the node treats 422 as a malformed (skippable) share, so a
+	// forwarded upstream 422 would be misclassified. 500 keeps these failures on the retryable path.
 	statusCode := fasthttp.StatusInternalServerError
-	if he := new(web3signer.HTTPResponseError); errors.As(err, &he) {
-		statusCode = he.Status
-	}
 
 	logger.Error("web3signer request failed",
 		zap.Error(err),

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -265,8 +265,9 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 // instead of dropping a valid validator.
 var errMalformedShare = errors.New("malformed share")
 
-// keystoreJSONFromEncryptedShare doesn't pass errors through intentionally
-// to prevent exposing information related to private key.
+// keystoreJSONFromEncryptedShare withholds the cause of share-data failures (tagged
+// errMalformedShare) so a bad share can't leak private-key material. Failures after the share
+// validates are internal, carry no key bytes, and pass their cause through for diagnosis.
 func (s *Server) keystoreJSONFromEncryptedShare(
 	encryptedPrivKey hexutil.Bytes,
 	sharePubKey phase0.BLSPubKey,
@@ -291,8 +292,7 @@ func (s *Server) keystoreJSONFromEncryptedShare(
 		return "", fmt.Errorf("%w: derived public key does not match expected public key", errMalformedShare)
 	}
 
-	// The share is valid past here; the remaining failures are internal (untagged -> 500). Pass the
-	// cause through (scrypt/AES/encoding, not key bytes) so the operator can diagnose the failure.
+	// Past this point the share is valid; remaining failures are internal (untagged -> 500).
 	shareKeystore, err := keystore.GenerateShareKeystore(sharePrivBLS, sharePubKey, keystorePassword)
 	if err != nil {
 		return "", fmt.Errorf("generate share keystore: %w", err)

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -192,11 +192,15 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 		// So, there's no need to store the password. We can just generate a random password for each keystore.
 		keystorePassword, err := s.generateRandomPassword(16)
 		if err != nil {
+			// A password-generation failure is an internal (transient) error, not a bad share,
+			// so reply 500 rather than 422. HTTP 422 from this endpoint is reserved for shares
+			// that cannot be decrypted/validated (see below): the node treats 422 as a malformed
+			// registry event and skips it, whereas other statuses are retried.
 			logger.Warn("failed to generate random password", zap.Error(err))
 			s.writeJSONErr(
 				ctx,
 				logger,
-				fasthttp.StatusUnprocessableEntity,
+				fasthttp.StatusInternalServerError,
 				fmt.Errorf("failed to generate random password: %w", err),
 			)
 			return
@@ -208,6 +212,9 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 			keystorePassword,
 		)
 		if err != nil {
+			// The share cannot be decrypted or validated (bad ciphertext, bad hex, or a
+			// pubkey mismatch). Reply 422 so the node classifies it as a malformed registry
+			// event (logged and skipped) instead of retrying it indefinitely.
 			logger.Warn("failed to get keystore from encrypted share", zap.Error(err))
 			s.writeJSONErr(
 				ctx,

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -212,13 +212,13 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 			keystorePassword,
 		)
 		if err != nil {
-			// 422 means the share is malformed (bad ciphertext/hex/BLS/pubkey mismatch): the node
-			// classifies it as a malformed registry event and skips it. Internal failures raised
-			// after validation (keystore generation/marshalling, tagged errInternalKeystore) are
-			// not share problems, so reply 500 (retryable) for those instead.
-			status := fasthttp.StatusUnprocessableEntity
-			if errors.Is(err, errInternalKeystore) {
-				status = fasthttp.StatusInternalServerError
+			// Reply 422 only for a malformed share (errMalformedShare): the node treats 422 as a
+			// malformed registry event and skips it. Everything else defaults to 500 (retryable).
+			// Keeping 422 opt-in means a future untagged failure surfaces as a noisy crash-retry
+			// rather than a silent validator drop — the safe direction to fail.
+			status := fasthttp.StatusInternalServerError
+			if errors.Is(err, errMalformedShare) {
+				status = fasthttp.StatusUnprocessableEntity
 			}
 			logger.Warn("failed to get keystore from encrypted share", zap.Error(err))
 			s.writeJSONErr(
@@ -262,11 +262,13 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 	s.writeJSON(ctx, logger, resp)
 }
 
-// errInternalKeystore tags failures in keystoreJSONFromEncryptedShare that occur after the
-// share has been validated (keystore generation or marshalling). These are internal signer
-// failures, not malformed shares, so handleAddValidator replies 500 (retryable) for them
-// rather than 422 (which the node treats as a malformed, skippable share).
-var errInternalKeystore = errors.New("internal keystore failure")
+// errMalformedShare tags the keystoreJSONFromEncryptedShare failures that mean the share itself
+// is bad (undecryptable, bad hex, invalid BLS key, or a pubkey mismatch). handleAddValidator
+// replies 422 for these, which the node treats as a malformed, skippable share. Every other
+// failure defaults to 500 (retryable): making 422 opt-in keeps the dangerous "silently skip"
+// path explicit, so an untagged internal error fails as a crash-retry instead of dropping a
+// valid validator.
+var errMalformedShare = errors.New("malformed share")
 
 // keystoreJSONFromEncryptedShare doesn't pass errors through intentionally
 // to prevent exposing information related to private key.
@@ -277,33 +279,33 @@ func (s *Server) keystoreJSONFromEncryptedShare(
 ) (string, error) {
 	sharePrivKeyHex, err := s.operatorPrivKey.Decrypt(encryptedPrivKey)
 	if err != nil {
-		return "", fmt.Errorf("failed to decrypt share")
+		return "", fmt.Errorf("%w: decrypt share", errMalformedShare)
 	}
 
 	sharePrivKey, err := hex.DecodeString(strings.TrimPrefix(string(sharePrivKeyHex), "0x"))
 	if err != nil {
-		return "", fmt.Errorf("failed to decode share private key from hex for pubkey %s", sharePubKey.String())
+		return "", fmt.Errorf("%w: decode share private key from hex for pubkey %s", errMalformedShare, sharePubKey.String())
 	}
 
 	sharePrivBLS := &bls.SecretKey{}
 	if err = sharePrivBLS.Deserialize(sharePrivKey); err != nil {
-		return "", fmt.Errorf("failed to deserialize share private key")
+		return "", fmt.Errorf("%w: deserialize share private key", errMalformedShare)
 	}
 
 	if !bytes.Equal(sharePrivBLS.GetPublicKey().Serialize(), sharePubKey[:]) {
-		return "", errors.New("derived public key does not match expected public key")
+		return "", fmt.Errorf("%w: derived public key does not match expected public key", errMalformedShare)
 	}
 
 	// Past this point the share itself is valid; the remaining failures are internal to the
-	// signer, so tag them with errInternalKeystore (see handleAddValidator's 500-vs-422 split).
+	// signer and stay untagged, so handleAddValidator replies 500 (retryable), not 422.
 	shareKeystore, err := keystore.GenerateShareKeystore(sharePrivBLS, sharePubKey, keystorePassword)
 	if err != nil {
-		return "", fmt.Errorf("%w: generate share keystore", errInternalKeystore)
+		return "", errors.New("generate share keystore")
 	}
 
 	keystoreJSON, err := json.Marshal(shareKeystore)
 	if err != nil {
-		return "", fmt.Errorf("%w: marshal share keystore", errInternalKeystore)
+		return "", fmt.Errorf("marshal share keystore: %w", err)
 	}
 
 	return string(keystoreJSON), nil

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -193,8 +193,9 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 		keystorePassword, err := s.generateRandomPassword(16)
 		if err != nil {
 			// Internal (transient) failure, not a bad share: reply 500 so the node retries
-			// rather than skips (see errMalformedShare for the 422/500 split).
-			logger.Warn("failed to generate random password", zap.Error(err))
+			// rather than skips (see errMalformedShare for the 422/500 split). Log at error since a
+			// 500 crash-loops the block on the node.
+			logger.Error("failed to generate random password", zap.Error(err))
 			s.writeJSONErr(
 				ctx,
 				logger,
@@ -211,11 +212,14 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 		)
 		if err != nil {
 			// 422 only for a malformed share; anything else defaults to 500 (see errMalformedShare).
+			// A 500 crash-loops the block on the node, so log it at error; a 422 is skipped, so warn.
 			status := fasthttp.StatusInternalServerError
+			logAt := logger.Error
 			if errors.Is(err, errMalformedShare) {
 				status = fasthttp.StatusUnprocessableEntity
+				logAt = logger.Warn
 			}
-			logger.Warn("failed to get keystore from encrypted share", zap.Error(err))
+			logAt("failed to get keystore from encrypted share", zap.Error(err))
 			s.writeJSONErr(
 				ctx,
 				logger,
@@ -290,10 +294,12 @@ func (s *Server) keystoreJSONFromEncryptedShare(
 		return "", fmt.Errorf("%w: derived public key does not match expected public key", errMalformedShare)
 	}
 
-	// The share is valid past this point; the remaining failures are internal (untagged) and get 500, not 422.
+	// The share is valid past this point; the remaining failures are internal (untagged) and get 500,
+	// not 422. Pass the cause through — these are scrypt/AES/encoding errors, not key bytes, and a
+	// 500 crash-loops the block, so the operator needs the detail.
 	shareKeystore, err := keystore.GenerateShareKeystore(sharePrivBLS, sharePubKey, keystorePassword)
 	if err != nil {
-		return "", errors.New("generate share keystore")
+		return "", fmt.Errorf("generate share keystore: %w", err)
 	}
 
 	keystoreJSON, err := json.Marshal(shareKeystore)
@@ -533,7 +539,7 @@ func (s *Server) handleWeb3SignerErr(ctx *fasthttp.RequestCtx, logger *zap.Logge
 
 	logger.Error("web3signer request failed",
 		zap.Error(err),
-		zap.Int("status_code", statusCode),
+		zap.Int("reply_status", statusCode),
 		zap.Any("resp", resp),
 	)
 	ctx.SetStatusCode(statusCode)

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -192,9 +192,8 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 		// So, there's no need to store the password. We can just generate a random password for each keystore.
 		keystorePassword, err := s.generateRandomPassword(16)
 		if err != nil {
-			// Internal (transient) failure, not a bad share: reply 500 so the node retries
-			// rather than skips (see errMalformedShare for the 422/500 split). Log at error since a
-			// 500 crash-loops the block on the node.
+			// Internal (transient) failure, not a bad share -> 500 (see errMalformedShare). Log at
+			// error to match the node-fatal reply.
 			logger.Error("failed to generate random password", zap.Error(err))
 			s.writeJSONErr(
 				ctx,
@@ -212,7 +211,7 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 		)
 		if err != nil {
 			// 422 only for a malformed share; anything else defaults to 500 (see errMalformedShare).
-			// A 500 crash-loops the block on the node, so log it at error; a 422 is skipped, so warn.
+			// Log level follows the reply: warn for the skippable 422, error for a node-fatal 500.
 			status := fasthttp.StatusInternalServerError
 			logAt := logger.Error
 			if errors.Is(err, errMalformedShare) {
@@ -294,9 +293,8 @@ func (s *Server) keystoreJSONFromEncryptedShare(
 		return "", fmt.Errorf("%w: derived public key does not match expected public key", errMalformedShare)
 	}
 
-	// The share is valid past this point; the remaining failures are internal (untagged) and get 500,
-	// not 422. Pass the cause through — these are scrypt/AES/encoding errors, not key bytes, and a
-	// 500 crash-loops the block, so the operator needs the detail.
+	// The share is valid past here; the remaining failures are internal (untagged -> 500). Pass the
+	// cause through (scrypt/AES/encoding, not key bytes) so the operator can diagnose the failure.
 	shareKeystore, err := keystore.GenerateShareKeystore(sharePrivBLS, sharePubKey, keystorePassword)
 	if err != nil {
 		return "", fmt.Errorf("generate share keystore: %w", err)

--- a/ssvsigner/server_test.go
+++ b/ssvsigner/server_test.go
@@ -257,6 +257,20 @@ func (s *ServerTestSuite) TestAddValidator() {
 		s.remoteSigner.ImportError = nil
 	})
 
+	t.Run("web3signer 422 is not forwarded", func(t *testing.T) {
+		// A Web3Signer 422 must be reported as 500, never forwarded: the node treats 422 as a
+		// malformed share, so forwarding it would misclassify an upstream failure as a bad share.
+		s.remoteSigner.ImportError = web3signer.HTTPResponseError{
+			Err:    errors.New("upstream"),
+			Status: fasthttp.StatusUnprocessableEntity,
+		}
+		resp, err := s.ServeHTTP("POST", PathValidators, reqBody)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusInternalServerError, resp.StatusCode())
+
+		s.remoteSigner.ImportError = nil
+	})
+
 	t.Run("too many shares", func(t *testing.T) {
 		tooBigRequest := request
 		for i := 0; i < addShareLimit*2; i++ {

--- a/ssvsigner/types.go
+++ b/ssvsigner/types.go
@@ -12,9 +12,9 @@ import (
 // on-chain data) rather than a transient/transport failure, so callers can skip the event
 // instead of treating it as fatal.
 //
-// It must stay a concrete type, returned by value. Callers match it with
-// errors.As(err, &ShareDecryptionError{}): an interface alias of error would match every error, and
-// a pointer return (&ShareDecryptionError{}) would slip past unmatched.
+// It must stay a concrete struct returned by value: callers match with
+// errors.As(err, &ShareDecryptionError{}). An interface alias of error would match every error, and
+// returning it by pointer (*ShareDecryptionError) would slip past that value-typed match.
 type ShareDecryptionError struct {
 	Err error
 }

--- a/ssvsigner/types.go
+++ b/ssvsigner/types.go
@@ -7,15 +7,13 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
-// ShareDecryptionError indicates that an encrypted validator share could not be turned
-// into a usable signing key: the ciphertext failed to decrypt, wasn't valid hex, or didn't
-// match the expected share public key. It marks a malformed share (bad on-chain event data),
-// as opposed to a transient or transport failure, so callers can treat it as a skippable
-// malformed event rather than a fatal error.
+// ShareDecryptionError marks an encrypted validator share that can't be turned into a signing
+// key — undecryptable, bad hex, or a share-pubkey mismatch. It signals a malformed share (bad
+// on-chain data) rather than a transient/transport failure, so callers can skip the event
+// instead of treating it as fatal.
 //
-// It must stay a concrete type (not an interface): callers distinguish it with
-// errors.As(err, &ShareDecryptionError{}), which an interface alias of error would defeat by
-// matching every error.
+// It must stay a concrete type: callers distinguish it with errors.As(err, &ShareDecryptionError{}),
+// which an interface alias of error would defeat by matching every error.
 type ShareDecryptionError struct {
 	Err error
 }

--- a/ssvsigner/types.go
+++ b/ssvsigner/types.go
@@ -12,8 +12,9 @@ import (
 // on-chain data) rather than a transient/transport failure, so callers can skip the event
 // instead of treating it as fatal.
 //
-// It must stay a concrete type: callers distinguish it with errors.As(err, &ShareDecryptionError{}),
-// which an interface alias of error would defeat by matching every error.
+// It must stay a concrete type and be returned by value: callers match it with
+// errors.As(err, &ShareDecryptionError{}), which an interface alias of error would defeat (matching
+// every error) and which a pointer return (&ShareDecryptionError{}) would slip past unmatched.
 type ShareDecryptionError struct {
 	Err error
 }

--- a/ssvsigner/types.go
+++ b/ssvsigner/types.go
@@ -12,9 +12,9 @@ import (
 // on-chain data) rather than a transient/transport failure, so callers can skip the event
 // instead of treating it as fatal.
 //
-// It must stay a concrete type and be returned by value: callers match it with
-// errors.As(err, &ShareDecryptionError{}), which an interface alias of error would defeat (matching
-// every error) and which a pointer return (&ShareDecryptionError{}) would slip past unmatched.
+// It must stay a concrete type, returned by value. Callers match it with
+// errors.As(err, &ShareDecryptionError{}): an interface alias of error would match every error, and
+// a pointer return (&ShareDecryptionError{}) would slip past unmatched.
 type ShareDecryptionError struct {
 	Err error
 }

--- a/ssvsigner/types.go
+++ b/ssvsigner/types.go
@@ -7,7 +7,29 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
-type ShareDecryptionError error
+// ShareDecryptionError indicates that an encrypted validator share could not be turned
+// into a usable signing key: the ciphertext failed to decrypt, wasn't valid hex, or didn't
+// match the expected share public key. It marks a malformed share (bad on-chain event data),
+// as opposed to a transient or transport failure, so callers can treat it as a skippable
+// malformed event rather than a fatal error.
+//
+// It must stay a concrete type (not an interface): callers distinguish it with
+// errors.As(err, &ShareDecryptionError{}), which an interface alias of error would defeat by
+// matching every error.
+type ShareDecryptionError struct {
+	Err error
+}
+
+func (e ShareDecryptionError) Error() string {
+	if e.Err == nil {
+		return "share decryption error: nil"
+	}
+	return "share decryption error: " + e.Err.Error()
+}
+
+func (e ShareDecryptionError) Unwrap() error {
+	return e.Err
+}
 
 var ErrOperatorDataProtectionUnsupported = errors.New("operator data protection is unsupported by this ssv-signer")
 


### PR DESCRIPTION
## Summary
A validator share that the signer cannot decrypt should be treated as a malformed registry event (logged and skipped), exactly as the local key manager already does. In remote-signing mode it wasn't: `ssvsigner` declared `ShareDecryptionError` as an interface alias of `error`, so the value the client returned on an HTTP 422 kept its underlying `*errors.errorString` dynamic type, and the event handler's `errors.As(err, &ekm.ShareDecryptionError{})` (a struct type) never matched. A share that failed to decrypt was therefore handled as a non-malformed error instead of a skippable malformed event, inconsistently with local signing.

## Change
- Consolidate the two identically-named `ShareDecryptionError` types into a single concrete struct in the `ssvsigner` package, used by the client, both key managers, and the event handler, so decryption failures are classified consistently across local and remote signing modes.
- Reserve HTTP 422 from the add-validator endpoint for shares that cannot be decrypted/validated: a random-password-generation failure now returns 500 (a transient, retryable error) rather than 422, so it is not misclassified as a malformed share.

## Tests
- Replace the `ShareDecryptionError` `errors.As` assertions that passed for any error (the type was an interface) with ones that distinguish a decryption error from other failures.
- Add coverage for the remote client → `AddShare` path.

## Compatibility
The classification fix is node-side and works with any ssv-signer version (it relies only on the existing HTTP 422 contract). The server-side 422 tightening is independent and degrades gracefully, so nodes and ssv-signer can still be upgraded independently.
