### PR TITLE
eth/executionclient: fix "close of nil channel" panic in MultiClient.Close

### DIFF
--- a/eth/executionclient/multi_client.go
+++ b/eth/executionclient/multi_client.go
@@ -81,6 +81,7 @@ func NewMulti(ctx context.Context, nodeAddrs []string, contractAddr ethcommon.Ad
 		clients:                    make([]SingleClientProvider, len(nodeAddrs)), // initialized with nil values (not connected)
 		clientsMu:                  make([]sync.Mutex, len(nodeAddrs)),
 		contractAddress:            contractAddr,
+		closed:                     make(chan struct{}), // must be non-nil: Close closes it and StreamLogs selects on it
 		logger:                     zap.NewNop(),
 		reqTimeout:                 DefaultReqTimeout,
 		reqRetryDelay:              DefaultReqRetryDelay,
@@ -370,7 +371,7 @@ func (mc *MultiClient) Close() error {
 
 		if client != nil {
 			if err := client.Close(); err != nil {
-				mc.logger.Debug("Failed to close client", zap.String("address", mc.clientAddrs[i]), zap.Error(err))
+				mc.logger.Debug("failed to close client", zap.String("address", mc.clientAddrs[i]), zap.Error(err))
 				multiErr = errors.Join(multiErr, err)
 			}
 		}

--- a/eth/executionclient/multi_client_test.go
+++ b/eth/executionclient/multi_client_test.go
@@ -49,6 +49,12 @@ func TestNewMulti(t *testing.T) {
 		require.EqualValues(t, DefaultReqRetryDelay, mc.reqRetryDelay)
 		require.EqualValues(t, DefaultHealthInvalidationInterval, mc.healthInvalidationInterval)
 		require.EqualValues(t, DefaultSyncDistanceTolerance, mc.syncDistanceTolerance)
+
+		// Regression: NewMulti must initialize mc.closed, or Close does close(nil) and panics —
+		// as it did when startup cleanup closed the EL client of a node that failed to assemble.
+		require.NotPanics(t, func() {
+			require.NoError(t, mc.Close())
+		})
 	})
 	t.Run("success, options override default values", func(t *testing.T) {
 		ctx := t.Context()


### PR DESCRIPTION
## Summary

Fixes a `FATAL "Recovered from panic" panic="close of nil channel"` observed on a production mainnet cluster right after a stage deploy.

`NewMulti` constructed the `MultiClient` struct literal **without initializing the `closed` channel**, leaving it `nil` — unlike the single-client `New`, which does `closed: make(chan struct{})`. Two consequences:

- `MultiClient.Close` does `close(mc.closed)` → **`close(nil)` → panic** (`close of nil channel`).
- `StreamLogs`' `case <-mc.closed:` shutdown branch was permanently dead — a receive on a `nil` channel never fires.

Only multi-EL configs (`>1` semicolon-separated address in `eth1.Addr`) were affected; single-EL setups go through `New`, which initializes the channel.

## Why it surfaced now

The bug is latent on both `main` and `stage`, but the panic only became **reachable** on `stage`: startup now cleans up the execution client on assembly failure — `buildNode` calls `executionClient.Close()` when `newNode` returns an error — instead of exiting via `Fatal`. That path invoked `Close()` on a `NewMulti`-built client, tripping the nil channel. Previously an `os.Exit`-style `Fatal` meant `Close()` was never called, so the channel was never closed.

The crash was a **startup** panic in the newly deployed pod (the `buildNode` cleanup path), not a shutdown of the old pod. The `newNode` failure that triggered the cleanup was most likely resource contention during the rolling deploy (e.g. the old pod still holding the DB lock / a port). As a side effect, the panic **masked the original `newNode` error**, since it fired before that error could be returned.

## Changes

- Initialize `closed` in `NewMulti`. This resolves both the `Close()` panic and the dead `StreamLogs` shutdown case. After the fix, a `newNode`-assembly failure closes the EL client cleanly and surfaces the real error instead of crashing.
- Extend `TestNewMulti` to call `Close()` on a `NewMulti`-built client and assert it does not panic. Verified the test **fails without the fix** (`close of nil channel`) and **passes with it**.
- Minor consistency tweak: lowercase the one capitalized log message in `Close` (`"Failed to close client"` → `"failed to close client"`) — it was the lone outlier against the file's lowercase-log house style.

## Deliberately out of scope

- **Idempotent `Close()` (`sync.Once`)**: the two `Close()` call sites (`buildNode`'s assembly-failure cleanup and `supervise`→`node.close()`) are mutually exclusive and each fire exactly once, and the health prober never closes its components — so a double-close guard would not be load-bearing here.
- **`buildNode` cleanup error handling** (`cli/operator`): out of this package's scope, and with the panic fixed the real `newNode` error is already surfaced by `start_node.go`'s `Fatal`.
