### PR TITLE
api: expose the node's operator identity on `/v1/node/identity`

### DIFF
--- a/api/handlers/node/mock_test.go
+++ b/api/handlers/node/mock_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/records"
+	registrystorage "github.com/ssvlabs/ssv/registry/storage"
 )
 
 // MockP2PNetwork is a simple value-based mock implementation of p2pNetwork.
@@ -152,4 +153,21 @@ func (m *MockPeersIndex) NodeInfo(id peer.ID) *records.NodeInfo {
 
 func (m *MockPeersIndex) GetPeerSubnets(id peer.ID) (commons.Subnets, bool) {
 	return m.peerSubnets, true
+}
+
+// MockOperatorDataStore is a simple value-based mock implementation of operatorDataStore.
+type MockOperatorDataStore struct {
+	// Returned by GetOperatorData()
+	OperatorDataValue *registrystorage.OperatorData
+
+	// Returned by OperatorIDReady()
+	OperatorIDReadyValue bool
+}
+
+func (m *MockOperatorDataStore) GetOperatorData() *registrystorage.OperatorData {
+	return m.OperatorDataValue
+}
+
+func (m *MockOperatorDataStore) OperatorIDReady() bool {
+	return m.OperatorIDReadyValue
 }

--- a/api/handlers/node/mock_test.go
+++ b/api/handlers/node/mock_test.go
@@ -159,15 +159,8 @@ func (m *MockPeersIndex) GetPeerSubnets(id peer.ID) (commons.Subnets, bool) {
 type MockOperatorDataStore struct {
 	// Returned by GetOperatorData()
 	OperatorDataValue *registrystorage.OperatorData
-
-	// Returned by OperatorIDReady()
-	OperatorIDReadyValue bool
 }
 
 func (m *MockOperatorDataStore) GetOperatorData() *registrystorage.OperatorData {
 	return m.OperatorDataValue
-}
-
-func (m *MockOperatorDataStore) OperatorIDReady() bool {
-	return m.OperatorIDReadyValue
 }

--- a/api/handlers/node/model.go
+++ b/api/handlers/node/model.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
 )
 
 const (
@@ -41,6 +42,17 @@ type identityJSON struct {
 	Addresses []string `json:"addresses"`
 	Subnets   string   `json:"subnets"`
 	Version   string   `json:"version"`
+	NetworkID string   `json:"network_id"`
+
+	// This node's operator identity, as opposed to the network identity above. These are
+	// omitted rather than zeroed because their absence is meaningful. A node running
+	// without an operator key (exporter mode) has none of them. OperatorID and
+	// OwnerAddress additionally stay absent until this operator's registration event has
+	// been synced, so a public key with no id means "registered but not yet observed, or
+	// not registered at all" - the public key is known from config at startup either way.
+	OperatorID        spectypes.OperatorID `json:"operator_id,omitempty"`
+	OperatorPublicKey string               `json:"operator_public_key,omitempty"`
+	OwnerAddress      string               `json:"owner_address,omitempty"`
 }
 
 type healthStatus struct{ err error }

--- a/api/handlers/node/node.go
+++ b/api/handlers/node/node.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"encoding/hex"
 	"errors"
 	"net/http"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	ma "github.com/multiformats/go-multiaddr"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
 
 	"github.com/ssvlabs/ssv/api"
 	"github.com/ssvlabs/ssv/hprobe"
@@ -24,7 +26,8 @@ type Node struct {
 	topicIndex topicIndex
 
 	// this node's own operator identity, as distinct from the p2p identity above
-	operatorDataStore operatorDataStore
+	operatorDataStore  operatorDataStore
+	domainTypeProvider func() spectypes.DomainType
 
 	healthProber             *hprobe.HealthProber
 	clComponentName          string
@@ -38,6 +41,7 @@ func NewNode(
 	network p2pNetwork,
 	topicIndex topicIndex,
 	operatorDataStore operatorDataStore,
+	domainTypeProvider func() spectypes.DomainType,
 	healthProber *hprobe.HealthProber,
 	clComponentName string,
 	elComponentName string,
@@ -49,6 +53,7 @@ func NewNode(
 		topicIndex:               topicIndex,
 		network:                  network,
 		operatorDataStore:        operatorDataStore,
+		domainTypeProvider:       domainTypeProvider,
 		healthProber:             healthProber,
 		clComponentName:          clComponentName,
 		elComponentName:          elComponentName,
@@ -61,27 +66,32 @@ func (h *Node) Identity(w http.ResponseWriter, r *http.Request) error {
 	resp := identityJSON{
 		PeerID: h.network.LocalPeer(),
 	}
-	if nodeInfo != nil {
-		resp.NetworkID = nodeInfo.NetworkID
-		// invariant: setupPeerServices initializes self.Metadata at startup, so on
-		// the live path nodeInfo.Metadata is always non-nil. The guard defends
-		// against a future UpdateSelfRecord caller that returns a NodeInfo without
-		// a Metadata block — cheap insurance and mirrors the peers-handler shape.
-		if nodeInfo.Metadata != nil {
-			resp.Subnets = nodeInfo.Metadata.Subnets
-			resp.Version = nodeInfo.Metadata.NodeVersion
-		}
+	// invariant: setupPeerServices initializes self.Metadata at startup, so on
+	// the live path nodeInfo.Metadata is always non-nil. The guard defends
+	// against a future UpdateSelfRecord caller that returns a NodeInfo without
+	// a Metadata block — cheap insurance and mirrors the peers-handler shape.
+	if nodeInfo != nil && nodeInfo.Metadata != nil {
+		resp.Subnets = nodeInfo.Metadata.Subnets
+		resp.Version = nodeInfo.Metadata.NodeVersion
 	}
+	// Read live rather than from the self record's NetworkID: that copy is only
+	// refreshed while sealing a node record for a handshake, so between a domain
+	// fork activating and the next handshake it still holds the pre-fork value.
+	domainType := h.domainTypeProvider()
+	resp.NetworkID = "0x" + hex.EncodeToString(domainType[:])
 	for _, addr := range h.network.ListenAddresses() {
 		resp.Addresses = append(resp.Addresses, addr.String())
 	}
 	// The operator public key is set from config at startup, so it identifies the node
-	// from first boot. The id and owner address arrive with this operator's registration
-	// event, so they are only reported once that has been synced - reporting id 0 and the
-	// zero address before then would read as real values.
+	// from first boot. The id and owner address arrive with the registration event, and
+	// are judged from this same snapshot rather than a second OperatorIDReady() call:
+	// SetOperatorData swaps the data and raises the ready flag under one lock, so two
+	// separate reads can pair pre-registration data with post-registration readiness and
+	// publish the zero owner address as real. The flag is only ever raised for a non-zero
+	// id, so this is the same test.
 	if od := h.operatorDataStore.GetOperatorData(); od != nil {
 		resp.OperatorPublicKey = od.PublicKey
-		if h.operatorDataStore.OperatorIDReady() {
+		if od.ID != 0 {
 			resp.OperatorID = od.ID
 			resp.OwnerAddress = od.OwnerAddress.String()
 		}
@@ -223,9 +233,9 @@ type topicIndex interface {
 
 // operatorDataStore exposes this node's own operator identity. The public key is
 // populated from config at startup; the id and owner address are filled in once the
-// operator's registration event has been synced from the chain, which OperatorIDReady
-// reports. A node started without an operator key holds an empty OperatorData.
+// operator's registration event has been synced from the chain, so a zero id means
+// that has not happened yet. A node started without an operator key holds an empty
+// OperatorData.
 type operatorDataStore interface {
 	GetOperatorData() *registrystorage.OperatorData
-	OperatorIDReady() bool
 }

--- a/api/handlers/node/node.go
+++ b/api/handlers/node/node.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ssvlabs/ssv/hprobe"
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/records"
+	registrystorage "github.com/ssvlabs/ssv/registry/storage"
 )
 
 type Node struct {
@@ -21,6 +22,9 @@ type Node struct {
 	network    p2pNetwork
 	peersIndex peersIndex
 	topicIndex topicIndex
+
+	// this node's own operator identity, as distinct from the p2p identity above
+	operatorDataStore operatorDataStore
 
 	healthProber             *hprobe.HealthProber
 	clComponentName          string
@@ -33,6 +37,7 @@ func NewNode(
 	peersIndex peersIndex,
 	network p2pNetwork,
 	topicIndex topicIndex,
+	operatorDataStore operatorDataStore,
 	healthProber *hprobe.HealthProber,
 	clComponentName string,
 	elComponentName string,
@@ -43,6 +48,7 @@ func NewNode(
 		peersIndex:               peersIndex,
 		topicIndex:               topicIndex,
 		network:                  network,
+		operatorDataStore:        operatorDataStore,
 		healthProber:             healthProber,
 		clComponentName:          clComponentName,
 		elComponentName:          elComponentName,
@@ -55,16 +61,30 @@ func (h *Node) Identity(w http.ResponseWriter, r *http.Request) error {
 	resp := identityJSON{
 		PeerID: h.network.LocalPeer(),
 	}
-	// invariant: setupPeerServices initializes self.Metadata at startup, so on
-	// the live path nodeInfo.Metadata is always non-nil. The guard defends
-	// against a future UpdateSelfRecord caller that returns a NodeInfo without
-	// a Metadata block — cheap insurance and mirrors the peers-handler shape.
-	if nodeInfo != nil && nodeInfo.Metadata != nil {
-		resp.Subnets = nodeInfo.Metadata.Subnets
-		resp.Version = nodeInfo.Metadata.NodeVersion
+	if nodeInfo != nil {
+		resp.NetworkID = nodeInfo.NetworkID
+		// invariant: setupPeerServices initializes self.Metadata at startup, so on
+		// the live path nodeInfo.Metadata is always non-nil. The guard defends
+		// against a future UpdateSelfRecord caller that returns a NodeInfo without
+		// a Metadata block — cheap insurance and mirrors the peers-handler shape.
+		if nodeInfo.Metadata != nil {
+			resp.Subnets = nodeInfo.Metadata.Subnets
+			resp.Version = nodeInfo.Metadata.NodeVersion
+		}
 	}
 	for _, addr := range h.network.ListenAddresses() {
 		resp.Addresses = append(resp.Addresses, addr.String())
+	}
+	// The operator public key is set from config at startup, so it identifies the node
+	// from first boot. The id and owner address arrive with this operator's registration
+	// event, so they are only reported once that has been synced - reporting id 0 and the
+	// zero address before then would read as real values.
+	if od := h.operatorDataStore.GetOperatorData(); od != nil {
+		resp.OperatorPublicKey = od.PublicKey
+		if h.operatorDataStore.OperatorIDReady() {
+			resp.OperatorID = od.ID
+			resp.OwnerAddress = od.OwnerAddress.String()
+		}
 	}
 	return api.Render(w, r, resp)
 }
@@ -199,4 +219,13 @@ type peersIndex interface {
 
 type topicIndex interface {
 	PeersByTopic() map[string][]peer.ID
+}
+
+// operatorDataStore exposes this node's own operator identity. The public key is
+// populated from config at startup; the id and owner address are filled in once the
+// operator's registration event has been synced from the chain, which OperatorIDReady
+// reports. A node started without an operator key holds an empty OperatorData.
+type operatorDataStore interface {
+	GetOperatorData() *registrystorage.OperatorData
+	OperatorIDReady() bool
 }

--- a/api/handlers/node/node_test.go
+++ b/api/handlers/node/node_test.go
@@ -11,9 +11,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	libp2pnetwork "github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	ma "github.com/multiformats/go-multiaddr"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -21,6 +23,13 @@ import (
 	"github.com/ssvlabs/ssv/hprobe"
 	"github.com/ssvlabs/ssv/network/commons"
 	"github.com/ssvlabs/ssv/network/records"
+	registrystorage "github.com/ssvlabs/ssv/registry/storage"
+)
+
+const (
+	testOperatorID     = 7
+	testOperatorPubKey = "LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0t"
+	testOwnerAddress   = "0x0000000000000000000000000000000000000abc"
 )
 
 // CreateTestNode builds a test Node using a local network.
@@ -89,6 +98,15 @@ func CreateTestNode(t *testing.T) *Node {
 		},
 	}
 
+	opDataStore := &MockOperatorDataStore{
+		OperatorDataValue: &registrystorage.OperatorData{
+			ID:           testOperatorID,
+			PublicKey:    testOperatorPubKey,
+			OwnerAddress: common.HexToAddress(testOwnerAddress),
+		},
+		OperatorIDReadyValue: true,
+	}
+
 	return NewNode(
 		[]string{
 			fmt.Sprintf("tcp://%s:%d", "localhost", 3030),
@@ -97,6 +115,7 @@ func CreateTestNode(t *testing.T) *Node {
 		pIndex,
 		net,
 		tIndex,
+		opDataStore,
 		healthProber,
 		component1,
 		component2,
@@ -143,6 +162,10 @@ func TestNodeHandlers(t *testing.T) {
 
 				require.NoError(t, json.Unmarshal(body, &resp))
 				require.NotEmpty(t, resp.PeerID)
+				require.Equal(t, "self", resp.NetworkID)
+				require.Equal(t, spectypes.OperatorID(testOperatorID), resp.OperatorID)
+				require.Equal(t, testOperatorPubKey, resp.OperatorPublicKey)
+				require.Equal(t, common.HexToAddress(testOwnerAddress).String(), resp.OwnerAddress)
 			},
 		},
 		{
@@ -285,4 +308,88 @@ func TestHealthCheckJSONString(t *testing.T) {
 	require.Equal(t, float64(3), advanced["inbound_conns"])
 	require.Equal(t, float64(0), advanced["outbound_conns"])
 	require.Equal(t, []any{"127.0.0.1:8000"}, advanced["p2p_listen_addresses"])
+}
+
+// TestIdentity_OperatorIdentity covers the three states this node's operator identity
+// can be in: registration synced, registration not yet synced, and a node running with
+// no operator key at all. The distinction matters to a caller trying to confirm which
+// operator a given node is - the public key answers that in every state, the id cannot.
+func TestIdentity_OperatorIdentity(t *testing.T) {
+	tests := []struct {
+		name           string
+		store          *MockOperatorDataStore
+		wantPublicKey  string
+		wantIdentified bool // operator_id and owner_address reported
+	}{
+		{
+			name: "registration synced",
+			store: &MockOperatorDataStore{
+				OperatorDataValue: &registrystorage.OperatorData{
+					ID:           testOperatorID,
+					PublicKey:    testOperatorPubKey,
+					OwnerAddress: common.HexToAddress(testOwnerAddress),
+				},
+				OperatorIDReadyValue: true,
+			},
+			wantPublicKey:  testOperatorPubKey,
+			wantIdentified: true,
+		},
+		{
+			// setupOperatorDataStore builds an OperatorData holding only the configured
+			// public key when the operator is not found in storage, so the key is
+			// available before the registration event has been synced - and the id is not.
+			name: "registration not yet synced",
+			store: &MockOperatorDataStore{
+				OperatorDataValue:    &registrystorage.OperatorData{PublicKey: testOperatorPubKey},
+				OperatorIDReadyValue: false,
+			},
+			wantPublicKey:  testOperatorPubKey,
+			wantIdentified: false,
+		},
+		{
+			// Exporter mode runs without an operator key and is given an empty
+			// OperatorData, so it reports no operator identity at all.
+			name:           "no operator key",
+			store:          &MockOperatorDataStore{OperatorDataValue: &registrystorage.OperatorData{}},
+			wantPublicKey:  "",
+			wantIdentified: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := CreateTestNode(t)
+			node.operatorDataStore = tt.store
+
+			req, err := http.NewRequest("GET", "/v1/node/identity", nil)
+			require.NoError(t, err)
+
+			rr := httptest.NewRecorder()
+			api.Handler(node.Identity).ServeHTTP(rr, req)
+			require.Equal(t, http.StatusOK, rr.Code)
+
+			var resp nodeIdentity
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+			// decoded as a map too, so an omitted field is distinguishable from a zero one
+			var raw map[string]any
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+
+			require.Equal(t, tt.wantPublicKey, resp.OperatorPublicKey)
+			if tt.wantPublicKey == "" {
+				require.NotContains(t, raw, "operator_public_key")
+			}
+
+			if tt.wantIdentified {
+				require.Equal(t, spectypes.OperatorID(testOperatorID), resp.OperatorID)
+				require.Equal(t, common.HexToAddress(testOwnerAddress).String(), resp.OwnerAddress)
+			} else {
+				require.NotContains(t, raw, "operator_id")
+				require.NotContains(t, raw, "owner_address")
+			}
+
+			// the network id comes from NodeInfo and is reported in every state
+			require.Equal(t, "self", resp.NetworkID)
+		})
+	}
 }

--- a/api/handlers/node/node_test.go
+++ b/api/handlers/node/node_test.go
@@ -30,7 +30,11 @@ const (
 	testOperatorID     = 7
 	testOperatorPubKey = "LS0tLS1CRUdJTiBSU0EgUFVCTElDIEtFWS0tLS0t"
 	testOwnerAddress   = "0x0000000000000000000000000000000000000abc"
+	// hex of testDomainType, as the handler renders it
+	testNetworkID = "0x00000503"
 )
+
+var testDomainType = spectypes.DomainType{0x0, 0x0, 0x5, 0x3}
 
 // CreateTestNode builds a test Node using a local network.
 func CreateTestNode(t *testing.T) *Node {
@@ -104,7 +108,6 @@ func CreateTestNode(t *testing.T) *Node {
 			PublicKey:    testOperatorPubKey,
 			OwnerAddress: common.HexToAddress(testOwnerAddress),
 		},
-		OperatorIDReadyValue: true,
 	}
 
 	return NewNode(
@@ -116,6 +119,7 @@ func CreateTestNode(t *testing.T) *Node {
 		net,
 		tIndex,
 		opDataStore,
+		func() spectypes.DomainType { return testDomainType },
 		healthProber,
 		component1,
 		component2,
@@ -162,7 +166,7 @@ func TestNodeHandlers(t *testing.T) {
 
 				require.NoError(t, json.Unmarshal(body, &resp))
 				require.NotEmpty(t, resp.PeerID)
-				require.Equal(t, "self", resp.NetworkID)
+				require.Equal(t, testNetworkID, resp.NetworkID)
 				require.Equal(t, spectypes.OperatorID(testOperatorID), resp.OperatorID)
 				require.Equal(t, testOperatorPubKey, resp.OperatorPublicKey)
 				require.Equal(t, common.HexToAddress(testOwnerAddress).String(), resp.OwnerAddress)
@@ -329,7 +333,6 @@ func TestIdentity_OperatorIdentity(t *testing.T) {
 					PublicKey:    testOperatorPubKey,
 					OwnerAddress: common.HexToAddress(testOwnerAddress),
 				},
-				OperatorIDReadyValue: true,
 			},
 			wantPublicKey:  testOperatorPubKey,
 			wantIdentified: true,
@@ -340,8 +343,21 @@ func TestIdentity_OperatorIdentity(t *testing.T) {
 			// available before the registration event has been synced - and the id is not.
 			name: "registration not yet synced",
 			store: &MockOperatorDataStore{
-				OperatorDataValue:    &registrystorage.OperatorData{PublicKey: testOperatorPubKey},
-				OperatorIDReadyValue: false,
+				OperatorDataValue: &registrystorage.OperatorData{PublicKey: testOperatorPubKey},
+			},
+			wantPublicKey:  testOperatorPubKey,
+			wantIdentified: false,
+		},
+		{
+			// A zero id is what makes an operator unidentified, not a missing owner
+			// address: reading readiness separately from the data could pair an unsynced
+			// snapshot with a raised ready flag and publish the zero address as real.
+			name: "zero id is not identified even with an owner address",
+			store: &MockOperatorDataStore{
+				OperatorDataValue: &registrystorage.OperatorData{
+					PublicKey:    testOperatorPubKey,
+					OwnerAddress: common.HexToAddress(testOwnerAddress),
+				},
 			},
 			wantPublicKey:  testOperatorPubKey,
 			wantIdentified: false,
@@ -388,8 +404,8 @@ func TestIdentity_OperatorIdentity(t *testing.T) {
 				require.NotContains(t, raw, "owner_address")
 			}
 
-			// the network id comes from NodeInfo and is reported in every state
-			require.Equal(t, "self", resp.NetworkID)
+			// the network id is independent of operator state and always reported
+			require.Equal(t, testNetworkID, resp.NetworkID)
 		})
 	}
 }

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -598,6 +598,7 @@ func (n *node) start(ctx context.Context, spawn func(func() error)) error {
 				n.p2pNetwork.(p2pv1.PeersIndexProvider).PeersIndex(),
 				n.p2pNetwork.(p2pv1.HostProvider).Host().Network(),
 				n.p2pNetwork,
+				n.operatorDataStore,
 				healthProber,
 				clComponentName,
 				elComponentName,

--- a/cli/operator/node.go
+++ b/cli/operator/node.go
@@ -599,6 +599,7 @@ func (n *node) start(ctx context.Context, spawn func(func() error)) error {
 				n.p2pNetwork.(p2pv1.HostProvider).Host().Network(),
 				n.p2pNetwork,
 				n.operatorDataStore,
+				n.networkConfig.CurrentDomainType,
 				healthProber,
 				clComponentName,
 				elComponentName,


### PR DESCRIPTION
## What

Four fields added to the `/v1/node/identity` response:

| Field | Notes |
|---|---|
| `network_id` | current domain type as `0x`-prefixed hex (`0x00000503` on Hoodi) |
| `operator_public_key` | base64, as registered on chain |
| `operator_id` | omitted until the registration event is synced |
| `owner_address` | omitted until the registration event is synced |

## Why

The endpoint reports the node's **network** identity — `peer_id`, `addresses`, `subnets`, `version` — but nothing about the **operator** it runs as, which in SSV terms is the node's identity.

So there is no way to ask a running node which operator it is. Fleet tooling can reach a node and read its health, but cannot confirm it is the operator it is configured to be; that has to be asserted out-of-band and drifts silently after a host move or a copied config.

`network_id` is included because operator IDs are per-network — operator 1 on Mainnet and on Hoodi are unrelated — so the ID alone is an incomplete identifier. It was already on the `NodeInfo` the handler reads and simply wasn't copied out.

## Lifecycle

The two identifiers become available at different times, and the response reflects that:

- `operator_public_key` is set from config at startup, so it is present from first boot — before registration, and while `event_syncer` is catching up.
- `operator_id` / `owner_address` arrive with the registration event, and are reported only when `OperatorIDReady()`, so a caller never sees id `0` or the zero address as real values.

`omitempty` because absence is meaningful: a public key with no id means "not yet observed on chain"; no public key at all means the node runs without an operator key (exporter mode).

## Notes

- `network_id` is the domain type, not a network name (`"0x" + hex(CurrentDomainType())`). Consumers should map it rather than string-match, and expect it to change at a fork. Reporting it verbatim keeps the handler correct across forks without it knowing anything about network naming.
- These are an identity *assertion*, not proof of possession — nothing here proves the node holds the operator's private key.
- No generated-doc changes: these handlers carry no swaggo annotations and regenerating `docs/api/ssvnode.openapi.*` produces no diff.

## Testing

`TestIdentity_OperatorIdentity` covers registration synced, not yet synced, and no operator key, asserting against both the decoded struct and the raw JSON map so "omitted" is verified as absent rather than zero. `TestNodeHandlers` is extended to cover the new fields.

Clean against `stage` with `GOTOOLCHAIN=go1.26.0`: `go build ./...`, `go vet`, `go test`, `gofmt`, and `golangci-lint` on the changed packages.
