### PR TITLE
eth/executionclient: dedupe MultiClient test construction via newTestMultiClient helper

### DIFF
--- a/eth/executionclient/multi_client.go
+++ b/eth/executionclient/multi_client.go
@@ -387,6 +387,11 @@ func (mc *MultiClient) call(ctx context.Context, f func(client SingleClientProvi
 	startTime := time.Now()
 
 	clientsTotal := len(mc.clients)
+	if clientsTotal == 0 {
+		// NewMulti guarantees at least one client, but guard the modulo arithmetic below
+		// from dividing by zero on a MultiClient constructed another way.
+		return nil, fmt.Errorf("no clients configured")
+	}
 
 	// Iterate over the clients in round-robin fashion, starting from the most likely healthy client (currentClientIndex).
 	startingIndex := int(mc.currentClientIndex.Load())

--- a/eth/executionclient/multi_client.go
+++ b/eth/executionclient/multi_client.go
@@ -275,6 +275,12 @@ func (mc *MultiClient) Healthy(ctx context.Context) error {
 		return nil
 	}
 
+	if len(mc.clients) == 0 {
+		// NewMulti guarantees at least one client; without this guard the "no healthy clients"
+		// error below would wrap a nil error for a MultiClient constructed another way.
+		return fmt.Errorf("no clients configured")
+	}
+
 	healthyClients := atomic.Bool{}
 	healthyCount := atomic.Int64{}
 	p := pool.New().WithErrors().WithContext(ctx)

--- a/eth/executionclient/multi_client_test.go
+++ b/eth/executionclient/multi_client_test.go
@@ -1217,6 +1217,18 @@ func TestMultiClient_Call_AllClientsFail(t *testing.T) {
 	require.Contains(t, err.Error(), "all clients failed")
 }
 
+func TestMultiClient_Call_NoClients(t *testing.T) {
+	mc := newTestMultiClient(t)
+
+	f := func(client SingleClientProvider) (any, error) {
+		return nil, nil
+	}
+
+	_, err := mc.call(t.Context(), f)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no clients configured")
+}
+
 // dummySubscription is a stub implementing ethereum.Subscription.
 type dummySubscription struct{}
 

--- a/eth/executionclient/multi_client_test.go
+++ b/eth/executionclient/multi_client_test.go
@@ -22,6 +22,26 @@ import (
 	"github.com/ssvlabs/ssv/observability/log"
 )
 
+// newTestMultiClient builds a MultiClient wired for tests: a test logger, an initialized
+// closed channel, and clientAddrs/clientsMu sized to the given clients. Routing test
+// construction through here keeps closed from being forgotten — a nil closed panics Close.
+func newTestMultiClient(t *testing.T, clients ...SingleClientProvider) *MultiClient {
+	t.Helper()
+
+	addrs := make([]string, len(clients))
+	for i := range clients {
+		addrs[i] = fmt.Sprintf("client-%d", i)
+	}
+
+	return &MultiClient{
+		clientAddrs: addrs,
+		clients:     clients,
+		clientsMu:   make([]sync.Mutex, len(clients)),
+		logger:      log.TestLogger(t),
+		closed:      make(chan struct{}),
+	}
+}
+
 func TestNewMulti(t *testing.T) {
 	t.Run("success, default values", func(t *testing.T) {
 		ctx := t.Context()
@@ -87,6 +107,8 @@ func TestNewMulti(t *testing.T) {
 		require.Equal(t, customLogger.Named(log.NameExecutionClientMulti), mc.logger)
 		require.EqualValues(t, customTimeout, mc.reqTimeout)
 		require.EqualValues(t, customSyncDistanceTolerance, mc.syncDistanceTolerance)
+
+		require.NoError(t, mc.Close())
 	})
 	t.Run("no node addresses", func(t *testing.T) {
 		ctx := t.Context()
@@ -115,9 +137,7 @@ func TestMultiClient_assertSameChainIDs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mc := &MultiClient{
-		logger: log.TestLogger(t),
-	}
+	mc := newTestMultiClient(t)
 
 	expected, ok := mc.assertSameChainID(big.NewInt(5))
 	require.True(t, ok)
@@ -136,10 +156,7 @@ func TestMultiClient_assertSameChainIDs_Error(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mc := &MultiClient{
-		logger: log.TestLogger(t),
-		closed: make(chan struct{}),
-	}
+	mc := newTestMultiClient(t)
 
 	expected, ok := mc.assertSameChainID(big.NewInt(5))
 	require.True(t, ok)
@@ -187,13 +204,7 @@ func TestMultiClient_FetchHistoricalLogs(t *testing.T) {
 		}).
 		AnyTimes()
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mockaddr"},
-		clients:     []SingleClientProvider{mockClient},
-		clientsMu:   make([]sync.Mutex, 1),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient)
 
 	logs, errs, err := mc.FetchHistoricalLogs(ctx, 100)
 	require.NoError(t, err)
@@ -246,13 +257,7 @@ func TestMultiClient_FetchHistoricalLogs_AllClientsNothingToSync(t *testing.T) {
 		Return(nil).
 		AnyTimes()
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mockNode1", "mockNode2"},
-		clients:     []SingleClientProvider{mockClient1, mockClient2},
-		clientsMu:   make([]sync.Mutex, 2),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient1, mockClient2)
 
 	logs, errs, err := mc.FetchHistoricalLogs(ctx, 100)
 	require.Error(t, err)
@@ -295,13 +300,7 @@ func TestMultiClient_FetchHistoricalLogs_MixedErrors(t *testing.T) {
 		Return(nil).
 		AnyTimes()
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mockNode1", "mockNode2"},
-		clients:     []SingleClientProvider{mockClient1, mockClient2},
-		clientsMu:   make([]sync.Mutex, 2),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient1, mockClient2)
 
 	logs, errs, err := mc.FetchHistoricalLogs(ctx, 100)
 	require.Error(t, err)
@@ -354,13 +353,7 @@ func TestMultiClient_StreamLogs_Failover(t *testing.T) {
 				Times(1),
 		)
 
-		mc := &MultiClient{
-			clientAddrs: []string{"mockNode1", "mockNode2"},
-			clients:     []SingleClientProvider{mockClient1, mockClient2},
-			clientsMu:   make([]sync.Mutex, 2),
-			logger:      log.TestLogger(t),
-			closed:      make(chan struct{}),
-		}
+		mc := newTestMultiClient(t, mockClient1, mockClient2)
 
 		logsCh := mc.StreamLogs(ctx, 200)
 
@@ -430,13 +423,7 @@ func TestMultiClient_StreamLogs_Failover(t *testing.T) {
 				Times(1),
 		)
 
-		mc := &MultiClient{
-			clientAddrs: []string{"mockNode1", "mockNode2"},
-			clients:     []SingleClientProvider{mockClient1, mockClient2},
-			clientsMu:   make([]sync.Mutex, 2),
-			logger:      log.TestLogger(t),
-			closed:      make(chan struct{}),
-		}
+		mc := newTestMultiClient(t, mockClient1, mockClient2)
 
 		logsCh := mc.StreamLogs(ctx, 200)
 
@@ -496,13 +483,7 @@ func TestMultiClient_StreamLogs_Failover(t *testing.T) {
 				Times(1),
 		)
 
-		mc := &MultiClient{
-			clientAddrs: []string{"mockNode1", "mockClient2"},
-			clients:     []SingleClientProvider{mockClient1, mockClient2},
-			clientsMu:   make([]sync.Mutex, 2),
-			logger:      log.TestLogger(t),
-			closed:      make(chan struct{}),
-		}
+		mc := newTestMultiClient(t, mockClient1, mockClient2)
 
 		logsCh := mc.StreamLogs(ctx, 200)
 
@@ -587,13 +568,7 @@ func TestMultiClient_StreamLogs_Failover(t *testing.T) {
 				Times(1),
 		)
 
-		mc := &MultiClient{
-			clientAddrs: []string{"mockNode1", "mockNode2", "mockNode3"},
-			clients:     []SingleClientProvider{mockClient1, mockClient2, mockClient3},
-			clientsMu:   make([]sync.Mutex, 3),
-			logger:      log.TestLogger(t),
-			closed:      make(chan struct{}),
-		}
+		mc := newTestMultiClient(t, mockClient1, mockClient2, mockClient3)
 
 		logsCh := mc.StreamLogs(ctx, 200)
 
@@ -633,13 +608,7 @@ func TestMultiClient_StreamLogs_Success(t *testing.T) {
 		}).
 		AnyTimes()
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mockNode1"},
-		clients:     []SingleClientProvider{mockClient},
-		clientsMu:   make([]sync.Mutex, 1),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient)
 
 	logsCh := mc.StreamLogs(ctx, 200)
 
@@ -698,13 +667,7 @@ func TestMultiClient_StreamLogs_Interrupted(t *testing.T) {
 			}).
 			AnyTimes()
 
-		mc := &MultiClient{
-			clientAddrs: []string{"mockNode1", "mockClient2"},
-			clients:     []SingleClientProvider{mockClient1, mockClient2},
-			clientsMu:   make([]sync.Mutex, 2),
-			logger:      log.TestLogger(t),
-			closed:      make(chan struct{}),
-		}
+		mc := newTestMultiClient(t, mockClient1, mockClient2)
 
 		logsCh := mc.StreamLogs(ctx, 200)
 		// Make sure logsCh is closed
@@ -756,13 +719,7 @@ func TestMultiClient_StreamLogs_Interrupted(t *testing.T) {
 			}).
 			AnyTimes()
 
-		mc := &MultiClient{
-			clientAddrs: []string{"mockNode1", "mockClient2"},
-			clients:     []SingleClientProvider{mockClient1, mockClient2},
-			clientsMu:   make([]sync.Mutex, 2),
-			logger:      log.TestLogger(t),
-			closed:      make(chan struct{}),
-		}
+		mc := newTestMultiClient(t, mockClient1, mockClient2)
 
 		logsCh := mc.StreamLogs(ctx, 200)
 		// Make sure logsCh is closed
@@ -811,13 +768,7 @@ func TestMultiClient_StreamLogs_Interrupted(t *testing.T) {
 			}).
 			AnyTimes()
 
-		mc := &MultiClient{
-			clientAddrs: []string{"mockNode1", "mockClient2"},
-			clients:     []SingleClientProvider{mockClient1, mockClient2},
-			clientsMu:   make([]sync.Mutex, 2),
-			logger:      log.TestLogger(t),
-			closed:      make(chan struct{}),
-		}
+		mc := newTestMultiClient(t, mockClient1, mockClient2)
 
 		logsCh := mc.StreamLogs(ctx, 200)
 		// Make sure logsCh is closed
@@ -839,13 +790,7 @@ func TestMultiClient_Healthy(t *testing.T) {
 		Return(nil).
 		Times(1)
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mock1"},
-		clients:     []SingleClientProvider{mockClient},
-		clientsMu:   make([]sync.Mutex, 1),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient)
 
 	err := mc.Healthy(t.Context())
 	require.NoError(t, err)
@@ -871,13 +816,7 @@ func TestMultiClient_Healthy_MultiClient(t *testing.T) {
 		Return(nil).
 		Times(1)
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mockNode1", "mockNode2"},
-		clients:     []SingleClientProvider{mockClient1, mockClient2},
-		clientsMu:   make([]sync.Mutex, 2),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient1, mockClient2)
 
 	err := mc.Healthy(t.Context())
 	require.NoError(t, err, "expected all clients to be healthy")
@@ -902,13 +841,7 @@ func TestMultiClient_Healthy_AllClientsUnhealthy(t *testing.T) {
 		Return(fmt.Errorf("client2 unhealthy")).
 		Times(1)
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mockNode1", "mockNode2"},
-		clients:     []SingleClientProvider{mockClient1, mockClient2},
-		clientsMu:   make([]sync.Mutex, 2),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient1, mockClient2)
 
 	err := mc.Healthy(t.Context())
 	require.Error(t, err)
@@ -934,13 +867,7 @@ func TestMultiClient_HeaderByNumber(t *testing.T) {
 		Return(&ethtypes.Header{}, nil).
 		Times(1)
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mock1"},
-		clients:     []SingleClientProvider{mockClient},
-		clientsMu:   make([]sync.Mutex, 1),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient)
 
 	blk, err := mc.HeaderByNumber(t.Context(), big.NewInt(1234))
 	require.NoError(t, err)
@@ -965,13 +892,7 @@ func TestMultiClient_HeaderByNumber_Error(t *testing.T) {
 		Return((*ethtypes.Header)(nil), fmt.Errorf("header not found")).
 		Times(1)
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mock1"},
-		clients:     []SingleClientProvider{mockClient},
-		clientsMu:   make([]sync.Mutex, 1),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient)
 
 	blk, err := mc.HeaderByNumber(t.Context(), big.NewInt(1234))
 	require.Error(t, err)
@@ -1007,13 +928,7 @@ func TestMultiClient_SubscribeFilterLogs(t *testing.T) {
 		Return(sub, nil).
 		Times(1)
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mock1"},
-		clients:     []SingleClientProvider{mockClient},
-		clientsMu:   make([]sync.Mutex, 1),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient)
 
 	subscription, err := mc.SubscribeFilterLogs(t.Context(), query, logCh)
 	require.NoError(t, err)
@@ -1046,13 +961,7 @@ func TestMultiClient_SubscribeFilterLogs_Error(t *testing.T) {
 		Return((ethereum.Subscription)(nil), fmt.Errorf("subscription error")).
 		Times(1)
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mock1"},
-		clients:     []SingleClientProvider{mockClient},
-		clientsMu:   make([]sync.Mutex, 1),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient)
 
 	subscription, err := mc.SubscribeFilterLogs(t.Context(), query, logCh)
 	require.Error(t, err)
@@ -1084,13 +993,7 @@ func TestMultiClient_FilterLogs(t *testing.T) {
 		Return(expectedLogs, nil).
 		Times(1)
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mock1"},
-		clients:     []SingleClientProvider{mockClient},
-		clientsMu:   make([]sync.Mutex, 1),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient)
 
 	logs, err := mc.FilterLogs(t.Context(), query)
 	require.NoError(t, err)
@@ -1117,13 +1020,7 @@ func TestMultiClient_FilterLogs_Error(t *testing.T) {
 		Return(nil, fmt.Errorf("filtering error")).
 		Times(1)
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mock1"},
-		clients:     []SingleClientProvider{mockClient},
-		clientsMu:   make([]sync.Mutex, 1),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient)
 
 	logs, err := mc.FilterLogs(t.Context(), query)
 	require.Error(t, err)
@@ -1135,11 +1032,8 @@ func TestMultiClient_Filterer(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	mc := &MultiClient{
-		contractAddress: ethcommon.HexToAddress("0x1234"),
-		logger:          log.TestLogger(t),
-		closed:          make(chan struct{}),
-	}
+	mc := newTestMultiClient(t)
+	mc.contractAddress = ethcommon.HexToAddress("0x1234")
 
 	filterer, err := mc.Filterer()
 	require.NoError(t, err)
@@ -1151,11 +1045,8 @@ func TestMultiClient_Filterer_Integration(t *testing.T) {
 	defer ctrl.Finish()
 
 	contractAddr := ethcommon.HexToAddress("0x1234")
-	mc := &MultiClient{
-		contractAddress: contractAddr,
-		logger:          log.TestLogger(t),
-		closed:          make(chan struct{}),
-	}
+	mc := newTestMultiClient(t)
+	mc.contractAddress = contractAddr
 
 	filterer, err := mc.Filterer()
 	require.NoError(t, err)
@@ -1181,10 +1072,7 @@ func TestMultiClient_Filterer_Integration(t *testing.T) {
 }
 
 func TestMultiClient_ChainID(t *testing.T) {
-	mc := &MultiClient{
-		logger: log.TestLogger(t),
-		closed: make(chan struct{}),
-	}
+	mc := newTestMultiClient(t)
 	mc.chainID.Store(big.NewInt(5))
 
 	cid, err := mc.ChainID(t.Context())
@@ -1193,10 +1081,7 @@ func TestMultiClient_ChainID(t *testing.T) {
 }
 
 func TestMultiClient_ChainID_NotSet(t *testing.T) {
-	mc := &MultiClient{
-		logger: log.TestLogger(t),
-		closed: make(chan struct{}),
-	}
+	mc := newTestMultiClient(t)
 
 	cid, err := mc.ChainID(t.Context())
 	require.NoError(t, err)
@@ -1222,13 +1107,7 @@ func TestMultiClient_Close(t *testing.T) {
 		Return(errors.New("close error")).
 		Times(1)
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mock1", "mock2"},
-		clients:     []SingleClientProvider{mockClient1, mockClient2},
-		clientsMu:   make([]sync.Mutex, 2),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient1, mockClient2)
 
 	err := mc.Close()
 	// Should combine errors if multiple close calls fail.
@@ -1262,13 +1141,7 @@ func TestMultiClient_Close_MultiClient(t *testing.T) {
 		Return(nil).
 		Times(1)
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mockNode1", "mockNode2", "mockNode3"},
-		clients:     []SingleClientProvider{mockClient1, mockClient2, mockClient3},
-		clientsMu:   make([]sync.Mutex, 3),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient1, mockClient2, mockClient3)
 
 	err := mc.Close()
 	// Should combine errors if multiple close calls fail.
@@ -1296,13 +1169,7 @@ func TestMultiClient_Call_Concurrency(t *testing.T) {
 		}).
 		Times(10)
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mock1"},
-		clients:     []SingleClientProvider{mockClient},
-		clientsMu:   make([]sync.Mutex, 1),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient)
 
 	var wg sync.WaitGroup
 	wg.Add(10)
@@ -1349,13 +1216,7 @@ func TestMultiClient_Call_AllClientsFail(t *testing.T) {
 		Return(uint64(0), false, fmt.Errorf("another streaming error")).
 		Times(1)
 
-	mc := &MultiClient{
-		clientAddrs: []string{"mockNode1", "mockNode2"},
-		clients:     []SingleClientProvider{mockClient1, mockClient2},
-		clientsMu:   make([]sync.Mutex, 2),
-		logger:      log.TestLogger(t),
-		closed:      make(chan struct{}),
-	}
+	mc := newTestMultiClient(t, mockClient1, mockClient2)
 
 	// Define a simple function to simulate a call
 	f := func(client SingleClientProvider) (any, error) {

--- a/eth/executionclient/multi_client_test.go
+++ b/eth/executionclient/multi_client_test.go
@@ -134,9 +134,6 @@ func TestNewMulti(t *testing.T) {
 }
 
 func TestMultiClient_assertSameChainIDs(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	mc := newTestMultiClient(t)
 
 	expected, ok := mc.assertSameChainID(big.NewInt(5))
@@ -153,9 +150,6 @@ func TestMultiClient_assertSameChainIDs(t *testing.T) {
 }
 
 func TestMultiClient_assertSameChainIDs_Error(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	mc := newTestMultiClient(t)
 
 	expected, ok := mc.assertSameChainID(big.NewInt(5))
@@ -1029,9 +1023,6 @@ func TestMultiClient_FilterLogs_Error(t *testing.T) {
 }
 
 func TestMultiClient_Filterer(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	mc := newTestMultiClient(t)
 	mc.contractAddress = ethcommon.HexToAddress("0x1234")
 
@@ -1041,9 +1032,6 @@ func TestMultiClient_Filterer(t *testing.T) {
 }
 
 func TestMultiClient_Filterer_Integration(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	contractAddr := ethcommon.HexToAddress("0x1234")
 	mc := newTestMultiClient(t)
 	mc.contractAddress = contractAddr

--- a/eth/executionclient/multi_client_test.go
+++ b/eth/executionclient/multi_client_test.go
@@ -843,6 +843,14 @@ func TestMultiClient_Healthy_AllClientsUnhealthy(t *testing.T) {
 	require.Contains(t, err.Error(), "client2 unhealthy")
 }
 
+func TestMultiClient_Healthy_NoClients(t *testing.T) {
+	mc := newTestMultiClient(t)
+
+	err := mc.Healthy(t.Context())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no clients configured")
+}
+
 func TestMultiClient_HeaderByNumber(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
## Summary

Follow-up to #3004 (now merged, so this PR stands alone). Refactor of the `MultiClient` tests, plus two small defensive guards in `MultiClient` itself that fell out of review.

The tests hand-rolled the `&MultiClient{...}` literal **30 times**, each re-initializing `closed` / `logger` / `clientsMu` — the exact boilerplate whose omission caused the `close of nil channel` panic that #3004 fixes. One literal (`TestMultiClient_assertSameChainIDs`) had already drifted and left `closed` unset, proving the point.

## Changes

- Add a single `newTestMultiClient(t, clients...)` helper that wires the test logger, an initialized `closed` channel, and `clientAddrs`/`clientsMu` sized to the given clients. All 30 construction sites now route through it, so `closed` can't be forgotten again.
- Client addresses are opaque labels in these tests (verified: never referenced or asserted on outside the literals), so the helper generates them — which is why call sites collapse to just the clients.
- The 2 sites that set `contractAddress` and the 1 that sets `chainID` keep those as explicit post-construction assignments (they're the field under test there).
- Close the client in `TestNewMulti`'s second subtest, matching the first (the consistency gap noted in review).
- Drop the unused `gomock.NewController` setup from the 4 tests that use no mocks.
- Guard `MultiClient.call` and `MultiClient.Healthy` against a zero-client `MultiClient`: `call` panicked with an integer divide-by-zero (round-robin index math is `% len(mc.clients)`), and `Healthy` returned an error wrapping a nil error (formats as `%!w(<nil>)`). `NewMulti` guarantees at least one client, so both guards are defensive-only; each comes with a regression test.

## Notes

- Production changes are limited to the two defensive guards above; everything else is test-only. Net **−120 lines**.
- Removing the repeated address-string literals also clears the package's pre-existing `goconst` lint warnings (`golangci-lint run ./eth/executionclient/...` → `0 issues`).
- Verified with `go test -race ./eth/executionclient/` (green), `go vet`, and `gofmt`.

## Review / merge order

Originally stacked on #3004; that PR has merged into `stage`, so this one now carries only its own commits and can merge independently.
