### PR TITLE
ssvsigner: correct stale docs and drop moot route-renaming TODOs

### DIFF
--- a/ssvsigner/CLAUDE.md
+++ b/ssvsigner/CLAUDE.md
@@ -29,7 +29,7 @@ SSV Signer is a lightweight remote signing service that acts as a security inter
 2. **Client** (`client.go`): HTTP client library for SSV nodes
     - Used by SSV nodes to communicate with SSV Signer
     - Supports TLS configuration
-    - Implements retry logic and error handling
+    - Single attempt per request: retrying is the caller's responsibility
 
 3. **EKM** (`ekm/`): Ethereum Key Manager abstraction
     - `RemoteKeyManager`: Delegates to SSV Signer (production)
@@ -157,7 +157,7 @@ BATCH_SIZE=20 \
 
 ### Error Handling
 - Decryption errors return specific status for malformed shares
-- Connection failures trigger retries with exponential backoff
+- Requests are not retried by the client; callers that need resilience implement their own retries
 - Web3Signer errors are propagated with original status codes
 
 ### Performance Optimizations

--- a/ssvsigner/CLAUDE.md
+++ b/ssvsigner/CLAUDE.md
@@ -29,7 +29,7 @@ SSV Signer is a lightweight remote signing service that acts as a security inter
 2. **Client** (`client.go`): HTTP client library for SSV nodes
     - Used by SSV nodes to communicate with SSV Signer
     - Supports TLS configuration
-    - Single attempt per request: retrying is the caller's responsibility
+    - Single attempt per request (retries are the caller's responsibility); wraps request errors, mapping some HTTP statuses to typed errors
 
 3. **EKM** (`ekm/`): Ethereum Key Manager abstraction
     - `RemoteKeyManager`: Delegates to SSV Signer (production)

--- a/ssvsigner/server.go
+++ b/ssvsigner/server.go
@@ -25,19 +25,17 @@ import (
 	"github.com/ssvlabs/ssv/ssvsigner/web3signer"
 )
 
-// TODO: The routes are currently custom and adhere DESIGN.md.
-//
-//	However, web3signer and eth remote signer APIs use different ones (prefixed with /api/v1/):
-//	- https://consensys.github.io/web3signer/web3signer-eth2.html
-//	- https://github.com/ethereum/remote-signing-api
-//	We need to decide if we need to match them.
+// The routes are custom, per DESIGN.md, and differ from the web3signer
+// (https://consensys.github.io/web3signer/web3signer-eth2.html) and eth remote-signing
+// (https://github.com/ethereum/remote-signing-api) APIs, which prefix theirs with /api/v1/.
+// Deployed nodes and signers depend on these paths, so renaming them would be a breaking change.
 const (
-	PathValidators       = "/v1/validators"        // TODO: /api/v1/eth2/publicKeys ?
-	PathValidatorsSign   = "/v1/validators/sign/"  // TODO: /api/v1/eth2/sign/ ?
-	PathOperatorIdentity = "/v1/operator/identity" // TODO: /api/v1/ssv/identity ?
-	PathOperatorSign     = "/v1/operator/sign"     // TODO: /api/v1/ssv/sign ?
-	PathOperatorEncrypt  = "/v1/operator/encrypt"  // TODO: /api/v1/ssv/encrypt ?
-	PathOperatorDecrypt  = "/v1/operator/decrypt"  // TODO: /api/v1/ssv/decrypt ?
+	PathValidators       = "/v1/validators"
+	PathValidatorsSign   = "/v1/validators/sign/"
+	PathOperatorIdentity = "/v1/operator/identity"
+	PathOperatorSign     = "/v1/operator/sign"
+	PathOperatorEncrypt  = "/v1/operator/encrypt"
+	PathOperatorDecrypt  = "/v1/operator/decrypt"
 )
 
 const (


### PR DESCRIPTION
Follow-ups from investigating a production startup failure (see #3010 / #3011), no behavior changes:

- **`ssvsigner/CLAUDE.md`**: claimed the client "implements retry logic" with "exponential backoff" — it never has (single attempt per request, 10s default timeout). Documented the actual contract: retries are the caller's responsibility. (#3011 adds exactly such a caller-side retry for the startup missing-keys check.)
- **`ssvsigner/server.go`**: the route constants carried `TODO: /api/v1/eth2/publicKeys ?`-style comments about matching web3signer's path conventions. Deployed nodes and signers depend on the current paths, so a rename would be a breaking change nobody plans — replaced the dangling decision with a factual note (kept the links to the web3signer / eth remote-signing API docs).