### PR TITLE
message/validation, network: level self-publish validation drops by outcome

### DIFF
--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -145,6 +145,23 @@ func (mv *messageValidator) handleValidationError(ctx context.Context, peerID pe
 		With(loggerFields.AsZapFields()...).
 		With(fields.PeerID(peerID))
 
+	// A discard of one of our own outbound messages (see isSelfPeer) is routine and usually benign
+	// — e.g. a decided message a peer already propagated before we published ours — so ignores are
+	// logged at debug rather than surfaced as a failed publish. A self-reject, though, means we
+	// produced a message our own validation refuses, a local bug worth a warn. The specific reason
+	// is surfaced here because the publisher only sees a generic pubsub.ValidationError.
+	if mv.isSelfPeer(peerID) {
+		var valErr Error
+		if errors.As(err, &valErr) && valErr.Reject() {
+			recordRejectedMessage(ctx, loggerFields.Role, valErr.Text())
+			logger.Warn("own outbound message rejected by local validation", zap.Error(err))
+			return pubsub.ValidationReject
+		}
+		recordIgnoredMessage(ctx, loggerFields.Role, discardReason(err))
+		logger.Debug("own outbound message ignored by local validation", zap.Error(err))
+		return pubsub.ValidationIgnore
+	}
+
 	switch {
 	case errors.Is(err, context.DeadlineExceeded):
 		recordIgnoredMessage(ctx, loggerFields.Role, validationTimeoutReason)
@@ -172,6 +189,23 @@ func (mv *messageValidator) handleValidationError(ctx context.Context, peerID pe
 	logger.Debug("rejecting invalid message", zap.Error(valErr))
 	recordRejectedMessage(ctx, loggerFields.Role, valErr.Text())
 	return pubsub.ValidationReject
+}
+
+// discardReason returns the metric label describing why a message was discarded, mirroring how
+// handleValidationError classifies the error into a pubsub result.
+func discardReason(err error) string {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return validationTimeoutReason
+	case errors.Is(err, context.Canceled):
+		return validationCanceledReason
+	}
+
+	var valErr Error
+	if errors.As(err, &valErr) {
+		return valErr.Text()
+	}
+	return err.Error()
 }
 
 func (mv *messageValidator) handleValidationSuccess(ctx context.Context, decodedMessage *queue.SSVMessage) pubsub.ValidationResult {

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -175,12 +175,45 @@ func classifyDiscard(err error) (discardKind, string) {
 	return discardIgnored, valErr.Text()
 }
 
-func (mv *messageValidator) handleValidationError(ctx context.Context, peerID peer.ID, decodedMessage *queue.SSVMessage, err error) pubsub.ValidationResult {
+// routineSelfIgnores are the ignore-classified errors that are benign for our own outbound
+// publishes: our validator's own state dedup (ErrDuplicatedMessage, ErrDecidedMessageWithTooFewSigners)
+// and slot/round-timing races between building a message and validating it. These stay at debug.
+//
+// Reject-vs-ignore is inbound peer-scoring policy, not how bad a drop is for us, so it can't level
+// our own drops: any other self-ignore means we published something our own validation won't pass
+// (wrong topic/domain, oversized, unknown validator/duty) and warrants a warn. Errors not listed
+// here default to warn.
+var routineSelfIgnores = []error{
+	ErrDuplicatedMessage,
+	ErrDecidedMessageWithTooFewSigners,
+	ErrSlotAlreadyAdvanced,
+	ErrRoundAlreadyAdvanced,
+	ErrEarlySlotMessage,
+	ErrLateSlotMessage,
+	ErrEstimatedRoundNotInAllowedSpread,
+}
+
+// isRoutineSelfIgnore reports whether err is one of the benign self-ignores in routineSelfIgnores.
+func isRoutineSelfIgnore(err error) bool {
+	for _, benign := range routineSelfIgnores {
+		if errors.Is(err, benign) {
+			return true
+		}
+	}
+	return false
+}
+
+func (mv *messageValidator) handleValidationError(ctx context.Context, peerID peer.ID, topic string, decodedMessage *queue.SSVMessage, err error) pubsub.ValidationResult {
 	loggerFields := mv.buildLoggerFields(decodedMessage)
 
 	logger := mv.logger.
 		With(loggerFields.AsZapFields()...).
 		With(fields.PeerID(peerID))
+	if topic != "" {
+		// On pre-decode discards decodedMessage is nil, so loggerFields carries no role/slot/duty
+		// and topic is the only field identifying what we dropped.
+		logger = logger.With(fields.Topic(topic))
+	}
 
 	kind, reason := classifyDiscard(err)
 
@@ -193,19 +226,26 @@ func (mv *messageValidator) handleValidationError(ctx context.Context, peerID pe
 	}
 
 	// A discard of one of our own outbound messages (see isSelfPeer) is leveled by what it says
-	// about this node: an ignored verdict is routine (e.g. a decided message a peer already
-	// propagated before we published ours) and a cancellation is shutdown noise — debug; a reject
-	// (we produced a message our own validation refuses) or a timeout (the message was never
-	// published because local validation was too slow) is a local problem — warn. The specific
-	// reason is logged here because the publisher only sees a generic pubsub.ValidationError.
+	// about this node: debug for the expected (a routine self-ignore or a shutdown cancellation),
+	// warn for the concerning (a reject or non-routine ignore means our own validation refuses a
+	// message we published; a timeout means it was never published). The reason is logged here
+	// because the publisher only sees a generic pubsub.ValidationError.
 	if mv.isSelfPeer(peerID) {
 		switch kind {
 		case discardRejected:
 			logger.Warn("own outbound message rejected by local validation", zap.Error(err))
 		case discardTimeout:
 			logger.Warn("own outbound message dropped by local validation timeout", zap.Error(err))
+		case discardCanceled:
+			logger.Debug("own outbound message discarded by local validation cancellation", zap.Error(err))
+		case discardIgnored:
+			if isRoutineSelfIgnore(err) {
+				logger.Debug("own outbound message ignored by local validation", zap.Error(err))
+			} else {
+				logger.Warn("own outbound message ignored by local validation (unexpected)", zap.Error(err))
+			}
 		default:
-			logger.Debug("own outbound message ignored by local validation", zap.Error(err))
+			logger.Debug("own outbound message discarded by local validation", zap.Error(err))
 		}
 		return result
 	}
@@ -217,8 +257,10 @@ func (mv *messageValidator) handleValidationError(ctx context.Context, peerID pe
 		logger.Debug("ignoring message due to validation cancellation", zap.Error(err))
 	case discardRejected:
 		logger.Debug("rejecting invalid message", zap.Error(err))
-	default:
+	case discardIgnored:
 		logger.Debug("ignoring invalid message", zap.Error(err))
+	default:
+		logger.Debug("discarding invalid message", zap.Error(err))
 	}
 	return result
 }

--- a/message/validation/errors.go
+++ b/message/validation/errors.go
@@ -138,6 +138,43 @@ var (
 	ErrZeroRound                                       = Error{text: "zero round", reject: true}
 )
 
+// discardKind classifies why a message is being discarded. handleValidationError derives the
+// pubsub result, the metric, and the log level/message from it, so classification is decided
+// in exactly one place (classifyDiscard).
+type discardKind int
+
+const (
+	// discardIgnored is an ignore-classified validation verdict (or an unclassified error).
+	discardIgnored discardKind = iota
+	// discardTimeout means validation ran out of time and the message was dropped unvalidated.
+	discardTimeout
+	// discardCanceled means validation was interrupted, typically by node shutdown.
+	discardCanceled
+	// discardRejected is a reject-classified validation verdict.
+	discardRejected
+)
+
+// classifyDiscard maps a validation error to its discard kind and metric reason label. Context
+// sentinels take precedence over verdict classification: an error that descends from a
+// timeout/cancellation is a validation that didn't finish, not a verdict.
+func classifyDiscard(err error) (discardKind, string) {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return discardTimeout, validationTimeoutReason
+	case errors.Is(err, context.Canceled):
+		return discardCanceled, validationCanceledReason
+	}
+
+	var valErr Error
+	if !errors.As(err, &valErr) {
+		return discardIgnored, err.Error()
+	}
+	if valErr.Reject() {
+		return discardRejected, valErr.Text()
+	}
+	return discardIgnored, valErr.Text()
+}
+
 func (mv *messageValidator) handleValidationError(ctx context.Context, peerID peer.ID, decodedMessage *queue.SSVMessage, err error) pubsub.ValidationResult {
 	loggerFields := mv.buildLoggerFields(decodedMessage)
 
@@ -145,67 +182,45 @@ func (mv *messageValidator) handleValidationError(ctx context.Context, peerID pe
 		With(loggerFields.AsZapFields()...).
 		With(fields.PeerID(peerID))
 
-	// A discard of one of our own outbound messages (see isSelfPeer) is routine and usually benign
-	// — e.g. a decided message a peer already propagated before we published ours — so ignores are
-	// logged at debug rather than surfaced as a failed publish. A self-reject, though, means we
-	// produced a message our own validation refuses, a local bug worth a warn. The specific reason
-	// is surfaced here because the publisher only sees a generic pubsub.ValidationError.
+	kind, reason := classifyDiscard(err)
+
+	result := pubsub.ValidationIgnore
+	if kind == discardRejected {
+		result = pubsub.ValidationReject
+		recordRejectedMessage(ctx, loggerFields.Role, reason)
+	} else {
+		recordIgnoredMessage(ctx, loggerFields.Role, reason)
+	}
+
+	// A discard of one of our own outbound messages (see isSelfPeer) is leveled by what it says
+	// about this node: an ignored verdict is routine (e.g. a decided message a peer already
+	// propagated before we published ours) and a cancellation is shutdown noise — debug; a reject
+	// (we produced a message our own validation refuses) or a timeout (the message was never
+	// published because local validation was too slow) is a local problem — warn. The specific
+	// reason is logged here because the publisher only sees a generic pubsub.ValidationError.
 	if mv.isSelfPeer(peerID) {
-		var valErr Error
-		if errors.As(err, &valErr) && valErr.Reject() {
-			recordRejectedMessage(ctx, loggerFields.Role, valErr.Text())
+		switch kind {
+		case discardRejected:
 			logger.Warn("own outbound message rejected by local validation", zap.Error(err))
-			return pubsub.ValidationReject
+		case discardTimeout:
+			logger.Warn("own outbound message dropped by local validation timeout", zap.Error(err))
+		default:
+			logger.Debug("own outbound message ignored by local validation", zap.Error(err))
 		}
-		recordIgnoredMessage(ctx, loggerFields.Role, discardReason(err))
-		logger.Debug("own outbound message ignored by local validation", zap.Error(err))
-		return pubsub.ValidationIgnore
+		return result
 	}
 
-	switch {
-	case errors.Is(err, context.DeadlineExceeded):
-		recordIgnoredMessage(ctx, loggerFields.Role, validationTimeoutReason)
+	switch kind {
+	case discardTimeout:
 		logger.Debug("ignoring message due to validation timeout", zap.Error(err))
-		return pubsub.ValidationIgnore
-	case errors.Is(err, context.Canceled):
-		recordIgnoredMessage(ctx, loggerFields.Role, validationCanceledReason)
+	case discardCanceled:
 		logger.Debug("ignoring message due to validation cancellation", zap.Error(err))
-		return pubsub.ValidationIgnore
-	}
-
-	var valErr Error
-	if !errors.As(err, &valErr) {
-		recordIgnoredMessage(ctx, loggerFields.Role, err.Error())
+	case discardRejected:
+		logger.Debug("rejecting invalid message", zap.Error(err))
+	default:
 		logger.Debug("ignoring invalid message", zap.Error(err))
-		return pubsub.ValidationIgnore
 	}
-
-	if !valErr.Reject() {
-		logger.Debug("ignoring invalid message", zap.Error(valErr))
-		recordIgnoredMessage(ctx, loggerFields.Role, valErr.Text())
-		return pubsub.ValidationIgnore
-	}
-
-	logger.Debug("rejecting invalid message", zap.Error(valErr))
-	recordRejectedMessage(ctx, loggerFields.Role, valErr.Text())
-	return pubsub.ValidationReject
-}
-
-// discardReason returns the metric label describing why a message was discarded, mirroring how
-// handleValidationError classifies the error into a pubsub result.
-func discardReason(err error) string {
-	switch {
-	case errors.Is(err, context.DeadlineExceeded):
-		return validationTimeoutReason
-	case errors.Is(err, context.Canceled):
-		return validationCanceledReason
-	}
-
-	var valErr Error
-	if errors.As(err, &valErr) {
-		return valErr.Text()
-	}
-	return err.Error()
+	return result
 }
 
 func (mv *messageValidator) handleValidationSuccess(ctx context.Context, decodedMessage *queue.SSVMessage) pubsub.ValidationResult {

--- a/message/validation/errors_test.go
+++ b/message/validation/errors_test.go
@@ -14,9 +14,11 @@ import (
 
 // TestHandleValidationError_SelfDiscardLeveling pins the logging contract for validation discards:
 // our own outbound messages (peerID == selfPID) are leveled by what the discard says about this
-// node — ignores and cancellations at debug (routine dedup, shutdown), rejects and timeouts at
-// warn (own message refused by own validation, or never published because validation was too
-// slow) — while messages received from peers keep their existing debug logging.
+// node — a routine self-ignore (own dedup / benign slot-timing race, see routineSelfIgnores) and a
+// cancellation (shutdown) at debug, while a reject, a timeout, or any non-routine ignore is at warn
+// (own message refused by own validation, or never published because validation was too slow) —
+// while messages received from peers keep their existing debug logging. It also pins that the topic
+// threaded in by the caller is logged even when the message never decoded (nil decodedMessage).
 func TestHandleValidationError_SelfDiscardLeveling(t *testing.T) {
 	const self = peer.ID("self")
 	const other = peer.ID("other")
@@ -25,37 +27,48 @@ func TestHandleValidationError_SelfDiscardLeveling(t *testing.T) {
 		name       string
 		selfPID    peer.ID
 		peerID     peer.ID
+		topic      string
 		err        error
 		wantResult pubsub.ValidationResult
 		wantLevel  zapcore.Level
 		wantMsg    string
 	}{
 		{
-			name:       "own ignored message is quiet (debug)",
+			name:       "own routine ignore is quiet (debug)",
 			selfPID:    self,
 			peerID:     self,
-			err:        ErrDecidedMessageWithTooFewSigners, // non-reject -> ignore
+			err:        ErrDecidedMessageWithTooFewSigners, // non-reject, routine -> ignore/debug
 			wantResult: pubsub.ValidationIgnore,
 			wantLevel:  zapcore.DebugLevel,
 			wantMsg:    "own outbound message ignored by local validation",
 		},
 		{
-			name:       "own rejected message is surfaced (warn)",
+			name:       "own non-routine ignore is surfaced (warn)",
 			selfPID:    self,
 			peerID:     self,
-			err:        ErrEmptyData, // reject:true -> reject
+			err:        ErrIncorrectTopic, // non-reject but not routine -> ignore/warn
+			wantResult: pubsub.ValidationIgnore,
+			wantLevel:  zapcore.WarnLevel,
+			wantMsg:    "own outbound message ignored by local validation (unexpected)",
+		},
+		{
+			name:       "own rejected message is surfaced (warn) with topic",
+			selfPID:    self,
+			peerID:     self,
+			topic:      "ssv.v2.some-topic", // pre-decode reject -> nil decodedMessage; topic is all we have
+			err:        ErrEmptyData,        // reject:true -> reject
 			wantResult: pubsub.ValidationReject,
 			wantLevel:  zapcore.WarnLevel,
 			wantMsg:    "own outbound message rejected by local validation",
 		},
 		{
-			name:       "own ignore via context cancellation is quiet (debug)",
+			name:       "own cancellation is quiet (debug)",
 			selfPID:    self,
 			peerID:     self,
 			err:        context.Canceled,
 			wantResult: pubsub.ValidationIgnore,
 			wantLevel:  zapcore.DebugLevel,
-			wantMsg:    "own outbound message ignored by local validation",
+			wantMsg:    "own outbound message discarded by local validation cancellation",
 		},
 		{
 			name:       "own drop via validation timeout is surfaced (warn)",
@@ -79,7 +92,7 @@ func TestHandleValidationError_SelfDiscardLeveling(t *testing.T) {
 			name:       "inbound ignore keeps existing debug log",
 			selfPID:    self,
 			peerID:     other,
-			err:        ErrDecidedMessageWithTooFewSigners,
+			err:        ErrIncorrectTopic, // non-routine for self, but inbound stays debug
 			wantResult: pubsub.ValidationIgnore,
 			wantLevel:  zapcore.DebugLevel,
 			wantMsg:    "ignoring invalid message",
@@ -112,13 +125,17 @@ func TestHandleValidationError_SelfDiscardLeveling(t *testing.T) {
 				selfPID: tt.selfPID,
 			}
 
-			got := mv.handleValidationError(context.Background(), tt.peerID, nil, tt.err)
+			got := mv.handleValidationError(context.Background(), tt.peerID, tt.topic, nil, tt.err)
 			require.Equal(t, tt.wantResult, got)
 
 			entries := logs.All()
 			require.Len(t, entries, 1, "expected exactly one log entry")
 			require.Equal(t, tt.wantLevel, entries[0].Level)
 			require.Equal(t, tt.wantMsg, entries[0].Message)
+			if tt.topic != "" {
+				require.Equal(t, tt.topic, entries[0].ContextMap()["topic"],
+					"topic threaded by the caller must be logged even with nil decodedMessage")
+			}
 		})
 	}
 }

--- a/message/validation/errors_test.go
+++ b/message/validation/errors_test.go
@@ -1,0 +1,105 @@
+package validation
+
+import (
+	"context"
+	"testing"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestHandleValidationError_SelfDiscardLeveling pins the logging contract for validation discards:
+// our own outbound messages (peerID == selfPID) are logged distinctly — ignores quietly at debug
+// (routine, e.g. decided-message dedup), rejects loudly at warn (we produced a message our own
+// validation refuses) — while messages received from peers keep their existing debug logging.
+func TestHandleValidationError_SelfDiscardLeveling(t *testing.T) {
+	const self = peer.ID("self")
+	const other = peer.ID("other")
+
+	tests := []struct {
+		name       string
+		selfPID    peer.ID
+		peerID     peer.ID
+		err        error
+		wantResult pubsub.ValidationResult
+		wantLevel  zapcore.Level
+		wantMsg    string
+	}{
+		{
+			name:       "own ignored message is quiet (debug)",
+			selfPID:    self,
+			peerID:     self,
+			err:        ErrDecidedMessageWithTooFewSigners, // non-reject -> ignore
+			wantResult: pubsub.ValidationIgnore,
+			wantLevel:  zapcore.DebugLevel,
+			wantMsg:    "own outbound message ignored by local validation",
+		},
+		{
+			name:       "own rejected message is surfaced (warn)",
+			selfPID:    self,
+			peerID:     self,
+			err:        ErrEmptyData, // reject:true -> reject
+			wantResult: pubsub.ValidationReject,
+			wantLevel:  zapcore.WarnLevel,
+			wantMsg:    "own outbound message rejected by local validation",
+		},
+		{
+			name:       "own ignore via context cancellation is quiet (debug)",
+			selfPID:    self,
+			peerID:     self,
+			err:        context.Canceled,
+			wantResult: pubsub.ValidationIgnore,
+			wantLevel:  zapcore.DebugLevel,
+			wantMsg:    "own outbound message ignored by local validation",
+		},
+		{
+			name:       "inbound ignore keeps existing debug log",
+			selfPID:    self,
+			peerID:     other,
+			err:        ErrDecidedMessageWithTooFewSigners,
+			wantResult: pubsub.ValidationIgnore,
+			wantLevel:  zapcore.DebugLevel,
+			wantMsg:    "ignoring invalid message",
+		},
+		{
+			name:       "inbound reject stays debug (not our bug)",
+			selfPID:    self,
+			peerID:     other,
+			err:        ErrEmptyData,
+			wantResult: pubsub.ValidationReject,
+			wantLevel:  zapcore.DebugLevel,
+			wantMsg:    "rejecting invalid message",
+		},
+		{
+			name:       "unset selfPID falls back to inbound handling",
+			selfPID:    "",
+			peerID:     self,
+			err:        ErrDecidedMessageWithTooFewSigners,
+			wantResult: pubsub.ValidationIgnore,
+			wantLevel:  zapcore.DebugLevel,
+			wantMsg:    "ignoring invalid message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, logs := observer.New(zapcore.DebugLevel)
+			mv := &messageValidator{
+				logger:  zap.New(core),
+				selfPID: tt.selfPID,
+			}
+
+			got := mv.handleValidationError(context.Background(), tt.peerID, nil, tt.err)
+			require.Equal(t, tt.wantResult, got)
+
+			entries := logs.All()
+			require.Len(t, entries, 1, "expected exactly one log entry")
+			require.Equal(t, tt.wantLevel, entries[0].Level)
+			require.Equal(t, tt.wantMsg, entries[0].Message)
+		})
+	}
+}

--- a/message/validation/errors_test.go
+++ b/message/validation/errors_test.go
@@ -13,9 +13,10 @@ import (
 )
 
 // TestHandleValidationError_SelfDiscardLeveling pins the logging contract for validation discards:
-// our own outbound messages (peerID == selfPID) are logged distinctly — ignores quietly at debug
-// (routine, e.g. decided-message dedup), rejects loudly at warn (we produced a message our own
-// validation refuses) — while messages received from peers keep their existing debug logging.
+// our own outbound messages (peerID == selfPID) are leveled by what the discard says about this
+// node — ignores and cancellations at debug (routine dedup, shutdown), rejects and timeouts at
+// warn (own message refused by own validation, or never published because validation was too
+// slow) — while messages received from peers keep their existing debug logging.
 func TestHandleValidationError_SelfDiscardLeveling(t *testing.T) {
 	const self = peer.ID("self")
 	const other = peer.ID("other")
@@ -55,6 +56,24 @@ func TestHandleValidationError_SelfDiscardLeveling(t *testing.T) {
 			wantResult: pubsub.ValidationIgnore,
 			wantLevel:  zapcore.DebugLevel,
 			wantMsg:    "own outbound message ignored by local validation",
+		},
+		{
+			name:       "own drop via validation timeout is surfaced (warn)",
+			selfPID:    self,
+			peerID:     self,
+			err:        context.DeadlineExceeded,
+			wantResult: pubsub.ValidationIgnore,
+			wantLevel:  zapcore.WarnLevel,
+			wantMsg:    "own outbound message dropped by local validation timeout",
+		},
+		{
+			name:       "inbound timeout keeps existing debug log",
+			selfPID:    self,
+			peerID:     other,
+			err:        context.DeadlineExceeded,
+			wantResult: pubsub.ValidationIgnore,
+			wantLevel:  zapcore.DebugLevel,
+			wantMsg:    "ignoring message due to validation timeout",
 		},
 		{
 			name:       "inbound ignore keeps existing debug log",

--- a/message/validation/validation.go
+++ b/message/validation/validation.go
@@ -138,7 +138,7 @@ func (mv *messageValidator) Validate(ctx context.Context, peerID peer.ID, pmsg *
 	}
 
 	if err := ctx.Err(); err != nil {
-		return mv.handleValidationError(ctx, peerID, nil, err)
+		return mv.handleValidationError(ctx, peerID, pmsg.GetTopic(), nil, err)
 	}
 
 	validationStart := time.Now()
@@ -150,7 +150,7 @@ func (mv *messageValidator) Validate(ctx context.Context, peerID peer.ID, pmsg *
 	}()
 
 	if err != nil {
-		return mv.handleValidationError(ctx, peerID, decodedMessage, err)
+		return mv.handleValidationError(ctx, peerID, pmsg.GetTopic(), decodedMessage, err)
 	}
 
 	pmsg.ValidatorData = decodedMessage

--- a/message/validation/validation.go
+++ b/message/validation/validation.go
@@ -34,6 +34,11 @@ import (
 type MessageValidator interface {
 	ValidatorForTopic(topic string) func(ctx context.Context, p peer.ID, pmsg *pubsub.Message) pubsub.ValidationResult
 	Validate(ctx context.Context, p peer.ID, pmsg *pubsub.Message) pubsub.ValidationResult
+	// SetSelfPID records this node's own libp2p peer ID so the validator can recognize the messages
+	// it publishes itself (gossipsub validates outbound messages locally). It does not bypass
+	// validation — it only affects how self-discards are logged. Call once during setup, before
+	// validation begins.
+	SetSelfPID(pid peer.ID)
 }
 
 // operators defines the minimal interface needed for validation
@@ -107,6 +112,16 @@ func New(
 	go mv.states.Start()
 
 	return mv
+}
+
+func (mv *messageValidator) SetSelfPID(pid peer.ID) {
+	mv.selfPID = pid
+}
+
+// isSelfPeer reports whether peerID is this node's own peer — i.e. a message we are publishing
+// ourselves, which gossipsub routes through validation with peerID set to our host ID.
+func (mv *messageValidator) isSelfPeer(peerID peer.ID) bool {
+	return mv.selfPID != "" && peerID == mv.selfPID
 }
 
 // ValidatorForTopic returns a validation function for the given topic.

--- a/network/p2p/p2p_setup.go
+++ b/network/p2p/p2p_setup.go
@@ -83,6 +83,13 @@ func (n *p2pNetwork) Setup() error {
 	logger = logger.With(zap.String("selfPeer", n.Host().ID().String()))
 	logger.Debug("host configured")
 
+	// Let the message validator recognize the messages we publish ourselves: gossipsub validates
+	// outbound messages locally, and self-discards should be logged as such rather than as publish
+	// failures. Must run before SetupServices wires the validator into pubsub.
+	if n.msgValidator != nil {
+		n.msgValidator.SetSelfPID(n.Host().ID())
+	}
+
 	err = n.SetupServices()
 	if err != nil {
 		return err

--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -492,6 +492,8 @@ func (v *MockMessageValidator) Validate(ctx context.Context, p peer.ID, pmsg *pu
 	return v.ValidateFunc(ctx, p, pmsg)
 }
 
+func (v *MockMessageValidator) SetSelfPID(peer.ID) {}
+
 type NodeIndex int
 
 type VirtualNode struct {

--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -451,6 +451,19 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 		t.Fatalf("peer score inspector: %s", *msg)
 	}
 
+	// Pin the assumption message/validation's self-discard leveling rests on (see
+	// MessageValidator.SetSelfPID): gossipsub runs every locally published message through the
+	// publishing node's own validator, with peerID set to that node's own host ID. Those
+	// self-deliveries are counted on the diagonal (a validator's own index), so a pubsub upgrade
+	// that changes this fails here rather than silently reverting self-discards to inbound-style
+	// logging.
+	mtx.Lock()
+	for i := 0; i < nodeCount; i++ {
+		selfSeen := messageValidators[i].Accepted[i] + messageValidators[i].Ignored[i] + messageValidators[i].Rejected[i]
+		require.Positivef(t, selfSeen, "node %d: own validator never saw the node's own publishes (peerID == own host ID)", i)
+	}
+	mtx.Unlock()
+
 	// Backfill any observer that never latched with its current snapshot so the
 	// diagnostics below report which invariant on which node actually failed
 	// (the loop only records the passing ones).

--- a/network/p2p/p2p_validation_test.go
+++ b/network/p2p/p2p_validation_test.go
@@ -457,12 +457,18 @@ func TestP2pNetwork_MessageValidation(t *testing.T) {
 	// self-deliveries are counted on the diagonal (a validator's own index), so a pubsub upgrade
 	// that changes this fails here rather than silently reverting self-discards to inbound-style
 	// logging.
+	// Snapshot under the lock, then assert after releasing it: require.Positivef calls FailNow
+	// (runtime.Goexit) on failure, which would leak a held mtx and deadlock the score-table cleanup
+	// and any in-flight ValidateFunc that take the same lock — hanging the package until -timeout.
+	selfSeen := make([]int, nodeCount)
 	mtx.Lock()
 	for i := 0; i < nodeCount; i++ {
-		selfSeen := messageValidators[i].Accepted[i] + messageValidators[i].Ignored[i] + messageValidators[i].Rejected[i]
-		require.Positivef(t, selfSeen, "node %d: own validator never saw the node's own publishes (peerID == own host ID)", i)
+		selfSeen[i] = messageValidators[i].Accepted[i] + messageValidators[i].Ignored[i] + messageValidators[i].Rejected[i]
 	}
 	mtx.Unlock()
+	for i := 0; i < nodeCount; i++ {
+		require.Positivef(t, selfSeen[i], "node %d: own validator never saw the node's own publishes (peerID == own host ID)", i)
+	}
 
 	// Backfill any observer that never latched with its current snapshot so the
 	// diagnostics below report which invariant on which node actually failed

--- a/network/p2p/testutils.go
+++ b/network/p2p/testutils.go
@@ -47,9 +47,10 @@ func randomMdnsTag() string {
 	return fmt.Sprintf("ssv.test.%016x", rand.Uint64()) //nolint: gosec // G404 is acceptable here
 }
 
-// CreateAndStartLocalNet creates a new local network and starts it
-// if any errors occurs during starting local network CreateAndStartLocalNet trying
-// to create and start local net one more time until pCtx is not Done()
+// CreateAndStartLocalNet creates a LocalNet and starts its nodes, retrying the whole setup
+// (up to maxAttempts) when the mesh doesn't form in time — discovery can be slow on a loaded
+// machine. Bounding the retries makes an environment where the nodes can never connect (mDNS
+// discovery needs multicast) fail fast instead of hanging until the go-test timeout.
 func CreateAndStartLocalNet(pCtx context.Context, logger *zap.Logger, options LocalNetOptions) (*LocalNet, error) {
 	attempt := func(pCtx context.Context) (*LocalNet, error) {
 		ln, err := NewLocalNet(pCtx, logger, options)
@@ -91,8 +92,9 @@ func CreateAndStartLocalNet(pCtx context.Context, logger *zap.Logger, options Lo
 		return ln, eg.Wait()
 	}
 
+	const maxAttempts = 3
 	var lastErr error
-	for {
+	for attemptNum := 1; ; attemptNum++ {
 		select {
 		case <-pCtx.Done():
 			if lastErr != nil {
@@ -115,6 +117,9 @@ func CreateAndStartLocalNet(pCtx context.Context, logger *zap.Logger, options Lo
 					closeNodesWithTimeout(logger, ln.Nodes, 10*time.Second)
 				}
 
+				if attemptNum == maxAttempts {
+					return nil, fmt.Errorf("network didn't start after %d attempts: %w", maxAttempts, lastErr)
+				}
 				logger.Debug("trying to relaunch local network", zap.Error(err))
 				continue
 			}

--- a/network/topics/controller.go
+++ b/network/topics/controller.go
@@ -196,6 +196,16 @@ func (ctrl *topicsCtrl) Broadcast(topicName string, data []byte, timeout time.Du
 
 		err := topic.Publish(ctx, data)
 		if err != nil {
+			var valErr pubsub.ValidationError
+			if errors.As(err, &valErr) {
+				// Our own message was declined by local (pre-publish) validation, not by the
+				// transport — not a publish failure. The message validator has already logged the
+				// specific reason (leveled by outcome) and recorded the discard metric, so keep a
+				// quiet breadcrumb for correlation rather than raising an error.
+				ctrl.logger.Debug("outbound message dropped by local validation",
+					zap.String("topic", topicName), zap.String("verdict", valErr.Reason))
+				return
+			}
 			ctrl.logger.Error("could not publish p2p message", zap.String("topic", topicName), zap.Error(err))
 			return
 		}

--- a/network/topics/controller.go
+++ b/network/topics/controller.go
@@ -2,6 +2,7 @@ package topics
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -199,11 +200,15 @@ func (ctrl *topicsCtrl) Broadcast(topicName string, data []byte, timeout time.Du
 			var valErr pubsub.ValidationError
 			if errors.As(err, &valErr) {
 				// Our own message was declined by local (pre-publish) validation, not by the
-				// transport — not a publish failure. The message validator has already logged the
-				// specific reason (leveled by outcome) and recorded the discard metric, so keep a
-				// quiet breadcrumb for correlation rather than raising an error.
+				// transport — not a publish failure. The validator has already logged the specific
+				// reason (leveled by outcome) and recorded the metric, so keep a quiet breadcrumb
+				// rather than raising an error. topic is the key shared with the validator's own
+				// line; msgID is the gossipsub id (as in tracer.go and every receiver's view), which
+				// the validator can't compute without an import cycle back into this package.
 				ctrl.logger.Debug("outbound message dropped by local validation",
-					zap.String("topic", topicName), zap.String("verdict", valErr.Reason))
+					zap.String("topic", topicName),
+					zap.String("msgID", hex.EncodeToString([]byte(MsgID(data)))),
+					zap.String("verdict", valErr.Reason))
 				return
 			}
 			ctrl.logger.Error("could not publish p2p message", zap.String("topic", topicName), zap.Error(err))

--- a/network/topics/controller_test.go
+++ b/network/topics/controller_test.go
@@ -527,3 +527,5 @@ func (m *DummyMessageValidator) ValidatorForTopic(topic string) func(ctx context
 func (m *DummyMessageValidator) Validate(ctx context.Context, p peer.ID, pmsg *pubsub.Message) pubsub.ValidationResult {
 	return pubsub.ValidationAccept
 }
+
+func (m *DummyMessageValidator) SetSelfPID(peer.ID) {}


### PR DESCRIPTION
## Summary

Removes a steady stream of `ERROR "could not publish p2p message" … "validation ignored"` log lines that are actually **benign**, and makes the ones that matter say **why**.

gossipsub runs our own message validator **locally on every publish** before a message goes on the wire. When that validation *ignores* the message — routinely, e.g. our validator's own **state dedup** of a redundant decided message ([`ErrDecidedMessageWithTooFewSigners`](message/validation/consensus_validation.go:271)) — pubsub returns a generic `pubsub.ValidationError{Reason:"validation ignored"}`, which `Broadcast` logged at **ERROR, identically to a real transport failure**. Noise for an expected condition, with no specific reason.

## Approach

Rather than special-case any one rule, treat a validation *verdict* as categorically different from a publish *failure*, and make the **validator the single source of truth** for logging these outcomes (it's the only component that knows the specific reason and full context):

- **`SetSelfPID`** — wire the node's own peer ID into the validator, from the p2p layer right after the host is created ([p2p_setup.go](network/p2p/p2p_setup.go)). This does **not** enable self-accept / bypass validation (that stays test-only); it only lets the validator *recognize* its own outbound messages — gossipsub delivers them to validation with `peerID == our host ID` (pubsub sets `ReceivedFrom = host.ID()` for local publishes).
- **`handleValidationError`** logs a self-discard distinctly, with the specific reason (classification is decided once, in `classifyDiscard`, so levels, metrics, and pubsub results can't drift apart). Reject-vs-ignore encodes inbound peer-scoring policy, not how bad a drop is for us, so self-discards are leveled by benignness instead:
  - **routine ignore → DEBUG** — the dedup / slot-round-timing family (e.g. decided-message dedup); cancellation (shutdown) also stays DEBUG
  - **any other ignore → WARN** — we published something our *own* validation won't pass (wrong topic/domain, oversized, unknown validator/duty); new reasons default here until classified benign
  - **reject → WARN** (we produced a message our *own* validation refuses — a local bug worth surfacing)
  - **timeout → WARN** (our message was never published because local validation was too slow)
- **`Broadcast`** no longer treats a `pubsub.ValidationError` as a publish failure: quiet DEBUG breadcrumb (topic + gossipsub `msgID`) for correlation; **ERROR reserved for genuine transport errors** (topic closed, ctx, etc.).

Inbound (peer) message validation logging is unchanged. The change is topic-agnostic and generalizes to every current and future self-discard reason.

## Test

`TestHandleValidationError_SelfDiscardLeveling` (observer-based) pins the contract across the matrix: self-routine-ignore→debug, self-non-routine-ignore→warn, self-cancellation→debug, self-reject→warn, self-timeout→warn, inbound-ignore/reject/timeout stay debug, unset `selfPID` falls back to inbound handling, and the caller-threaded topic is logged even when the message never decoded. `TestP2pNetwork_MessageValidation` additionally pins the assumption this all rests on: gossipsub delivers local publishes to the publishing node's own validator with `peerID == host.ID()`.

## Verification

- `go build ./...` (whole repo) and `go test ./... -run '^$'` (all test binaries compile) — the `MessageValidator` interface gained `SetSelfPID`; the two test implementers were updated.
- `go test -race ./message/validation/…`, `go vet`, `gofmt` — all clean.
- Pre-existing `network/topics` mdns/multicast test failure is environmental (fails identically on clean `stage`), unrelated to this change; the `network/p2p` LocalNet suite is affected the same way — its setup now fails fast (bounded retries) instead of hanging until the go-test timeout.

## Deliberately out of scope (follow-ups)

- **Metric self/outbound dimension** — `recordIgnoredMessage`/`recordRejectedMessage` still don't distinguish self from inbound, so you can't yet alert on "we're dropping our *own* messages" via metrics (the WARN log covers the concerning case). Adding a `source` attribute means churning the shared record funcs; left for a focused follow-up.
- **Pre-existing `QF1012` staticcheck** nits in `errors.go`'s `Error.Error()` (unrelated, untouched).


