### PR TITLE
network/p2p: deflake TestUpdateSubnetsStopsOnContextCancel

### DIFF
--- a/network/p2p/p2p_pubsub_test.go
+++ b/network/p2p/p2p_pubsub_test.go
@@ -54,16 +54,22 @@ func (c *subscribeRandomsTopicsController) Close() error {
 
 var _ topics.Controller = (*subscribeRandomsTopicsController)(nil)
 
+// testNetworkWithBoole returns a copy of TestNetwork with the Boole fork set to booleEpoch,
+// leaving the shared global config untouched.
+func testNetworkWithBoole(booleEpoch phase0.Epoch) *networkconfig.Network {
+	cfg := *networkconfig.TestNetwork
+	beacon := *networkconfig.TestNetwork.Beacon
+	ssv := *networkconfig.TestNetwork.SSV
+	ssv.Forks.Boole = booleEpoch
+	cfg.Beacon = &beacon
+	cfg.SSV = &ssv
+	return &cfg
+}
+
 // subscribeRandomsTestNetCfg returns a NetworkConfig with Boole far enough in the future that
 // these tests exercise pre-fork (Alan-only) subscription behavior.
 func subscribeRandomsTestNetCfg() *networkconfig.Network {
-	cfg := *networkconfig.TestNetwork
-	beaconCfg := *networkconfig.TestNetwork.Beacon
-	ssvCfg := *networkconfig.TestNetwork.SSV
-	ssvCfg.Forks.Boole = cfg.EstimatedCurrentEpoch() + 100
-	cfg.Beacon = &beaconCfg
-	cfg.SSV = &ssvCfg
-	return &cfg
+	return testNetworkWithBoole(networkconfig.TestNetwork.EstimatedCurrentEpoch() + 100)
 }
 
 func TestSubscribeRandomsReturnsErrorWhenNotEnoughAvailableSubnets(t *testing.T) {
@@ -127,16 +133,6 @@ func TestSubscribeRandomsSubscribesOnlyAvailableSubnets(t *testing.T) {
 // transition window, Boole-only post-fork — for both the node's persistent subnets and its
 // active committee subscriptions.
 func TestSubscribedSubnetsForCurrentEpoch(t *testing.T) {
-	booleCfg := func(booleEpoch phase0.Epoch) *networkconfig.Network {
-		cfg := *networkconfig.TestNetwork
-		beaconCfg := *networkconfig.TestNetwork.Beacon
-		ssvCfg := *networkconfig.TestNetwork.SSV
-		ssvCfg.Forks.Boole = booleEpoch
-		cfg.Beacon = &beaconCfg
-		cfg.SSV = &ssvCfg
-		return &cfg
-	}
-
 	subnetsOf := func(indices ...uint64) commons.Subnets {
 		s := commons.ZeroSubnets
 		for _, i := range indices {
@@ -159,13 +155,13 @@ func TestSubscribedSubnetsForCurrentEpoch(t *testing.T) {
 	cur := networkconfig.TestNetwork.EstimatedCurrentEpoch()
 
 	t.Run("pre-fork subscribes Alan only", func(t *testing.T) {
-		alan, boole := newNet(booleCfg(cur + 100)).subscribedSubnetsForCurrentEpoch()
+		alan, boole := newNet(testNetworkWithBoole(cur + 100)).subscribedSubnetsForCurrentEpoch()
 		require.Equal(t, subnetsOf(1, 2, 5), alan)
 		require.Equal(t, commons.ZeroSubnets, boole)
 	})
 
 	t.Run("transition window subscribes both", func(t *testing.T) {
-		cfg := booleCfg(cur + 1)
+		cfg := testNetworkWithBoole(cur + 1)
 		require.True(t, cfg.InBooleTransitionWindow(cfg.EstimatedCurrentSlot()), "expected current slot in the Boole transition window")
 		alan, boole := newNet(cfg).subscribedSubnetsForCurrentEpoch()
 		require.Equal(t, subnetsOf(1, 2, 5), alan)
@@ -173,7 +169,7 @@ func TestSubscribedSubnetsForCurrentEpoch(t *testing.T) {
 	})
 
 	t.Run("post-fork subscribes Boole only", func(t *testing.T) {
-		alan, boole := newNet(booleCfg(0)).subscribedSubnetsForCurrentEpoch()
+		alan, boole := newNet(testNetworkWithBoole(0)).subscribedSubnetsForCurrentEpoch()
 		require.Equal(t, commons.ZeroSubnets, alan)
 		require.Equal(t, subnetsOf(1, 2, 7), boole)
 	})

--- a/network/p2p/p2p_shutdown_test.go
+++ b/network/p2p/p2p_shutdown_test.go
@@ -16,7 +16,8 @@ import (
 const timeout = 400 * time.Millisecond
 
 type mockTopicsController struct {
-	updateCalled chan struct{}
+	updateCalled     chan struct{}
+	deregisterCalled chan struct{}
 }
 
 func (f *mockTopicsController) Subscribe(string) error {
@@ -39,7 +40,12 @@ func (f *mockTopicsController) Broadcast(string, []byte, time.Duration) error {
 	return nil
 }
 
-func (f *mockTopicsController) DeregisterTopics(...string) {}
+func (f *mockTopicsController) DeregisterTopics(...string) {
+	select {
+	case f.deregisterCalled <- struct{}{}:
+	default:
+	}
+}
 
 func (f *mockTopicsController) UpdateScoreParams() error {
 	select {
@@ -56,8 +62,21 @@ func (f *mockTopicsController) Close() error {
 func TestUpdateSubnetsStopsOnContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
+	// A post-fork config (Boole at genesis) makes the first loop iteration run the
+	// subscription-filter tightening path under both CI fork configs. That path dereferences cfg
+	// (nil here previously, which flaked this test as a panic) and calls DeregisterTopics, which
+	// signals that the loop is running so we cancel it mid-run instead of racing startup.
+	//
+	// idx and disc are left nil deliberately: empty persistent/committee subnets keep
+	// currentSubnets empty, so the subnet-changes branch is never entered. Adding a committee to
+	// this fixture would reach it and panic.
+	topicsCtrl := &mockTopicsController{deregisterCalled: make(chan struct{}, 1)}
+
 	n := &p2pNetwork{
 		ctx:                  ctx,
+		logger:               zap.NewNop(),
+		cfg:                  &Config{NetworkConfig: testNetworkWithBoole(0)},
+		topicsCtrl:           topicsCtrl,
 		subscribedCommittees: hashmap.New[string, statusWithSubnet](),
 	}
 
@@ -66,6 +85,14 @@ func TestUpdateSubnetsStopsOnContextCancel(t *testing.T) {
 		defer close(done)
 		n.UpdateSubnets()
 	}()
+
+	select {
+	case <-topicsCtrl.deregisterCalled:
+	case <-time.After(timeout):
+		// The signal is the Alan-whitelist tightening in UpdateSubnets; if that block is removed
+		// post-Boole, pick a new signal here rather than treating this as a shutdown regression.
+		require.Fail(t, "UpdateSubnets did not run its initial iteration")
+	}
 
 	cancel()
 


### PR DESCRIPTION
## Summary

Deflakes `TestUpdateSubnetsStopsOnContextCancel` in `network/p2p`, which
intermittently **panics** (nil-pointer SIGSEGV) and aborts the entire
`network/p2p` unit-test binary. Because a panic takes down the whole package,
this surfaces as a red `Unit tests` job on unrelated PRs — e.g. it failed the
`ssv-boole-post` job on #2993 (whose own change is confined to
`eth/executionclient`), while the parallel `ssv` job passed on the very same
commit.

## Root cause

The test builds a `p2pNetwork` with only `ctx` and `subscribedCommittees` set —
`cfg`, `logger` and `topicsCtrl` are left `nil` — then starts `UpdateSubnets()`
in a goroutine and immediately calls `cancel()`, assuming `cancel()` always wins
the race so the loop's top `ctx.Err()` guard returns before touching any nil
field.

It's a plain race. When the goroutine wins instead (readily on a loaded CI
runner), the first loop iteration runs the subscription-filter *tightening* step
and dereferences the nil `cfg` (`n.cfg.NetworkConfig.EstimatedCurrentSlot()`) →
SIGSEGV:

```
panic: runtime error: invalid memory address or nil pointer dereference
network/p2p.(*p2pNetwork).UpdateSubnets(...)
	network/p2p/p2p.go:591
network/p2p.TestUpdateSubnetsStopsOnContextCancel.func1()
	network/p2p/p2p_shutdown_test.go:67
```

That `cfg` access sits at the very top of the loop body and became reachable on
the first iteration once the post-fork subscription-filter tightening landed
(#2971); before that, the first statements didn't unconditionally touch `cfg`,
so losing the race was benign.

## Fix

Give the goroutine an environment where the only reason it can exit is context
cancellation, then assert it does — mirroring the sibling
`TestUpdateScoreParamsStopsOnContextCancel`:

- Provide the real dependencies the loop body needs (nop `logger`, a network
  `cfg`, a mock `topicsCtrl`); empty committee/persistent subnets keep the
  index/discovery paths out of the iteration, so no further mocks are required.
- Use a **post-fork** config (Boole active from genesis) so the tightening path
  — the exact code that used to panic — runs deterministically under **both** the
  default and `SSV_TEST_BOOLE_FORK=post` CI configs, and reuse its
  `DeregisterTopics` call as a synchronization signal so cancellation happens
  against a running loop instead of racing startup.

The test now exercises the previously-crashing path on every run and still fails
loudly if `UpdateSubnets` ever stops honoring context cancellation.

## Testing

- `TestUpdateSubnetsStopsOnContextCancel` and the sibling shutdown test: 300–400×
  under `-race`, in both the default and `SSV_TEST_BOOLE_FORK=post` configs — all
  green (was reliably reproducible as a panic beforehand).
- Full `network/p2p` package builds and passes.
