### PR TITLE
ssvsigner: surface upstream failure reasons in error responses and client errors

### DIFF
--- a/ssvsigner/CLAUDE.md
+++ b/ssvsigner/CLAUDE.md
@@ -159,6 +159,7 @@ BATCH_SIZE=20 \
 - Decryption errors return specific status for malformed shares
 - Connection failures trigger retries with exponential backoff
 - Web3Signer errors are propagated with original status codes
+- Keystore-import failures are the exception: the upstream body is withheld (it may echo share key material) and an upstream 422 is remapped to 502
 
 ### Performance Optimizations
 - Per-validator locking prevents concurrent signing conflicts

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -354,32 +355,55 @@ func (c *Client) MissingKeys(ctx context.Context, localKeys []phase0.BLSPubKey) 
 // server can't bloat error messages and logs.
 const maxErrBodyLen = 1024
 
-// errBodyValidator returns a response validator that defers to requests.DefaultValidator
-// and, on a rejected status, captures a bounded copy of the error body into *dst for
-// requestFailedErr to attach. It reads one byte past the cap so truncation is detectable.
+// errBodyValidator runs requests.DefaultValidator and, on a rejected status, captures a
+// bounded copy of the error body into *dst for requestFailedErr to attach, reading one byte
+// past the cap so truncation stays detectable.
+//
+// It returns the validation error directly rather than wrapping it with
+// requests.ValidatorHandler, which labels a successful body capture "handled recovery from
+// invalid response". Capturing the body is the normal path here, so that phrase would be
+// prefixed onto every error (and a capture-read failure would render as a multi-line join);
+// returning the error directly avoids both and still satisfies requests.HasStatusErr.
 func errBodyValidator(dst *string) requests.ResponseHandler {
-	return requests.ValidatorHandler(requests.DefaultValidator, func(resp *http.Response) error {
-		b, err := io.ReadAll(io.LimitReader(resp.Body, maxErrBodyLen+1))
-		if err != nil {
-			return err
+	return func(resp *http.Response) error {
+		err := requests.DefaultValidator(resp)
+		if err == nil {
+			return nil
 		}
-		*dst = string(b)
-		return nil
-	})
+		if b, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrBodyLen+1)); readErr == nil {
+			*dst = string(b)
+		}
+		return err
+	}
 }
 
-// requestFailedErr wraps a failed request error, attaching the captured error body (if
-// any) so callers see the reason reported by the server instead of just a status code.
+// requestFailedErr wraps a failed request error, attaching the reason reported by the
+// server (if any) so callers see it instead of just a status code.
 func requestFailedErr(err error, errBody string) error {
 	// Record whether the body was truncated from its raw length, before TrimSpace can
 	// shrink a whitespace tail back under the cap and hide that content was dropped.
 	truncated := len(errBody) > maxErrBodyLen
 	errBody = strings.TrimSpace(errBody)
-	// Older servers write the zero-value response on errors, which carries no information
-	// ("null" / "{}"), so don't attach it.
-	if errBody == "" || errBody == "null" || errBody == "{}" {
+	if errBody == "" {
 		return fmt.Errorf("request failed: %w", err)
 	}
+
+	// The server reports failures as {"message": ...} (web3signer.ErrorMessage), so a
+	// non-empty message is the reason. A body that parses as JSON without one is the
+	// zero-value success response an older server writes on error — null, {},
+	// {"signature":"0x0…0"} (a zero SignResponse) — with nothing useful, so drop it and let
+	// err's status speak. Keying on the message avoids enumerating those zero values, which
+	// drift as the response structs change.
+	var em web3signer.ErrorMessage
+	if json.Unmarshal([]byte(errBody), &em) == nil {
+		if msg := strings.TrimSpace(em.Message); msg != "" {
+			return fmt.Errorf("request failed: %w: %s", err, msg)
+		}
+		return fmt.Errorf("request failed: %w", err)
+	}
+
+	// Not JSON we recognize: a plain-text error from an intermediary in front of the
+	// signer, or a body truncated mid-JSON. Surface it raw, bounded.
 	if len(errBody) > maxErrBodyLen {
 		errBody = errBody[:maxErrBodyLen]
 	}

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -133,7 +132,10 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (status
 		Fetch(ctx)
 
 	if requests.HasStatusErr(err, http.StatusUnprocessableEntity) {
-		return nil, ShareDecryptionError(errors.New(errBody))
+		// Wrap via requestFailedErr so the ResponseError chain survives (errors.Is /
+		// requests.HasStatusErr keep working) and an empty-body 422 yields the status text
+		// instead of an empty message.
+		return nil, ShareDecryptionError(requestFailedErr(err, errBody))
 	}
 
 	if err != nil {

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -80,14 +80,19 @@ func (c *Client) ListValidators(ctx context.Context) (listResp []phase0.BLSPubKe
 		recordClientRequest(ctx, opListValidators, err, duration)
 		c.logger.Debug("requested to list keys in remote signer", zap.Duration("duration", duration), zap.Error(err))
 	}()
+	var errStr string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
 		Path(PathValidators).
 		ToJSON(&listResp).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
 		Fetch(ctx)
+	if err != nil {
+		return nil, requestFailedErr(err, errStr)
+	}
 
-	return listResp, err
+	return listResp, nil
 }
 
 func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (statuses []web3signer.Status, err error) {
@@ -131,7 +136,7 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (status
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, requestFailedErr(err, errStr)
 	}
 
 	if len(resp.Data) != len(shares) {
@@ -158,6 +163,7 @@ func (c *Client) RemoveValidators(ctx context.Context, pubKeys ...phase0.BLSPubK
 	}
 
 	var resp web3signer.DeleteKeystoreResponse
+	var errStr string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
@@ -165,9 +171,10 @@ func (c *Client) RemoveValidators(ctx context.Context, pubKeys ...phase0.BLSPubK
 		BodyJSON(req).
 		Delete().
 		ToJSON(&resp).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
 		Fetch(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, requestFailedErr(err, errStr)
 	}
 
 	if len(resp.Data) != len(pubKeys) {
@@ -190,6 +197,7 @@ func (c *Client) Sign(ctx context.Context, sharePubKey phase0.BLSPubKey, payload
 		recordClientRequest(ctx, opSignValidator, err, duration)
 		c.logger.Debug("requested to sign with share key", zap.Stringer("share_pubkey", sharePubKey), zap.Duration("duration", duration), zap.Error(err))
 	}()
+	var errStr string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
@@ -197,9 +205,10 @@ func (c *Client) Sign(ctx context.Context, sharePubKey phase0.BLSPubKey, payload
 		BodyJSON(payload).
 		Post().
 		ToJSON(&resp).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
 		Fetch(ctx)
 	if err != nil {
-		return phase0.BLSSignature{}, fmt.Errorf("request failed: %w", err)
+		return phase0.BLSSignature{}, requestFailedErr(err, errStr)
 	}
 
 	return resp.Signature, nil
@@ -213,14 +222,16 @@ func (c *Client) OperatorIdentity(ctx context.Context) (pubKeyBase64 string, err
 		recordClientRequest(ctx, opOperatorIdentity, err, duration)
 		c.logger.Debug("requested operator identity", zap.Duration("duration", duration), zap.Error(err))
 	}()
+	var errStr string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
 		Path(PathOperatorIdentity).
 		ToString(&resp).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
 		Fetch(ctx)
 	if err != nil {
-		return "", fmt.Errorf("request failed: %w", err)
+		return "", requestFailedErr(err, errStr)
 	}
 
 	return resp, nil
@@ -234,6 +245,7 @@ func (c *Client) OperatorSign(ctx context.Context, payload []byte) (signature []
 		recordClientRequest(ctx, opOperatorSign, err, duration)
 		c.logger.Debug("requested to sign with operator key", zap.Duration("duration", duration), zap.Error(err))
 	}()
+	var errStr string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
@@ -241,9 +253,10 @@ func (c *Client) OperatorSign(ctx context.Context, payload []byte) (signature []
 		BodyBytes(payload).
 		Post().
 		ToBytesBuffer(&respBuf).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
 		Fetch(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, requestFailedErr(err, errStr)
 	}
 
 	return respBuf.Bytes(), nil
@@ -257,6 +270,7 @@ func (c *Client) OperatorEncrypt(ctx context.Context, payload []byte) (encrypted
 		recordClientRequest(ctx, opOperatorEncrypt, err, duration)
 		c.logger.Debug("requested operator encrypt", zap.Duration("duration", duration), zap.Error(err))
 	}()
+	var errStr string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
@@ -264,12 +278,13 @@ func (c *Client) OperatorEncrypt(ctx context.Context, payload []byte) (encrypted
 		BodyBytes(payload).
 		Post().
 		ToBytesBuffer(&respBuf).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
 		Fetch(ctx)
 	if err != nil {
 		if requests.HasStatusErr(err, http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusNotImplemented) {
 			return nil, fmt.Errorf("%w: %w", ErrOperatorDataProtectionUnsupported, err)
 		}
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, requestFailedErr(err, errStr)
 	}
 
 	return respBuf.Bytes(), nil
@@ -283,6 +298,7 @@ func (c *Client) OperatorDecrypt(ctx context.Context, payload []byte) (decrypted
 		recordClientRequest(ctx, opOperatorDecrypt, err, duration)
 		c.logger.Debug("requested operator decrypt", zap.Duration("duration", duration), zap.Error(err))
 	}()
+	var errStr string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
@@ -290,12 +306,13 @@ func (c *Client) OperatorDecrypt(ctx context.Context, payload []byte) (decrypted
 		BodyBytes(payload).
 		Post().
 		ToBytesBuffer(&respBuf).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
 		Fetch(ctx)
 	if err != nil {
 		if requests.HasStatusErr(err, http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusNotImplemented) {
 			return nil, fmt.Errorf("%w: %w", ErrOperatorDataProtectionUnsupported, err)
 		}
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, requestFailedErr(err, errStr)
 	}
 
 	return respBuf.Bytes(), nil
@@ -328,6 +345,26 @@ func (c *Client) MissingKeys(ctx context.Context, localKeys []phase0.BLSPubKey) 
 	)
 
 	return missingKeys, nil
+}
+
+// maxErrBodyLen caps the error response body attached to returned errors, so a
+// misbehaving server can't blow up error messages and log lines.
+const maxErrBodyLen = 1024
+
+// requestFailedErr wraps a failed request error, attaching the error response body
+// (if any) so callers can see the reason reported by the server instead of just a
+// status code.
+func requestFailedErr(err error, errBody string) error {
+	errBody = strings.TrimSpace(errBody)
+	// Older server versions write the zero-value response on errors, which carries
+	// no information ("null" / "{}"), so don't attach it.
+	if errBody == "" || errBody == "null" || errBody == "{}" {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	if len(errBody) > maxErrBodyLen {
+		errBody = errBody[:maxErrBodyLen] + "...(truncated)"
+	}
+	return fmt.Errorf("request failed: %w: %s", err, errBody)
 }
 
 // applyTLSConfig applies the given TLS configuration to the HTTP client.

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -81,16 +81,16 @@ func (c *Client) ListValidators(ctx context.Context) (listResp []phase0.BLSPubKe
 		recordClientRequest(ctx, opListValidators, err, duration)
 		c.logger.Debug("requested to list keys in remote signer", zap.Duration("duration", duration), zap.Error(err))
 	}()
-	var errStr string
+	var errBody string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
 		Path(PathValidators).
 		ToJSON(&listResp).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
+		AddValidator(errBodyValidator(&errBody)).
 		Fetch(ctx)
 	if err != nil {
-		return nil, requestFailedErr(err, errStr)
+		return nil, requestFailedErr(err, errBody)
 	}
 
 	return listResp, nil
@@ -121,7 +121,7 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (status
 	}
 
 	var resp web3signer.ImportKeystoreResponse
-	var errStr string
+	var errBody string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
@@ -129,15 +129,15 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (status
 		BodyJSON(req).
 		Post().
 		ToJSON(&resp).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
+		AddValidator(errBodyValidator(&errBody)).
 		Fetch(ctx)
 
 	if requests.HasStatusErr(err, http.StatusUnprocessableEntity) {
-		return nil, ShareDecryptionError(errors.New(errStr))
+		return nil, ShareDecryptionError(errors.New(errBody))
 	}
 
 	if err != nil {
-		return nil, requestFailedErr(err, errStr)
+		return nil, requestFailedErr(err, errBody)
 	}
 
 	if len(resp.Data) != len(shares) {
@@ -164,7 +164,7 @@ func (c *Client) RemoveValidators(ctx context.Context, pubKeys ...phase0.BLSPubK
 	}
 
 	var resp web3signer.DeleteKeystoreResponse
-	var errStr string
+	var errBody string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
@@ -172,10 +172,10 @@ func (c *Client) RemoveValidators(ctx context.Context, pubKeys ...phase0.BLSPubK
 		BodyJSON(req).
 		Delete().
 		ToJSON(&resp).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
+		AddValidator(errBodyValidator(&errBody)).
 		Fetch(ctx)
 	if err != nil {
-		return nil, requestFailedErr(err, errStr)
+		return nil, requestFailedErr(err, errBody)
 	}
 
 	if len(resp.Data) != len(pubKeys) {
@@ -198,7 +198,7 @@ func (c *Client) Sign(ctx context.Context, sharePubKey phase0.BLSPubKey, payload
 		recordClientRequest(ctx, opSignValidator, err, duration)
 		c.logger.Debug("requested to sign with share key", zap.Stringer("share_pubkey", sharePubKey), zap.Duration("duration", duration), zap.Error(err))
 	}()
-	var errStr string
+	var errBody string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
@@ -206,10 +206,10 @@ func (c *Client) Sign(ctx context.Context, sharePubKey phase0.BLSPubKey, payload
 		BodyJSON(payload).
 		Post().
 		ToJSON(&resp).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
+		AddValidator(errBodyValidator(&errBody)).
 		Fetch(ctx)
 	if err != nil {
-		return phase0.BLSSignature{}, requestFailedErr(err, errStr)
+		return phase0.BLSSignature{}, requestFailedErr(err, errBody)
 	}
 
 	return resp.Signature, nil
@@ -223,16 +223,16 @@ func (c *Client) OperatorIdentity(ctx context.Context) (pubKeyBase64 string, err
 		recordClientRequest(ctx, opOperatorIdentity, err, duration)
 		c.logger.Debug("requested operator identity", zap.Duration("duration", duration), zap.Error(err))
 	}()
-	var errStr string
+	var errBody string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
 		Path(PathOperatorIdentity).
 		ToString(&resp).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
+		AddValidator(errBodyValidator(&errBody)).
 		Fetch(ctx)
 	if err != nil {
-		return "", requestFailedErr(err, errStr)
+		return "", requestFailedErr(err, errBody)
 	}
 
 	return resp, nil
@@ -246,7 +246,7 @@ func (c *Client) OperatorSign(ctx context.Context, payload []byte) (signature []
 		recordClientRequest(ctx, opOperatorSign, err, duration)
 		c.logger.Debug("requested to sign with operator key", zap.Duration("duration", duration), zap.Error(err))
 	}()
-	var errStr string
+	var errBody string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
@@ -254,10 +254,10 @@ func (c *Client) OperatorSign(ctx context.Context, payload []byte) (signature []
 		BodyBytes(payload).
 		Post().
 		ToBytesBuffer(&respBuf).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
+		AddValidator(errBodyValidator(&errBody)).
 		Fetch(ctx)
 	if err != nil {
-		return nil, requestFailedErr(err, errStr)
+		return nil, requestFailedErr(err, errBody)
 	}
 
 	return respBuf.Bytes(), nil
@@ -271,7 +271,7 @@ func (c *Client) OperatorEncrypt(ctx context.Context, payload []byte) (encrypted
 		recordClientRequest(ctx, opOperatorEncrypt, err, duration)
 		c.logger.Debug("requested operator encrypt", zap.Duration("duration", duration), zap.Error(err))
 	}()
-	var errStr string
+	var errBody string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
@@ -279,13 +279,13 @@ func (c *Client) OperatorEncrypt(ctx context.Context, payload []byte) (encrypted
 		BodyBytes(payload).
 		Post().
 		ToBytesBuffer(&respBuf).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
+		AddValidator(errBodyValidator(&errBody)).
 		Fetch(ctx)
 	if err != nil {
 		if requests.HasStatusErr(err, http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusNotImplemented) {
 			return nil, fmt.Errorf("%w: %w", ErrOperatorDataProtectionUnsupported, err)
 		}
-		return nil, requestFailedErr(err, errStr)
+		return nil, requestFailedErr(err, errBody)
 	}
 
 	return respBuf.Bytes(), nil
@@ -299,7 +299,7 @@ func (c *Client) OperatorDecrypt(ctx context.Context, payload []byte) (decrypted
 		recordClientRequest(ctx, opOperatorDecrypt, err, duration)
 		c.logger.Debug("requested operator decrypt", zap.Duration("duration", duration), zap.Error(err))
 	}()
-	var errStr string
+	var errBody string
 	err = requests.
 		URL(c.baseURL).
 		Client(c.httpClient).
@@ -307,13 +307,13 @@ func (c *Client) OperatorDecrypt(ctx context.Context, payload []byte) (decrypted
 		BodyBytes(payload).
 		Post().
 		ToBytesBuffer(&respBuf).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
+		AddValidator(errBodyValidator(&errBody)).
 		Fetch(ctx)
 	if err != nil {
 		if requests.HasStatusErr(err, http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusNotImplemented) {
 			return nil, fmt.Errorf("%w: %w", ErrOperatorDataProtectionUnsupported, err)
 		}
-		return nil, requestFailedErr(err, errStr)
+		return nil, requestFailedErr(err, errBody)
 	}
 
 	return respBuf.Bytes(), nil
@@ -348,37 +348,41 @@ func (c *Client) MissingKeys(ctx context.Context, localKeys []phase0.BLSPubKey) 
 	return missingKeys, nil
 }
 
-// maxErrBodyLen caps the error response body attached to returned errors, so a
-// misbehaving server can't blow up error messages and log lines.
+// maxErrBodyLen caps the error-body text attached to returned errors, so a misbehaving
+// server can't bloat error messages and logs.
 const maxErrBodyLen = 1024
 
-// toLimitedString is like requests.ToString, but reads at most maxErrBodyLen+1
-// bytes, so a misbehaving server can't force unbounded reads while the error
-// response body is captured. requestFailedErr's truncation then trims anything
-// past the cap.
-func toLimitedString(dst *string) requests.ResponseHandler {
-	return func(resp *http.Response) error {
+// errBodyValidator returns a response validator that defers to requests.DefaultValidator
+// and, on a rejected status, captures a bounded copy of the error body into *dst for
+// requestFailedErr to attach. It reads one byte past the cap so truncation is detectable.
+func errBodyValidator(dst *string) requests.ResponseHandler {
+	return requests.ValidatorHandler(requests.DefaultValidator, func(resp *http.Response) error {
 		b, err := io.ReadAll(io.LimitReader(resp.Body, maxErrBodyLen+1))
 		if err != nil {
 			return err
 		}
 		*dst = string(b)
 		return nil
-	}
+	})
 }
 
-// requestFailedErr wraps a failed request error, attaching the error response body
-// (if any) so callers can see the reason reported by the server instead of just a
-// status code.
+// requestFailedErr wraps a failed request error, attaching the captured error body (if
+// any) so callers see the reason reported by the server instead of just a status code.
 func requestFailedErr(err error, errBody string) error {
+	// Record whether the body was truncated from its raw length, before TrimSpace can
+	// shrink a whitespace tail back under the cap and hide that content was dropped.
+	truncated := len(errBody) > maxErrBodyLen
 	errBody = strings.TrimSpace(errBody)
-	// Older server versions write the zero-value response on errors, which carries
-	// no information ("null" / "{}"), so don't attach it.
+	// Older servers write the zero-value response on errors, which carries no information
+	// ("null" / "{}"), so don't attach it.
 	if errBody == "" || errBody == "null" || errBody == "{}" {
 		return fmt.Errorf("request failed: %w", err)
 	}
 	if len(errBody) > maxErrBodyLen {
-		errBody = errBody[:maxErrBodyLen] + "...(truncated)"
+		errBody = errBody[:maxErrBodyLen]
+	}
+	if truncated {
+		errBody += "...(truncated)"
 	}
 	return fmt.Errorf("request failed: %w: %s", err, errBody)
 }

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -389,21 +389,24 @@ func requestFailedErr(err error, errBody string) error {
 	}
 
 	// The server reports failures as {"message": ...} (web3signer.ErrorMessage), so a
-	// non-empty message is the reason. A body that parses as JSON without one is the
-	// zero-value success response an older server writes on error — null, {},
-	// {"signature":"0x0…0"} (a zero SignResponse) — with nothing useful, so drop it and let
-	// err's status speak. Keying on the message avoids enumerating those zero values, which
-	// drift as the response structs change.
+	// non-empty message is the reason. Keying on the message avoids enumerating zero values,
+	// which drift as the response structs change.
 	var em web3signer.ErrorMessage
 	if json.Unmarshal([]byte(errBody), &em) == nil {
 		if msg := strings.TrimSpace(em.Message); msg != "" {
 			return fmt.Errorf("request failed: %w: %s", err, msg)
 		}
-		return fmt.Errorf("request failed: %w", err)
+		// A JSON object without ssv-signer's "message": either a zero-value success body an
+		// older server writes on error (nothing to surface), or a real reason from a
+		// JSON-speaking intermediary, e.g. {"error":"..."} from a gateway. Drop the former and
+		// let err's status speak; surface the latter raw.
+		if !jsonBodyCarriesReason(errBody) {
+			return fmt.Errorf("request failed: %w", err)
+		}
 	}
 
-	// Not JSON we recognize: a plain-text error from an intermediary in front of the
-	// signer, or a body truncated mid-JSON. Surface it raw, bounded.
+	// A plain-text error from an intermediary in front of the signer, a body truncated
+	// mid-JSON, or a JSON body carrying its reason outside "message". Surface it raw, bounded.
 	if len(errBody) > maxErrBodyLen {
 		errBody = errBody[:maxErrBodyLen]
 	}
@@ -411,6 +414,46 @@ func requestFailedErr(err error, errBody string) error {
 		errBody += "...(truncated)"
 	}
 	return fmt.Errorf("request failed: %w: %s", err, errBody)
+}
+
+// jsonBodyCarriesReason reports whether a JSON object error body holds a human-readable reason in
+// a field other than "message" (which requestFailedErr handles directly). It returns true for a
+// field with real string content — e.g. {"error":"upstream connect failure"} from a gateway — and
+// false for the zero-value success bodies an older signer writes on error, whose fields are absent,
+// null, or an all-zero hex blob (the zero SignResponse's {"signature":"0x0…0"}).
+func jsonBodyCarriesReason(body string) bool {
+	var fields map[string]json.RawMessage
+	if json.Unmarshal([]byte(body), &fields) != nil {
+		return false // not a JSON object — nothing structured to extract
+	}
+	for name, raw := range fields {
+		if name == "message" {
+			continue
+		}
+		var s string
+		if json.Unmarshal(raw, &s) != nil {
+			continue // not a string value
+		}
+		if isMeaningfulReason(s) {
+			return true
+		}
+	}
+	return false
+}
+
+// isMeaningfulReason reports whether s carries content worth surfacing. A zero-value BLS field
+// (e.g. the zero SignResponse's signature) marshals to "0x" followed by all zeros; that reads as
+// empty here so an older signer's zero-value body isn't surfaced as a bogus reason (see
+// TestSignOldSignerZeroValueBodyNotSurfaced).
+func isMeaningfulReason(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	if rest, found := strings.CutPrefix(s, "0x"); found && strings.Trim(rest, "0") == "" {
+		return false
+	}
+	return true
 }
 
 // applyTLSConfig applies the given TLS configuration to the HTTP client.

--- a/ssvsigner/client.go
+++ b/ssvsigner/client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -86,7 +87,7 @@ func (c *Client) ListValidators(ctx context.Context) (listResp []phase0.BLSPubKe
 		Client(c.httpClient).
 		Path(PathValidators).
 		ToJSON(&listResp).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
 		Fetch(ctx)
 	if err != nil {
 		return nil, requestFailedErr(err, errStr)
@@ -128,7 +129,7 @@ func (c *Client) AddValidators(ctx context.Context, shares ...ShareKeys) (status
 		BodyJSON(req).
 		Post().
 		ToJSON(&resp).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
 		Fetch(ctx)
 
 	if requests.HasStatusErr(err, http.StatusUnprocessableEntity) {
@@ -171,7 +172,7 @@ func (c *Client) RemoveValidators(ctx context.Context, pubKeys ...phase0.BLSPubK
 		BodyJSON(req).
 		Delete().
 		ToJSON(&resp).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
 		Fetch(ctx)
 	if err != nil {
 		return nil, requestFailedErr(err, errStr)
@@ -205,7 +206,7 @@ func (c *Client) Sign(ctx context.Context, sharePubKey phase0.BLSPubKey, payload
 		BodyJSON(payload).
 		Post().
 		ToJSON(&resp).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
 		Fetch(ctx)
 	if err != nil {
 		return phase0.BLSSignature{}, requestFailedErr(err, errStr)
@@ -228,7 +229,7 @@ func (c *Client) OperatorIdentity(ctx context.Context) (pubKeyBase64 string, err
 		Client(c.httpClient).
 		Path(PathOperatorIdentity).
 		ToString(&resp).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
 		Fetch(ctx)
 	if err != nil {
 		return "", requestFailedErr(err, errStr)
@@ -253,7 +254,7 @@ func (c *Client) OperatorSign(ctx context.Context, payload []byte) (signature []
 		BodyBytes(payload).
 		Post().
 		ToBytesBuffer(&respBuf).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
 		Fetch(ctx)
 	if err != nil {
 		return nil, requestFailedErr(err, errStr)
@@ -278,7 +279,7 @@ func (c *Client) OperatorEncrypt(ctx context.Context, payload []byte) (encrypted
 		BodyBytes(payload).
 		Post().
 		ToBytesBuffer(&respBuf).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
 		Fetch(ctx)
 	if err != nil {
 		if requests.HasStatusErr(err, http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusNotImplemented) {
@@ -306,7 +307,7 @@ func (c *Client) OperatorDecrypt(ctx context.Context, payload []byte) (decrypted
 		BodyBytes(payload).
 		Post().
 		ToBytesBuffer(&respBuf).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errStr))).
+		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, toLimitedString(&errStr))).
 		Fetch(ctx)
 	if err != nil {
 		if requests.HasStatusErr(err, http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusNotImplemented) {
@@ -350,6 +351,21 @@ func (c *Client) MissingKeys(ctx context.Context, localKeys []phase0.BLSPubKey) 
 // maxErrBodyLen caps the error response body attached to returned errors, so a
 // misbehaving server can't blow up error messages and log lines.
 const maxErrBodyLen = 1024
+
+// toLimitedString is like requests.ToString, but reads at most maxErrBodyLen+1
+// bytes, so a misbehaving server can't force unbounded reads while the error
+// response body is captured. requestFailedErr's truncation then trims anything
+// past the cap.
+func toLimitedString(dst *string) requests.ResponseHandler {
+	return func(resp *http.Response) error {
+		b, err := io.ReadAll(io.LimitReader(resp.Body, maxErrBodyLen+1))
+		if err != nil {
+			return err
+		}
+		*dst = string(b)
+		return nil
+	}
+}
 
 // requestFailedErr wraps a failed request error, attaching the error response body
 // (if any) so callers can see the reason reported by the server instead of just a

--- a/ssvsigner/client_test.go
+++ b/ssvsigner/client_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -1045,4 +1046,49 @@ func TestNewClient_TrimsTrailingSlashFromURL(t *testing.T) {
 
 	require.NotNil(t, client)
 	assert.Equal(t, expectedURL, client.baseURL)
+}
+
+func Test_requestFailedErr(t *testing.T) {
+	baseErr := errors.New("unexpected status: 500")
+
+	t.Run("no body", func(t *testing.T) {
+		err := requestFailedErr(baseErr, "")
+		require.EqualError(t, err, "request failed: unexpected status: 500")
+		require.ErrorIs(t, err, baseErr)
+	})
+
+	t.Run("information-free bodies are skipped", func(t *testing.T) {
+		for _, body := range []string{"null", "{}", "  null  ", "\n"} {
+			require.EqualError(t, requestFailedErr(baseErr, body), "request failed: unexpected status: 500")
+		}
+	})
+
+	t.Run("body attached", func(t *testing.T) {
+		err := requestFailedErr(baseErr, `{"message":"web3signer unavailable"}`)
+		require.ErrorContains(t, err, "web3signer unavailable")
+		require.ErrorIs(t, err, baseErr)
+	})
+
+	t.Run("oversized body truncated", func(t *testing.T) {
+		err := requestFailedErr(baseErr, strings.Repeat("x", maxErrBodyLen+100))
+		require.ErrorContains(t, err, "...(truncated)")
+		require.Less(t, len(err.Error()), maxErrBodyLen+100)
+	})
+}
+
+// TestErrorBodyCaptureIsBounded verifies that a huge error response body is capped
+// at read time (toLimitedString), keeping the returned error bounded.
+func TestErrorBodyCaptureIsBounded(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		// The client stops reading past the cap and drops the connection,
+		// so this write is expected to fail partway through.
+		_, _ = w.Write(bytes.Repeat([]byte("a"), 1<<20)) // 1 MiB
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := NewClient(server.URL).ListValidators(t.Context())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "...(truncated)")
+	require.Less(t, len(err.Error()), 2*maxErrBodyLen)
 }

--- a/ssvsigner/client_test.go
+++ b/ssvsigner/client_test.go
@@ -336,6 +336,7 @@ func (s *SSVSignerClientSuite) TestListValidators() {
 		expectedResponse   interface{}
 		expectedResult     []phase0.BLSPubKey
 		expectError        bool
+		errContains        string
 	}{
 		{
 			name:               "Success", // TODO: fix
@@ -363,6 +364,8 @@ func (s *SSVSignerClientSuite) TestListValidators() {
 			expectedResponse:   nil,
 			expectedResult:     nil,
 			expectError:        true,
+			// writeJSONResponse writes "Server error" as the body for non-OK statuses.
+			errContains: "Server error",
 		},
 	}
 
@@ -378,6 +381,10 @@ func (s *SSVSignerClientSuite) TestListValidators() {
 
 			if tc.expectError {
 				require.Error(t, err, "Expected an error")
+				if tc.errContains != "" {
+					require.ErrorContains(t, err, tc.errContains,
+						"Expected the error to include the server-provided reason")
+				}
 			} else {
 				require.NoError(t, err, "Unexpected error")
 				assert.Equal(t, tc.expectedResult, result)
@@ -424,6 +431,7 @@ func (s *SSVSignerClientSuite) TestSign() {
 		responseBody       string
 		expectedResult     phase0.BLSSignature
 		expectError        bool
+		errContains        string
 	}{
 		{
 			name:               "Success", // TODO: fix
@@ -441,6 +449,7 @@ func (s *SSVSignerClientSuite) TestSign() {
 			expectedStatusCode: http.StatusBadRequest,
 			responseBody:       "invalid signature",
 			expectError:        true,
+			errContains:        "invalid signature",
 		},
 		{
 			name:               "ServerError",
@@ -449,6 +458,7 @@ func (s *SSVSignerClientSuite) TestSign() {
 			expectedStatusCode: http.StatusInternalServerError,
 			responseBody:       "Server error",
 			expectError:        true,
+			errContains:        "Server error",
 		},
 	}
 
@@ -475,6 +485,10 @@ func (s *SSVSignerClientSuite) TestSign() {
 
 			if tc.expectError {
 				require.Error(t, err, "Expected an error")
+				if tc.errContains != "" {
+					require.ErrorContains(t, err, tc.errContains,
+						"Expected the error to include the server-provided reason")
+				}
 			} else {
 				require.NoError(t, err, "Unexpected error")
 				assert.Equal(t, tc.expectedResult, result)

--- a/ssvsigner/client_test.go
+++ b/ssvsigner/client_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/carlmjohnson/requests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -1081,6 +1082,41 @@ func Test_requestFailedErr(t *testing.T) {
 		body := strings.Repeat("x", maxErrBodyLen-1) + "  "
 		err := requestFailedErr(baseErr, body)
 		require.ErrorContains(t, err, "...(truncated)")
+	})
+}
+
+// TestAddValidatorsUnprocessableEntitySurfacesReason checks that a 422 from ssv-signer becomes a
+// ShareDecryptionError that keeps the ResponseError chain intact (requests.HasStatusErr still
+// works) and never collapses to an empty message, even with an empty upstream body.
+func TestAddValidatorsUnprocessableEntitySurfacesReason(t *testing.T) {
+	share := ShareKeys{EncryptedPrivKey: []byte("x"), PubKey: phase0.BLSPubKey{1}}
+
+	t.Run("empty body yields status text, not an empty message", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+		}))
+		t.Cleanup(server.Close)
+
+		_, err := NewClient(server.URL).AddValidators(t.Context(), share)
+		require.Error(t, err)
+
+		var decryptErr ShareDecryptionError
+		require.ErrorAs(t, err, &decryptErr)
+		require.True(t, requests.HasStatusErr(err, http.StatusUnprocessableEntity))
+		require.ErrorContains(t, err, "request failed")
+	})
+
+	t.Run("server reason is surfaced", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"failed to decrypt share"}`))
+		}))
+		t.Cleanup(server.Close)
+
+		_, err := NewClient(server.URL).AddValidators(t.Context(), share)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to decrypt share")
+		require.True(t, requests.HasStatusErr(err, http.StatusUnprocessableEntity))
 	})
 }
 

--- a/ssvsigner/client_test.go
+++ b/ssvsigner/client_test.go
@@ -1074,15 +1074,23 @@ func Test_requestFailedErr(t *testing.T) {
 		require.ErrorContains(t, err, "...(truncated)")
 		require.Less(t, len(err.Error()), maxErrBodyLen+100)
 	})
+
+	t.Run("over-cap body trimming under the cap is still marked truncated", func(t *testing.T) {
+		// A body one byte over the cap with a whitespace tail: TrimSpace brings it back
+		// under the cap, but the truncation marker must still appear.
+		body := strings.Repeat("x", maxErrBodyLen-1) + "  "
+		err := requestFailedErr(baseErr, body)
+		require.ErrorContains(t, err, "...(truncated)")
+	})
 }
 
-// TestErrorBodyCaptureIsBounded verifies that a huge error response body is capped
-// at read time (toLimitedString), keeping the returned error bounded.
+// TestErrorBodyCaptureIsBounded verifies a huge error response body is capped at read
+// time, keeping the returned error bounded.
 func TestErrorBodyCaptureIsBounded(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		// The client stops reading past the cap and drops the connection,
-		// so this write is expected to fail partway through.
+		// The client stops reading past the cap and drops the connection, so this
+		// write may fail partway through.
 		_, _ = w.Write(bytes.Repeat([]byte("a"), 1<<20)) // 1 MiB
 	}))
 	t.Cleanup(server.Close)

--- a/ssvsigner/client_test.go
+++ b/ssvsigner/client_test.go
@@ -1088,6 +1088,20 @@ func Test_requestFailedErr(t *testing.T) {
 		require.ErrorIs(t, err, baseErr)
 	})
 
+	t.Run("json reason outside message is surfaced", func(t *testing.T) {
+		// A JSON-speaking intermediary in front of ssv-signer (e.g. a gateway) can report its
+		// own failure in a field other than "message". That's a real reason, not an older
+		// signer's zero-value body, so it must be surfaced rather than dropped as a bare status.
+		for _, body := range []string{
+			`{"error":"upstream connect failure"}`,
+			`{"message":"","detail":"bad gateway"}`,
+		} {
+			err := requestFailedErr(baseErr, body)
+			require.ErrorContains(t, err, body, "body %q should be surfaced", body)
+			require.ErrorIs(t, err, baseErr)
+		}
+	})
+
 	t.Run("oversized body truncated", func(t *testing.T) {
 		err := requestFailedErr(baseErr, strings.Repeat("x", maxErrBodyLen+100))
 		require.ErrorContains(t, err, "...(truncated)")
@@ -1176,6 +1190,23 @@ func TestSignOldSignerZeroValueBodyNotSurfaced(t *testing.T) {
 	require.NotContains(t, err.Error(), "0x00000")
 	require.True(t, requests.HasStatusErr(err, http.StatusInternalServerError))
 	require.ErrorContains(t, err, "request failed")
+}
+
+// TestSignSurfacesIntermediaryReason is the counterpart to the zero-value case above: a
+// JSON-speaking intermediary in front of ssv-signer (e.g. a gateway) reports its failure in a
+// field other than "message". That's a real reason, not a zero-value body, so it must reach the
+// caller rather than collapse to a bare status.
+func TestSignSurfacesIntermediaryReason(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":"upstream connect failure"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := NewClient(server.URL).Sign(t.Context(), phase0.BLSPubKey{1}, web3signer.SignRequest{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "upstream connect failure")
+	require.True(t, requests.HasStatusErr(err, http.StatusBadGateway))
 }
 
 // TestClientErrorOmitsHandledRecoveryPhrase guards against errBodyValidator reintroducing

--- a/ssvsigner/client_test.go
+++ b/ssvsigner/client_test.go
@@ -1064,6 +1064,24 @@ func Test_requestFailedErr(t *testing.T) {
 		}
 	})
 
+	t.Run("zero-value success bodies carry no reason", func(t *testing.T) {
+		// Older servers write the zero value of the success response on errors. These parse
+		// as JSON but have no message, so no reason must be attached — in particular the
+		// zero SignResponse, whose fixed-size BLSSignature array always serializes, giving
+		// 210 bytes of hex zeros.
+		signZero, err := json.Marshal(web3signer.SignResponse{})
+		require.NoError(t, err)
+		for _, body := range []string{
+			string(signZero),
+			`{"data":null}`,
+			`{"signature":"0x0000000000","message":""}`,
+		} {
+			require.EqualError(t, requestFailedErr(baseErr, body),
+				"request failed: unexpected status: 500",
+				"body %q should not be surfaced as a reason", body)
+		}
+	})
+
 	t.Run("body attached", func(t *testing.T) {
 		err := requestFailedErr(baseErr, `{"message":"web3signer unavailable"}`)
 		require.ErrorContains(t, err, "web3signer unavailable")
@@ -1135,4 +1153,47 @@ func TestErrorBodyCaptureIsBounded(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "...(truncated)")
 	require.Less(t, len(err.Error()), 2*maxErrBodyLen)
+}
+
+// TestSignOldSignerZeroValueBodyNotSurfaced covers a mixed deployment where the node is
+// upgraded before the signer: an older signer writes the zero-value success response on a
+// Sign failure, which marshals to {"signature":"0x0…0"} (210 bytes) because a fixed-size
+// BLSSignature array is always serialized. That body must not be surfaced as the reason —
+// the status carries the signal instead.
+func TestSignOldSignerZeroValueBodyNotSurfaced(t *testing.T) {
+	zeroBody, err := json.Marshal(web3signer.SignResponse{})
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(zeroBody)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err = NewClient(server.URL).Sign(t.Context(), phase0.BLSPubKey{1}, web3signer.SignRequest{})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "signature")
+	require.NotContains(t, err.Error(), "0x00000")
+	require.True(t, requests.HasStatusErr(err, http.StatusInternalServerError))
+	require.ErrorContains(t, err, "request failed")
+}
+
+// TestClientErrorOmitsHandledRecoveryPhrase guards against errBodyValidator reintroducing
+// the requests.ValidatorHandler "handled recovery from invalid response" phrase. Capturing
+// the error body is the normal failure path here, so the phrase would otherwise be prefixed
+// onto every returned error — including the startup ListValidators path this PR improves —
+// while the actual server reason must still come through.
+func TestClientErrorOmitsHandledRecoveryPhrase(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"web3signer down"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := NewClient(server.URL).ListValidators(t.Context())
+	require.Error(t, err)
+	require.False(t, errors.Is(err, requests.ErrInvalidHandled))
+	require.NotContains(t, err.Error(), "handled recovery from invalid response")
+	require.ErrorContains(t, err, "web3signer down")
+	require.True(t, requests.HasStatusErr(err, http.StatusInternalServerError))
 }

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -227,7 +227,7 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 	recordRemoteSignerOperation(ctx, opRemoteSignerImportKeystore, err, time.Since(start))
 	logger = logger.With(zap.Duration("took", time.Since(start)))
 	if err != nil {
-		s.handleWeb3SignerErr(ctx, logger, err)
+		s.handleImportKeystoreErr(ctx, logger, err)
 		return
 	}
 
@@ -511,21 +511,44 @@ func (s *Server) handleOperatorDecrypt(ctx *fasthttp.RequestCtx) {
 	s.writeBytes(ctx, logger, decrypted)
 }
 
-// handleWeb3SignerErr responds with the upstream Web3Signer status when known (or 500 for
-// transport failures such as connection errors and timeouts) and an error body describing
-// the failure, so clients can log the actual reason rather than just a bare status code.
-func (s *Server) handleWeb3SignerErr(ctx *fasthttp.RequestCtx, logger *zap.Logger, err error) {
-	statusCode := fasthttp.StatusInternalServerError
+// web3SignerErrStatus returns the HTTP status to surface for a failed Web3Signer request:
+// the upstream status when known, or 500 for transport failures (connection errors, timeouts).
+func web3SignerErrStatus(err error) int {
 	var he web3signer.HTTPResponseError
 	if errors.As(err, &he) {
-		statusCode = he.Status
+		return he.Status
 	}
+	return fasthttp.StatusInternalServerError
+}
 
+// handleWeb3SignerErr responds with the Web3Signer failure's status and an error body
+// describing the reason, so clients can log the actual cause instead of a bare status code.
+func (s *Server) handleWeb3SignerErr(ctx *fasthttp.RequestCtx, logger *zap.Logger, err error) {
+	statusCode := web3SignerErrStatus(err)
 	logger.Error("web3signer request failed",
 		zap.Error(err),
 		zap.Int("status_code", statusCode),
 	)
 	s.writeJSONErr(ctx, logger, statusCode, err)
+}
+
+// handleImportKeystoreErr handles a failed keystore import. Unlike handleWeb3SignerErr it never
+// relays the upstream error body: the import request carries the share keystore JSON and its
+// plaintext password, so a server that echoes the request back in an error could leak recoverable
+// key material to the node — the reason keystoreJSONFromEncryptedShare also withholds its errors.
+// The upstream status is still forwarded, except a 422, which is remapped to 502 so it can't be
+// read as ssv-signer's own share-decryption failure (see Client.AddValidators). The full error is
+// still logged locally.
+func (s *Server) handleImportKeystoreErr(ctx *fasthttp.RequestCtx, logger *zap.Logger, err error) {
+	statusCode := web3SignerErrStatus(err)
+	if statusCode == fasthttp.StatusUnprocessableEntity {
+		statusCode = fasthttp.StatusBadGateway
+	}
+	logger.Error("web3signer request failed",
+		zap.Error(err),
+		zap.Int("status_code", statusCode),
+	)
+	s.writeJSONErr(ctx, logger, statusCode, errors.New("keystore import failed"))
 }
 
 func (s *Server) writeString(ctx *fasthttp.RequestCtx, logger *zap.Logger, str string) {

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -156,7 +156,7 @@ func (s *Server) handleListValidators(ctx *fasthttp.RequestCtx) {
 	recordRemoteSignerOperation(ctx, opRemoteSignerListKeys, err, time.Since(start))
 	logger = logger.With(zap.Duration("took", time.Since(start)))
 	if err != nil {
-		s.handleWeb3SignerErr(ctx, logger, resp, err)
+		s.handleWeb3SignerErr(ctx, logger, err)
 		return
 	}
 
@@ -227,7 +227,7 @@ func (s *Server) handleAddValidator(ctx *fasthttp.RequestCtx) {
 	recordRemoteSignerOperation(ctx, opRemoteSignerImportKeystore, err, time.Since(start))
 	logger = logger.With(zap.Duration("took", time.Since(start)))
 	if err != nil {
-		s.handleWeb3SignerErr(ctx, logger, resp, err)
+		s.handleWeb3SignerErr(ctx, logger, err)
 		return
 	}
 
@@ -321,7 +321,7 @@ func (s *Server) handleRemoveValidator(ctx *fasthttp.RequestCtx) {
 	recordRemoteSignerOperation(ctx, opRemoteSignerDeleteKeystore, err, time.Since(start))
 	logger = logger.With(zap.Duration("took", time.Since(start)))
 	if err != nil {
-		s.handleWeb3SignerErr(ctx, logger, resp, err)
+		s.handleWeb3SignerErr(ctx, logger, err)
 		return
 	}
 
@@ -372,7 +372,7 @@ func (s *Server) handleSignValidator(ctx *fasthttp.RequestCtx) {
 	recordRemoteSignerOperation(ctx, opRemoteSignerValidatorSign, err, time.Since(start))
 	logger = logger.With(zap.Duration("took", time.Since(start)))
 	if err != nil {
-		s.handleWeb3SignerErr(ctx, logger, resp, err)
+		s.handleWeb3SignerErr(ctx, logger, err)
 		return
 	}
 
@@ -511,19 +511,22 @@ func (s *Server) handleOperatorDecrypt(ctx *fasthttp.RequestCtx) {
 	s.writeBytes(ctx, logger, decrypted)
 }
 
-func (s *Server) handleWeb3SignerErr(ctx *fasthttp.RequestCtx, logger *zap.Logger, resp any, err error) {
+// handleWeb3SignerErr responds with the upstream Web3Signer status when it is known
+// (falling back to 500 for transport-level failures such as connection errors and
+// timeouts) and an error body describing the failure, so that clients can log the
+// actual reason rather than just a bare status code.
+func (s *Server) handleWeb3SignerErr(ctx *fasthttp.RequestCtx, logger *zap.Logger, err error) {
 	statusCode := fasthttp.StatusInternalServerError
-	if he := new(web3signer.HTTPResponseError); errors.As(err, &he) {
+	var he web3signer.HTTPResponseError
+	if errors.As(err, &he) {
 		statusCode = he.Status
 	}
 
 	logger.Error("web3signer request failed",
 		zap.Error(err),
 		zap.Int("status_code", statusCode),
-		zap.Any("resp", resp),
 	)
-	ctx.SetStatusCode(statusCode)
-	s.writeJSON(ctx, logger, resp)
+	s.writeJSONErr(ctx, logger, statusCode, err)
 }
 
 func (s *Server) writeString(ctx *fasthttp.RequestCtx, logger *zap.Logger, str string) {

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -511,10 +511,9 @@ func (s *Server) handleOperatorDecrypt(ctx *fasthttp.RequestCtx) {
 	s.writeBytes(ctx, logger, decrypted)
 }
 
-// handleWeb3SignerErr responds with the upstream Web3Signer status when it is known
-// (falling back to 500 for transport-level failures such as connection errors and
-// timeouts) and an error body describing the failure, so that clients can log the
-// actual reason rather than just a bare status code.
+// handleWeb3SignerErr responds with the upstream Web3Signer status when known (or 500 for
+// transport failures such as connection errors and timeouts) and an error body describing
+// the failure, so clients can log the actual reason rather than just a bare status code.
 func (s *Server) handleWeb3SignerErr(ctx *fasthttp.RequestCtx, logger *zap.Logger, err error) {
 	statusCode := fasthttp.StatusInternalServerError
 	var he web3signer.HTTPResponseError

--- a/ssvsigner/server_test.go
+++ b/ssvsigner/server_test.go
@@ -268,6 +268,39 @@ func (s *ServerTestSuite) TestAddValidator() {
 		resp, err := s.ServeHTTP("POST", PathValidators, reqBody)
 		require.NoError(t, err)
 		assert.Equal(t, fasthttp.StatusInternalServerError, resp.StatusCode())
+		// Import failures return a fixed message; the upstream body is never relayed.
+		assert.JSONEq(t, `{"message":"keystore import failed"}`, string(resp.Body()))
+
+		s.remoteSigner.ImportError = nil
+	})
+
+	t.Run("import error forwards upstream status but redacts body", func(t *testing.T) {
+		s.remoteSigner.ImportError = web3signer.HTTPResponseError{
+			Err:     errors.New("unexpected status: 503"),
+			Status:  fasthttp.StatusServiceUnavailable,
+			ErrText: "sensitive upstream keystore echo",
+		}
+		resp, err := s.ServeHTTP("POST", PathValidators, reqBody)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusServiceUnavailable, resp.StatusCode())
+		assert.JSONEq(t, `{"message":"keystore import failed"}`, string(resp.Body()))
+		assert.NotContains(t, string(resp.Body()), "sensitive")
+
+		s.remoteSigner.ImportError = nil
+	})
+
+	t.Run("import error remaps upstream 422 to 502", func(t *testing.T) {
+		// 422 on this endpoint is the client's share-decryption sentinel (raised by
+		// ssv-signer itself), so an upstream 422 must not alias onto it.
+		s.remoteSigner.ImportError = web3signer.HTTPResponseError{
+			Err:     errors.New("unexpected status: 422"),
+			Status:  fasthttp.StatusUnprocessableEntity,
+			ErrText: "web3signer rejected keystore",
+		}
+		resp, err := s.ServeHTTP("POST", PathValidators, reqBody)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusBadGateway, resp.StatusCode())
+		assert.JSONEq(t, `{"message":"keystore import failed"}`, string(resp.Body()))
 
 		s.remoteSigner.ImportError = nil
 	})

--- a/ssvsigner/server_test.go
+++ b/ssvsigner/server_test.go
@@ -127,6 +127,21 @@ func (s *ServerTestSuite) TestListValidators() {
 		resp, err := s.ServeHTTP("GET", PathValidators, nil)
 		require.NoError(t, err)
 		assert.Equal(t, fasthttp.StatusInternalServerError, resp.StatusCode())
+		assert.JSONEq(t, `{"message":"remote signer error"}`, string(resp.Body()))
+
+		s.remoteSigner.ListKeysError = nil
+	})
+
+	t.Run("web3signer error status and reason propagated", func(t *testing.T) {
+		s.remoteSigner.ListKeysError = web3signer.HTTPResponseError{
+			Err:     errors.New("unexpected status: 503"),
+			Status:  fasthttp.StatusServiceUnavailable,
+			ErrText: "web3signer unavailable",
+		}
+		resp, err := s.ServeHTTP("GET", PathValidators, nil)
+		require.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusServiceUnavailable, resp.StatusCode())
+		assert.Contains(t, string(resp.Body()), "web3signer unavailable")
 
 		s.remoteSigner.ListKeysError = nil
 	})

--- a/ssvsigner/server_test.go
+++ b/ssvsigner/server_test.go
@@ -345,6 +345,7 @@ func (s *ServerTestSuite) TestRemoveValidator() {
 		resp, err := s.ServeHTTP("DELETE", PathValidators, reqBody)
 		require.NoError(t, err)
 		assert.Equal(t, fasthttp.StatusInternalServerError, resp.StatusCode())
+		assert.JSONEq(t, `{"message":"remote signer error"}`, string(resp.Body()))
 
 		s.remoteSigner.DeleteError = nil
 	})
@@ -395,6 +396,7 @@ func (s *ServerTestSuite) TestSignValidator() {
 		resp, err := s.ServeHTTP("POST", PathValidatorsSign+pubKeyHex, reqBody)
 		require.NoError(t, err)
 		assert.Equal(t, fasthttp.StatusInternalServerError, resp.StatusCode())
+		assert.JSONEq(t, `{"message":"remote signer error"}`, string(resp.Body()))
 
 		s.remoteSigner.SignError = nil
 	})

--- a/ssvsigner/web3signer/web3signer.go
+++ b/ssvsigner/web3signer/web3signer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -58,7 +59,7 @@ func (w3s *Web3Signer) ListKeys(ctx context.Context) (ListKeysResponse, error) {
 		Client(w3s.httpClient).
 		Path(PathPublicKeys).
 		ToJSON(&resp).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errResp))).
+		AddValidator(errTextValidator(&errResp)).
 		Fetch(ctx)
 	return resp, w3s.handleWeb3SignerErr(err, errResp)
 }
@@ -85,7 +86,7 @@ func (w3s *Web3Signer) ImportKeystore(ctx context.Context, req ImportKeystoreReq
 		BodyJSON(req).
 		Post().
 		ToJSON(&resp).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errResp))).
+		AddValidator(errTextValidator(&errResp)).
 		Fetch(ctx)
 	return resp, w3s.handleWeb3SignerErr(err, errResp)
 }
@@ -111,7 +112,7 @@ func (w3s *Web3Signer) DeleteKeystore(ctx context.Context, req DeleteKeystoreReq
 		BodyJSON(req).
 		Delete().
 		ToJSON(&resp).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errResp))).
+		AddValidator(errTextValidator(&errResp)).
 		Fetch(ctx)
 	return resp, w3s.handleWeb3SignerErr(err, errResp)
 }
@@ -148,9 +149,27 @@ func (w3s *Web3Signer) Sign(ctx context.Context, sharePubKey phase0.BLSPubKey, r
 		Post().
 		Accept("application/json").
 		ToJSON(&resp).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errResp))).
+		AddValidator(errTextValidator(&errResp)).
 		Fetch(ctx)
 	return resp, w3s.handleWeb3SignerErr(err, errResp)
+}
+
+// maxErrTextLen caps the upstream error body captured into HTTPResponseError.ErrText, so a
+// misbehaving Web3Signer can't force unbounded reads and allocations on failure (the node
+// applies its own cap when reading ssv-signer's response; see client.go maxErrBodyLen).
+const maxErrTextLen = 1024
+
+// errTextValidator defers to requests.DefaultValidator and, on a rejected status, captures a
+// bounded copy of the error body into *dst for handleWeb3SignerErr to attach as ErrText.
+func errTextValidator(dst *string) requests.ResponseHandler {
+	return requests.ValidatorHandler(requests.DefaultValidator, func(resp *http.Response) error {
+		b, err := io.ReadAll(io.LimitReader(resp.Body, maxErrTextLen))
+		if err != nil {
+			return err
+		}
+		*dst = string(b)
+		return nil
+	})
 }
 
 func (w3s *Web3Signer) handleWeb3SignerErr(err error, errResp string) error {
@@ -173,7 +192,7 @@ func (w3s *Web3Signer) UpCheck(ctx context.Context) error {
 		Client(w3s.httpClient).
 		Path(PathUpCheck).
 		CheckStatus(http.StatusOK).
-		AddValidator(requests.ValidatorHandler(requests.DefaultValidator, requests.ToString(&errResp))).
+		AddValidator(errTextValidator(&errResp)).
 		Fetch(ctx)
 	return w3s.handleWeb3SignerErr(err, errResp)
 }

--- a/ssvsigner/web3signer/web3signer.go
+++ b/ssvsigner/web3signer/web3signer.go
@@ -59,7 +59,7 @@ func (w3s *Web3Signer) ListKeys(ctx context.Context) (ListKeysResponse, error) {
 		Client(w3s.httpClient).
 		Path(PathPublicKeys).
 		ToJSON(&resp).
-		AddValidator(errTextValidator(&errResp)).
+		AddValidator(errTextValidator(requests.DefaultValidator, &errResp)).
 		Fetch(ctx)
 	return resp, w3s.handleWeb3SignerErr(err, errResp)
 }
@@ -86,7 +86,7 @@ func (w3s *Web3Signer) ImportKeystore(ctx context.Context, req ImportKeystoreReq
 		BodyJSON(req).
 		Post().
 		ToJSON(&resp).
-		AddValidator(errTextValidator(&errResp)).
+		AddValidator(errTextValidator(requests.DefaultValidator, &errResp)).
 		Fetch(ctx)
 	return resp, w3s.handleWeb3SignerErr(err, errResp)
 }
@@ -112,7 +112,7 @@ func (w3s *Web3Signer) DeleteKeystore(ctx context.Context, req DeleteKeystoreReq
 		BodyJSON(req).
 		Delete().
 		ToJSON(&resp).
-		AddValidator(errTextValidator(&errResp)).
+		AddValidator(errTextValidator(requests.DefaultValidator, &errResp)).
 		Fetch(ctx)
 	return resp, w3s.handleWeb3SignerErr(err, errResp)
 }
@@ -149,32 +149,48 @@ func (w3s *Web3Signer) Sign(ctx context.Context, sharePubKey phase0.BLSPubKey, r
 		Post().
 		Accept("application/json").
 		ToJSON(&resp).
-		AddValidator(errTextValidator(&errResp)).
+		AddValidator(errTextValidator(requests.DefaultValidator, &errResp)).
 		Fetch(ctx)
 	return resp, w3s.handleWeb3SignerErr(err, errResp)
 }
 
 // maxErrTextLen caps the upstream error body captured into HTTPResponseError.ErrText, so a
-// misbehaving Web3Signer can't force unbounded reads and allocations on failure (the node
-// applies its own cap when reading ssv-signer's response; see client.go maxErrBodyLen).
-const maxErrTextLen = 1024
-
-// errTextValidator runs requests.DefaultValidator and, on a rejected status, captures a
-// bounded copy of the upstream error body into *dst for handleWeb3SignerErr to attach as
-// ErrText.
+// misbehaving Web3Signer can't force unbounded reads and allocations on failure.
 //
-// It returns the validation error directly rather than wrapping it with
+// It stays well below the node's cap (client.go maxErrBodyLen, 1024): ErrText reaches the node
+// twice-escaped — HTTPResponseError.Error() quotes it with %q, then writeJSONErr JSON-encodes
+// that into the {"message":...} body — so a value near the node's cap would overflow the node's
+// read budget and arrive truncated mid-JSON, unparseable, instead of as the reason. 256 leaves
+// room for that expansion plus the envelope.
+const maxErrTextLen = 256
+
+// errTextValidator runs the given validator and, on a rejected response, captures a bounded copy
+// of the upstream error body into *dst for handleWeb3SignerErr to attach as ErrText. It reads one
+// byte past the cap and appends a truncation marker when the body is over-long, so a body sliced
+// mid-JSON is visibly cut rather than passing as complete (the node's errBodyValidator reads the
+// same extra byte but marks it later, in requestFailedErr).
+//
+// It returns the validator's error directly rather than wrapping it with
 // requests.ValidatorHandler, which labels a successful body capture "handled recovery from
 // invalid response" — a phrase that would otherwise travel into HTTPResponseError.Err, the
 // signer's logs, and the error body returned to the node.
-func errTextValidator(dst *string) requests.ResponseHandler {
+//
+// Taking the validator as a parameter lets UpCheck run its stricter requests.CheckStatus(200)
+// through the same capture: a status check added separately would short-circuit ahead of this
+// handler (requests stops at the first failing validator) and leave ErrText empty on that
+// endpoint alone.
+func errTextValidator(validator requests.ResponseHandler, dst *string) requests.ResponseHandler {
 	return func(resp *http.Response) error {
-		err := requests.DefaultValidator(resp)
+		err := validator(resp)
 		if err == nil {
 			return nil
 		}
-		if b, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrTextLen)); readErr == nil {
-			*dst = string(b)
+		if b, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrTextLen+1)); readErr == nil {
+			text := string(b)
+			if len(b) > maxErrTextLen {
+				text = text[:maxErrTextLen] + "...(truncated)"
+			}
+			*dst = text
 		}
 		return err
 	}
@@ -199,8 +215,7 @@ func (w3s *Web3Signer) UpCheck(ctx context.Context) error {
 		URL(w3s.baseURL).
 		Client(w3s.httpClient).
 		Path(PathUpCheck).
-		CheckStatus(http.StatusOK).
-		AddValidator(errTextValidator(&errResp)).
+		AddValidator(errTextValidator(requests.CheckStatus(http.StatusOK), &errResp)).
 		Fetch(ctx)
 	return w3s.handleWeb3SignerErr(err, errResp)
 }

--- a/ssvsigner/web3signer/web3signer.go
+++ b/ssvsigner/web3signer/web3signer.go
@@ -134,7 +134,7 @@ type SignRequest struct {
 }
 
 type SignResponse struct {
-	Signature phase0.BLSSignature `json:"signature,omitempty"`
+	Signature phase0.BLSSignature `json:"signature"`
 }
 
 // Sign signs using https://consensys.github.io/web3signer/web3signer-eth2.html#tag/Signing/operation/ETH2_SIGN
@@ -159,17 +159,25 @@ func (w3s *Web3Signer) Sign(ctx context.Context, sharePubKey phase0.BLSPubKey, r
 // applies its own cap when reading ssv-signer's response; see client.go maxErrBodyLen).
 const maxErrTextLen = 1024
 
-// errTextValidator defers to requests.DefaultValidator and, on a rejected status, captures a
-// bounded copy of the error body into *dst for handleWeb3SignerErr to attach as ErrText.
+// errTextValidator runs requests.DefaultValidator and, on a rejected status, captures a
+// bounded copy of the upstream error body into *dst for handleWeb3SignerErr to attach as
+// ErrText.
+//
+// It returns the validation error directly rather than wrapping it with
+// requests.ValidatorHandler, which labels a successful body capture "handled recovery from
+// invalid response" — a phrase that would otherwise travel into HTTPResponseError.Err, the
+// signer's logs, and the error body returned to the node.
 func errTextValidator(dst *string) requests.ResponseHandler {
-	return requests.ValidatorHandler(requests.DefaultValidator, func(resp *http.Response) error {
-		b, err := io.ReadAll(io.LimitReader(resp.Body, maxErrTextLen))
-		if err != nil {
-			return err
+	return func(resp *http.Response) error {
+		err := requests.DefaultValidator(resp)
+		if err == nil {
+			return nil
 		}
-		*dst = string(b)
-		return nil
-	})
+		if b, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrTextLen)); readErr == nil {
+			*dst = string(b)
+		}
+		return err
+	}
 }
 
 func (w3s *Web3Signer) handleWeb3SignerErr(err error, errResp string) error {

--- a/ssvsigner/web3signer/web3signer_test.go
+++ b/ssvsigner/web3signer/web3signer_test.go
@@ -471,6 +471,29 @@ func TestErrTextBounded(t *testing.T) {
 	require.LessOrEqual(t, len(httpErr.ErrText), maxErrTextLen)
 }
 
+// TestErrOmitsHandledRecoveryPhrase guards against errTextValidator reintroducing the
+// requests.ValidatorHandler "handled recovery from invalid response" phrase: capturing the
+// upstream body is the normal failure path, and the phrase would otherwise travel into
+// HTTPResponseError.Err, the signer's logs, and the error body returned to the node.
+func TestErrOmitsHandledRecoveryPhrase(t *testing.T) {
+	t.Parallel()
+
+	_, web3Signer := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("upstream boom"))
+	})
+
+	_, err := web3Signer.ListKeys(t.Context())
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "handled recovery from invalid response")
+
+	var httpErr HTTPResponseError
+	require.ErrorAs(t, err, &httpErr)
+	require.Equal(t, http.StatusInternalServerError, httpErr.Status)
+	require.Equal(t, "upstream boom", httpErr.ErrText)
+	require.NotContains(t, httpErr.Err.Error(), "handled recovery from invalid response")
+}
+
 func TestTLSConfig(t *testing.T) {
 	t.Parallel()
 

--- a/ssvsigner/web3signer/web3signer_test.go
+++ b/ssvsigner/web3signer/web3signer_test.go
@@ -412,6 +412,7 @@ func TestUpCheck(t *testing.T) {
 		name            string
 		setupServer     func(w http.ResponseWriter, r *http.Request)
 		wantErrContains string
+		wantErrText     string
 	}{
 		{
 			name: "successful up check",
@@ -429,6 +430,19 @@ func TestUpCheck(t *testing.T) {
 			},
 			wantErrContains: "error status 500",
 		},
+		{
+			// UpCheck validates a stricter status (exactly 200) than the other endpoints, yet
+			// must still capture the upstream body into ErrText on failure: the status check
+			// runs through errTextValidator instead of short-circuiting ahead of it.
+			name: "server error body is captured",
+			setupServer: func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, PathUpCheck, r.URL.Path)
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte("web3signer starting up"))
+			},
+			wantErrContains: "error status 503",
+			wantErrText:     "web3signer starting up",
+		},
 	}
 
 	for _, tt := range testCases {
@@ -445,6 +459,9 @@ func TestUpCheck(t *testing.T) {
 
 				var httpErr HTTPResponseError
 				require.ErrorAs(t, err, &httpErr)
+				if tt.wantErrText != "" {
+					require.Equal(t, tt.wantErrText, httpErr.ErrText)
+				}
 			} else {
 				require.NoError(t, err)
 			}
@@ -456,7 +473,9 @@ func TestErrTextBounded(t *testing.T) {
 	t.Parallel()
 
 	// The upstream returns a body larger than the cap; ErrText must be bounded so a
-	// misbehaving Web3Signer can't force unbounded reads and allocations on failure.
+	// misbehaving Web3Signer can't force unbounded reads and allocations on failure, and the
+	// truncation must be marked so a body sliced mid-JSON is visible rather than passing as
+	// complete.
 	const upstreamBodyLen = maxErrTextLen * 4
 
 	_, web3Signer := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -468,7 +487,8 @@ func TestErrTextBounded(t *testing.T) {
 
 	var httpErr HTTPResponseError
 	require.ErrorAs(t, err, &httpErr)
-	require.LessOrEqual(t, len(httpErr.ErrText), maxErrTextLen)
+	require.LessOrEqual(t, len(httpErr.ErrText), maxErrTextLen+len("...(truncated)"))
+	require.Contains(t, httpErr.ErrText, "...(truncated)")
 }
 
 // TestErrOmitsHandledRecoveryPhrase guards against errTextValidator reintroducing the

--- a/ssvsigner/web3signer/web3signer_test.go
+++ b/ssvsigner/web3signer/web3signer_test.go
@@ -452,6 +452,25 @@ func TestUpCheck(t *testing.T) {
 	}
 }
 
+func TestErrTextBounded(t *testing.T) {
+	t.Parallel()
+
+	// The upstream returns a body larger than the cap; ErrText must be bounded so a
+	// misbehaving Web3Signer can't force unbounded reads and allocations on failure.
+	const upstreamBodyLen = maxErrTextLen * 4
+
+	_, web3Signer := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(bytes.Repeat([]byte("x"), upstreamBodyLen))
+	})
+
+	_, err := web3Signer.ListKeys(t.Context())
+
+	var httpErr HTTPResponseError
+	require.ErrorAs(t, err, &httpErr)
+	require.LessOrEqual(t, len(httpErr.ErrText), maxErrTextLen)
+}
+
 func TestTLSConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

A production node failed startup with:

```
FATAL could not start node: failed to check for missing keys: get remote keys: ErrValidator: response error for https://127.0.0.1:8090/v1/validators: unexpected status: 500
```

The node log carries no hint of *why* the signer returned 500 — diagnosing required correlating logs across ssv-signer and Web3Signer. Two gaps cause that: ssv-signer replies to Web3Signer failures with an empty payload (the zero-value response), and the node's client discards error response bodies on most endpoints.

## Changes

**Server** (`ssvsigner/server.go`):
- `handleWeb3SignerErr` now responds with the usual `{"message": ...}` error body (via `writeJSONErr`) describing the Web3Signer failure — e.g. `dial tcp ...: connection refused`, `context deadline exceeded`, or the status + body Web3Signer returned — instead of writing the zero-value response. The `resp` parameter is dropped: it was always the zero value on this path.
- **Bug fix uncovered by the new test:** the `errors.As` target for `web3signer.HTTPResponseError` was `**HTTPResponseError` (via `new(...)` + `&`), while the web3signer client returns the value type — so the match never fired and *every* upstream failure surfaced as 500, regardless of Web3Signer's real status (e.g. slashing-protection 412s). Statuses are now actually propagated, as `DESIGN.md`/docs already claimed.

**Client** (`ssvsigner/client.go`):
- All endpoints now capture the error response body and attach it to the returned error (truncated to 1 KB; bodies with no information — empty, `null`, `{}` from older servers — are skipped), matching what `AddValidators` already did for 422s. With both sides deployed, the startup failure above becomes self-diagnosing from the node log alone, and signing failures (e.g. slashing denials) show their reason too.

## Compatibility

Only error *bodies/texts* change; success responses, routes, and status sentinels (422 share-decryption, 404/405/501 data-protection-unsupported) are untouched, and `%w` wrapping preserves `requests.HasStatusErr` checks. Mixed old/new versions of node and signer remain interoperable — clients never parse error bodies structurally.

## Testing

- Extended `TestListValidators` (server) with body assertions and a Web3Signer-status-propagation case (this is the test that caught the `errors.As` bug).
- Extended `TestListValidators`/`TestSign` (client) to assert the server-provided reason lands in returned errors.
- `go test ./...` for the ssvsigner module (excl. Docker e2e), `go build ./...` + `go test ./cli/operator/...` for the root module.