### PR TITLE
cli/operator: retry the startup missing-keys check before failing the node

### DIFF
--- a/cli/operator/keys.go
+++ b/cli/operator/keys.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"go.uber.org/zap"
@@ -27,8 +28,19 @@ import (
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
+// The remote signer may be briefly unavailable when the missing-keys check runs —
+// most commonly when the whole stack (node, ssv-signer, web3signer) restarts
+// together and web3signer is still starting or loading keys — so the check retries
+// with backoff for a bounded window instead of failing startup on the first error.
+const (
+	missingKeysRetryWindow   = 2 * time.Minute
+	missingKeysRetryDelay    = time.Second
+	missingKeysRetryMaxDelay = 16 * time.Second
+)
+
 func ensureNoMissingKeys(
 	ctx context.Context,
+	logger *zap.Logger,
 	nodeStorage operatorstorage.Storage,
 	operatorDataStore operatordatastore.OperatorDataStore,
 	ssvSignerClient *ssvsigner.Client,
@@ -51,7 +63,7 @@ func ensureNoMissingKeys(
 		localKeys = append(localKeys, phase0.BLSPubKey(share.SharePubKey))
 	}
 
-	missingKeys, err := ssvSignerClient.MissingKeys(ctx, localKeys)
+	missingKeys, err := fetchMissingKeysWithRetry(ctx, logger, ssvSignerClient, localKeys, missingKeysRetryWindow, missingKeysRetryDelay)
 	if err != nil {
 		return fmt.Errorf("failed to check for missing keys: %w", err)
 	}
@@ -65,6 +77,48 @@ func ensureNoMissingKeys(
 		return startupError{err: fmt.Errorf("remote signer misses keys"), fields: []zap.Field{keysField}}
 	}
 	return nil
+}
+
+// fetchMissingKeysWithRetry calls MissingKeys on the remote signer, retrying failed
+// attempts with exponential backoff until the window elapses or ctx is canceled.
+// All errors are retried: transient ones (the signer stack still starting up)
+// resolve within the window, and persistent ones only postpone the startup failure
+// by at most the window.
+func fetchMissingKeysWithRetry(
+	ctx context.Context,
+	logger *zap.Logger,
+	ssvSignerClient *ssvsigner.Client,
+	localKeys []phase0.BLSPubKey,
+	window time.Duration,
+	delay time.Duration,
+) ([]phase0.BLSPubKey, error) {
+	deadline := time.Now().Add(window)
+	for {
+		missingKeys, err := ssvSignerClient.MissingKeys(ctx, localKeys)
+		if err == nil {
+			return missingKeys, nil
+		}
+
+		// Give up if ctx is done or the next attempt wouldn't start within the window.
+		if ctx.Err() != nil || time.Now().Add(delay).After(deadline) {
+			return nil, err
+		}
+
+		logger.Warn("failed to check for missing keys in remote signer, retrying",
+			zap.Duration("retry_in", delay),
+			zap.Error(err))
+
+		select {
+		case <-ctx.Done():
+			return nil, err
+		case <-time.After(delay):
+		}
+
+		delay *= 2
+		if delay > missingKeysRetryMaxDelay {
+			delay = missingKeysRetryMaxDelay
+		}
+	}
 }
 
 func privateKeyFromKeystore(privKeyFile, passwordFile string) (keys.OperatorPrivateKey, []byte, error) {

--- a/cli/operator/keys.go
+++ b/cli/operator/keys.go
@@ -119,10 +119,7 @@ func fetchMissingKeysWithRetry(
 		case <-time.After(delay):
 		}
 
-		delay *= 2
-		if delay > missingKeysRetryMaxDelay {
-			delay = missingKeysRetryMaxDelay
-		}
+		delay = min(delay*2, missingKeysRetryMaxDelay)
 	}
 }
 

--- a/cli/operator/keys.go
+++ b/cli/operator/keys.go
@@ -81,9 +81,14 @@ func ensureNoMissingKeys(
 
 // fetchMissingKeysWithRetry calls MissingKeys on the remote signer, retrying failed
 // attempts with exponential backoff until the window elapses or ctx is canceled.
+// The window bounds when attempts may start, not the total duration: an in-flight
+// attempt is never cut short (each is already bounded by the client's request
+// timeout), so the final one may finish up to that timeout past the window. A hard
+// cutoff would only clip the last attempt and mask its underlying error with a
+// context error.
 // All errors are retried: transient ones (the signer stack still starting up)
 // resolve within the window, and persistent ones only postpone the startup failure
-// by at most the window.
+// by roughly the window.
 func fetchMissingKeysWithRetry(
 	ctx context.Context,
 	logger *zap.Logger,

--- a/cli/operator/keys.go
+++ b/cli/operator/keys.go
@@ -28,15 +28,22 @@ import (
 	"github.com/ssvlabs/ssv/storage/basedb"
 )
 
+// retryBackoff configures fetchMissingKeysWithRetry's bounded exponential backoff.
+type retryBackoff struct {
+	window   time.Duration // span in which new attempts may start
+	delay    time.Duration // wait before the first retry, doubled after each failure
+	maxDelay time.Duration // ceiling for the doubling delay
+}
+
 // The remote signer may be briefly unavailable when the missing-keys check runs —
 // most commonly when the whole stack (node, ssv-signer, web3signer) restarts
 // together and web3signer is still starting or loading keys — so the check retries
 // with backoff for a bounded window instead of failing startup on the first error.
-const (
-	missingKeysRetryWindow   = 2 * time.Minute
-	missingKeysRetryDelay    = time.Second
-	missingKeysRetryMaxDelay = 16 * time.Second
-)
+var missingKeysRetryBackoff = retryBackoff{
+	window:   2 * time.Minute,
+	delay:    time.Second,
+	maxDelay: 16 * time.Second,
+}
 
 func ensureNoMissingKeys(
 	ctx context.Context,
@@ -63,7 +70,7 @@ func ensureNoMissingKeys(
 		localKeys = append(localKeys, phase0.BLSPubKey(share.SharePubKey))
 	}
 
-	missingKeys, err := fetchMissingKeysWithRetry(ctx, logger, ssvSignerClient, localKeys, missingKeysRetryWindow, missingKeysRetryDelay)
+	missingKeys, err := fetchMissingKeysWithRetry(ctx, logger, ssvSignerClient, localKeys, missingKeysRetryBackoff)
 	if err != nil {
 		return fmt.Errorf("failed to check for missing keys: %w", err)
 	}
@@ -81,23 +88,24 @@ func ensureNoMissingKeys(
 
 // fetchMissingKeysWithRetry calls MissingKeys on the remote signer, retrying failed
 // attempts with exponential backoff until the window elapses or ctx is canceled.
+//
 // The window bounds when attempts may start, not the total duration: an in-flight
-// attempt is never cut short (each is already bounded by the client's request
-// timeout), so the final one may finish up to that timeout past the window. A hard
-// cutoff would only clip the last attempt and mask its underlying error with a
-// context error.
+// attempt is never cut short (it is already bounded by the client's request
+// timeout), so the last one may finish up to that timeout past the window — a hard
+// cutoff would only clip it and mask its error with a context error.
+//
 // All errors are retried: transient ones (the signer stack still starting up)
-// resolve within the window, and persistent ones only postpone the startup failure
-// by roughly the window.
+// resolve within the window; persistent ones only postpone the startup failure by
+// roughly the window.
 func fetchMissingKeysWithRetry(
 	ctx context.Context,
 	logger *zap.Logger,
 	ssvSignerClient *ssvsigner.Client,
 	localKeys []phase0.BLSPubKey,
-	window time.Duration,
-	delay time.Duration,
+	backoff retryBackoff,
 ) ([]phase0.BLSPubKey, error) {
-	deadline := time.Now().Add(window)
+	deadline := time.Now().Add(backoff.window)
+	delay := backoff.delay
 	for {
 		missingKeys, err := ssvSignerClient.MissingKeys(ctx, localKeys)
 		if err == nil {
@@ -119,7 +127,7 @@ func fetchMissingKeysWithRetry(
 		case <-time.After(delay):
 		}
 
-		delay = min(delay*2, missingKeysRetryMaxDelay)
+		delay = min(delay*2, backoff.maxDelay)
 	}
 }
 

--- a/cli/operator/keys_test.go
+++ b/cli/operator/keys_test.go
@@ -16,20 +16,26 @@ import (
 	"github.com/ssvlabs/ssv/ssvsigner"
 )
 
+// newMissingKeysClient returns an ssv-signer client whose validators endpoint —
+// the one MissingKeys queries — is served by handler.
+func newMissingKeysClient(t *testing.T, handler http.HandlerFunc) *ssvsigner.Client {
+	return newTestSSVSignerClient(t, func(mux *http.ServeMux) {
+		mux.HandleFunc(ssvsigner.PathValidators, handler)
+	})
+}
+
 func Test_fetchMissingKeysWithRetry(t *testing.T) {
 	localKeys := []phase0.BLSPubKey{{1, 2, 3}}
 
 	t.Run("succeeds after transient failures", func(t *testing.T) {
 		var hits int
-		client := newTestSSVSignerClient(t, func(mux *http.ServeMux) {
-			mux.HandleFunc(ssvsigner.PathValidators, func(w http.ResponseWriter, r *http.Request) {
-				hits++
-				if hits <= 2 {
-					http.Error(w, "web3signer starting up", http.StatusInternalServerError)
-					return
-				}
-				require.NoError(t, json.NewEncoder(w).Encode(localKeys))
-			})
+		client := newMissingKeysClient(t, func(w http.ResponseWriter, r *http.Request) {
+			hits++
+			if hits <= 2 {
+				http.Error(w, "web3signer starting up", http.StatusInternalServerError)
+				return
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(localKeys))
 		})
 
 		missingKeys, err := fetchMissingKeysWithRetry(
@@ -42,11 +48,9 @@ func Test_fetchMissingKeysWithRetry(t *testing.T) {
 
 	t.Run("gives up when the window elapses", func(t *testing.T) {
 		var hits int
-		client := newTestSSVSignerClient(t, func(mux *http.ServeMux) {
-			mux.HandleFunc(ssvsigner.PathValidators, func(w http.ResponseWriter, r *http.Request) {
-				hits++
-				http.Error(w, "permanent failure", http.StatusInternalServerError)
-			})
+		client := newMissingKeysClient(t, func(w http.ResponseWriter, r *http.Request) {
+			hits++
+			http.Error(w, "permanent failure", http.StatusInternalServerError)
 		})
 
 		_, err := fetchMissingKeysWithRetry(
@@ -60,11 +64,9 @@ func Test_fetchMissingKeysWithRetry(t *testing.T) {
 	// before reaching any backoff wait.
 	t.Run("stops retrying when ctx is canceled during a request", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		client := newTestSSVSignerClient(t, func(mux *http.ServeMux) {
-			mux.HandleFunc(ssvsigner.PathValidators, func(w http.ResponseWriter, r *http.Request) {
-				cancel()
-				http.Error(w, "failure", http.StatusInternalServerError)
-			})
+		client := newMissingKeysClient(t, func(w http.ResponseWriter, r *http.Request) {
+			cancel()
+			http.Error(w, "failure", http.StatusInternalServerError)
 		})
 
 		start := time.Now()
@@ -78,10 +80,8 @@ func Test_fetchMissingKeysWithRetry(t *testing.T) {
 	// Cancellation during the backoff wait (the select), not a request — the path
 	// that keeps shutdown prompt when a signal lands mid-backoff.
 	t.Run("aborts the backoff wait when ctx is canceled between attempts", func(t *testing.T) {
-		client := newTestSSVSignerClient(t, func(mux *http.ServeMux) {
-			mux.HandleFunc(ssvsigner.PathValidators, func(w http.ResponseWriter, r *http.Request) {
-				http.Error(w, "failure", http.StatusInternalServerError)
-			})
+		client := newMissingKeysClient(t, func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "failure", http.StatusInternalServerError)
 		})
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -117,14 +117,12 @@ func Test_fetchMissingKeysWithRetry(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		var hits int
-		client := newTestSSVSignerClient(t, func(mux *http.ServeMux) {
-			mux.HandleFunc(ssvsigner.PathValidators, func(w http.ResponseWriter, r *http.Request) {
-				hits++
-				if hits >= stopAfter {
-					cancel() // stop retrying once enough backoffs are logged
-				}
-				http.Error(w, "web3signer starting up", http.StatusInternalServerError)
-			})
+		client := newMissingKeysClient(t, func(w http.ResponseWriter, r *http.Request) {
+			hits++
+			if hits >= stopAfter {
+				cancel() // stop retrying once enough backoffs are logged
+			}
+			http.Error(w, "web3signer starting up", http.StatusInternalServerError)
 		})
 
 		initialDelay, maxDelay := time.Millisecond, 4*time.Millisecond
@@ -133,8 +131,9 @@ func Test_fetchMissingKeysWithRetry(t *testing.T) {
 			retryBackoff{window: time.Hour, delay: initialDelay, maxDelay: maxDelay})
 		require.Error(t, err)
 
-		var delays []time.Duration
-		for _, entry := range logs.All() {
+		entries := logs.All()
+		delays := make([]time.Duration, 0, len(entries))
+		for _, entry := range entries {
 			d, ok := entry.ContextMap()["retry_in"].(time.Duration)
 			require.True(t, ok, "retry log is missing a retry_in duration")
 			delays = append(delays, d)

--- a/cli/operator/keys_test.go
+++ b/cli/operator/keys_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/ssvlabs/ssv/ssvsigner"
 )
@@ -31,7 +33,8 @@ func Test_fetchMissingKeysWithRetry(t *testing.T) {
 		})
 
 		missingKeys, err := fetchMissingKeysWithRetry(
-			context.Background(), zap.NewNop(), client, localKeys, time.Minute, time.Millisecond)
+			context.Background(), zap.NewNop(), client, localKeys,
+			retryBackoff{window: time.Minute, delay: time.Millisecond, maxDelay: 16 * time.Millisecond})
 		require.NoError(t, err)
 		require.Empty(t, missingKeys)
 		require.Equal(t, 3, hits)
@@ -47,7 +50,8 @@ func Test_fetchMissingKeysWithRetry(t *testing.T) {
 		})
 
 		_, err := fetchMissingKeysWithRetry(
-			context.Background(), zap.NewNop(), client, localKeys, 200*time.Millisecond, 20*time.Millisecond)
+			context.Background(), zap.NewNop(), client, localKeys,
+			retryBackoff{window: 200 * time.Millisecond, delay: 20 * time.Millisecond, maxDelay: time.Second})
 		require.ErrorContains(t, err, "unexpected status: 500")
 		require.Greater(t, hits, 1, "expected at least one retry within the window")
 	})
@@ -65,7 +69,8 @@ func Test_fetchMissingKeysWithRetry(t *testing.T) {
 
 		start := time.Now()
 		_, err := fetchMissingKeysWithRetry(
-			ctx, zap.NewNop(), client, localKeys, time.Hour, time.Hour)
+			ctx, zap.NewNop(), client, localKeys,
+			retryBackoff{window: time.Hour, delay: time.Hour, maxDelay: time.Hour})
 		require.Error(t, err)
 		require.Less(t, time.Since(start), time.Minute, "expected to give up without waiting out the backoff")
 	})
@@ -90,7 +95,8 @@ func Test_fetchMissingKeysWithRetry(t *testing.T) {
 		done := make(chan error, 1)
 		go func() {
 			_, err := fetchMissingKeysWithRetry(
-				ctx, zap.NewNop(), client, localKeys, time.Hour, 10*time.Second)
+				ctx, zap.NewNop(), client, localKeys,
+				retryBackoff{window: time.Hour, delay: 10 * time.Second, maxDelay: time.Minute})
 			done <- err
 		}()
 
@@ -100,5 +106,46 @@ func Test_fetchMissingKeysWithRetry(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			t.Fatal("expected the backoff wait to be interrupted by ctx cancellation")
 		}
+	})
+
+	// Drive several retries against a small injected cap and assert the logged
+	// retry_in delays double from the initial value and then plateau at the cap.
+	t.Run("caps the backoff delay at maxDelay", func(t *testing.T) {
+		const stopAfter = 6 // enough retries to reach the cap and stay there
+
+		core, logs := observer.New(zapcore.DebugLevel)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var hits int
+		client := newTestSSVSignerClient(t, func(mux *http.ServeMux) {
+			mux.HandleFunc(ssvsigner.PathValidators, func(w http.ResponseWriter, r *http.Request) {
+				hits++
+				if hits >= stopAfter {
+					cancel() // stop retrying once enough backoffs are logged
+				}
+				http.Error(w, "web3signer starting up", http.StatusInternalServerError)
+			})
+		})
+
+		initialDelay, maxDelay := time.Millisecond, 4*time.Millisecond
+		_, err := fetchMissingKeysWithRetry(
+			ctx, zap.New(core), client, localKeys,
+			retryBackoff{window: time.Hour, delay: initialDelay, maxDelay: maxDelay})
+		require.Error(t, err)
+
+		var delays []time.Duration
+		for _, entry := range logs.All() {
+			d, ok := entry.ContextMap()["retry_in"].(time.Duration)
+			require.True(t, ok, "retry log is missing a retry_in duration")
+			delays = append(delays, d)
+		}
+		require.GreaterOrEqual(t, len(delays), 4, "need enough retries to observe the plateau")
+
+		want := initialDelay
+		for i, got := range delays {
+			require.Equal(t, want, got, "unexpected backoff at retry %d", i)
+			want = min(want*2, maxDelay)
+		}
+		require.Equal(t, maxDelay, delays[len(delays)-1], "backoff should plateau at the cap")
 	})
 }

--- a/cli/operator/keys_test.go
+++ b/cli/operator/keys_test.go
@@ -47,12 +47,14 @@ func Test_fetchMissingKeysWithRetry(t *testing.T) {
 		})
 
 		_, err := fetchMissingKeysWithRetry(
-			context.Background(), zap.NewNop(), client, localKeys, 50*time.Millisecond, 10*time.Millisecond)
+			context.Background(), zap.NewNop(), client, localKeys, 200*time.Millisecond, 20*time.Millisecond)
 		require.ErrorContains(t, err, "unexpected status: 500")
 		require.Greater(t, hits, 1, "expected at least one retry within the window")
 	})
 
-	t.Run("stops retrying when ctx is canceled", func(t *testing.T) {
+	// Cancellation during a request: the helper bails at the ctx.Err() check,
+	// before reaching any backoff wait.
+	t.Run("stops retrying when ctx is canceled during a request", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		client := newTestSSVSignerClient(t, func(mux *http.ServeMux) {
 			mux.HandleFunc(ssvsigner.PathValidators, func(w http.ResponseWriter, r *http.Request) {
@@ -66,5 +68,37 @@ func Test_fetchMissingKeysWithRetry(t *testing.T) {
 			ctx, zap.NewNop(), client, localKeys, time.Hour, time.Hour)
 		require.Error(t, err)
 		require.Less(t, time.Since(start), time.Minute, "expected to give up without waiting out the backoff")
+	})
+
+	// Cancellation during the backoff wait (the select), not a request — the path
+	// that keeps shutdown prompt when a signal lands mid-backoff.
+	t.Run("aborts the backoff wait when ctx is canceled between attempts", func(t *testing.T) {
+		client := newTestSSVSignerClient(t, func(mux *http.ServeMux) {
+			mux.HandleFunc(ssvsigner.PathValidators, func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "failure", http.StatusInternalServerError)
+			})
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		// First attempt fails fast; cancel while the retry is parked on its long
+		// backoff, so cancellation interrupts the wait itself.
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			cancel()
+		}()
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := fetchMissingKeysWithRetry(
+				ctx, zap.NewNop(), client, localKeys, time.Hour, 10*time.Second)
+			done <- err
+		}()
+
+		select {
+		case err := <-done:
+			require.Error(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("expected the backoff wait to be interrupted by ctx cancellation")
+		}
 	})
 }

--- a/cli/operator/keys_test.go
+++ b/cli/operator/keys_test.go
@@ -1,0 +1,70 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/ssvsigner"
+)
+
+func Test_fetchMissingKeysWithRetry(t *testing.T) {
+	localKeys := []phase0.BLSPubKey{{1, 2, 3}}
+
+	t.Run("succeeds after transient failures", func(t *testing.T) {
+		var hits int
+		client := newTestSSVSignerClient(t, func(mux *http.ServeMux) {
+			mux.HandleFunc(ssvsigner.PathValidators, func(w http.ResponseWriter, r *http.Request) {
+				hits++
+				if hits <= 2 {
+					http.Error(w, "web3signer starting up", http.StatusInternalServerError)
+					return
+				}
+				require.NoError(t, json.NewEncoder(w).Encode(localKeys))
+			})
+		})
+
+		missingKeys, err := fetchMissingKeysWithRetry(
+			context.Background(), zap.NewNop(), client, localKeys, time.Minute, time.Millisecond)
+		require.NoError(t, err)
+		require.Empty(t, missingKeys)
+		require.Equal(t, 3, hits)
+	})
+
+	t.Run("gives up when the window elapses", func(t *testing.T) {
+		var hits int
+		client := newTestSSVSignerClient(t, func(mux *http.ServeMux) {
+			mux.HandleFunc(ssvsigner.PathValidators, func(w http.ResponseWriter, r *http.Request) {
+				hits++
+				http.Error(w, "permanent failure", http.StatusInternalServerError)
+			})
+		})
+
+		_, err := fetchMissingKeysWithRetry(
+			context.Background(), zap.NewNop(), client, localKeys, 50*time.Millisecond, 10*time.Millisecond)
+		require.ErrorContains(t, err, "unexpected status: 500")
+		require.Greater(t, hits, 1, "expected at least one retry within the window")
+	})
+
+	t.Run("stops retrying when ctx is canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		client := newTestSSVSignerClient(t, func(mux *http.ServeMux) {
+			mux.HandleFunc(ssvsigner.PathValidators, func(w http.ResponseWriter, r *http.Request) {
+				cancel()
+				http.Error(w, "failure", http.StatusInternalServerError)
+			})
+		})
+
+		start := time.Now()
+		_, err := fetchMissingKeysWithRetry(
+			ctx, zap.NewNop(), client, localKeys, time.Hour, time.Hour)
+		require.Error(t, err)
+		require.Less(t, time.Since(start), time.Minute, "expected to give up without waiting out the backoff")
+	})
+}

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -572,7 +572,7 @@ func (n *node) start(ctx context.Context, spawn func(func() error)) error {
 	}
 
 	if n.usingSSVSigner {
-		if err := ensureNoMissingKeys(ctx, n.nodeStorage, n.operatorDataStore, n.ssvSignerClient); err != nil {
+		if err := ensureNoMissingKeys(ctx, n.logger, n.nodeStorage, n.operatorDataStore, n.ssvSignerClient); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Motivation

A production node hit:

```
FATAL could not start node: failed to check for missing keys: get remote keys: ErrValidator: response error for https://127.0.0.1:8090/v1/validators: unexpected status: 500
```

The missing-keys check is the **first call in the startup sequence that requires Web3Signer to be alive** (everything before it is served by ssv-signer alone), and a single failure is fatal. When the whole stack restarts together — node, ssv-signer, web3signer — the node races a web3signer that is still starting or bulk-loading keys, dies, and crash-loops via the supervisor until web3signer is ready. That works, but produces process churn, alert noise, and FATAL logs for a routine ordering race.

## Changes

`ensureNoMissingKeys` now retries the `MissingKeys` call with exponential backoff (1s doubling to a 16s cap) for a bounded 2-minute window before giving up and failing startup exactly as before. Each failed attempt logs a WARN with the error and the next delay, so startup never looks hung. Ctx cancellation aborts the wait immediately, keeping shutdown prompt.

All errors are retried rather than classified: transient ones (signer stack starting up) resolve within the window, and persistent ones (bad endpoint, broken web3signer) only postpone the inevitable startup failure by at most the window.

The "remote signer misses keys" outcome (successful check, keys genuinely absent) is **not** retried — that's a definitive state, still an immediate startup error.

## Testing

New `Test_fetchMissingKeysWithRetry` covers: success after transient 500s (verifying attempt count), giving up after the window with the underlying error preserved, and prompt abort on ctx cancellation. Full `go test ./cli/operator/...` and root-module build pass.

Related: with #3010, the retry WARNs (and the final error) also carry the signer-reported reason instead of a bare status code.