### PR TITLE
runner: keep duty-state sentinels reachable and drop their unreachable retry

### DIFF
--- a/operator/duties/validator_registration.go
+++ b/operator/duties/validator_registration.go
@@ -46,9 +46,10 @@ const (
 	// validatorRegistrationSchedulingSlack absorbs per-operator timing
 	// variance once a registration event clears the EL follow distance — see
 	// voluntaryExitSchedulingSlack for the full rationale; the same race
-	// applies here on the runner-level ErrNoDutyAssigned check at the
-	// receiver side. Independent of validatorRegistrationDutySlotsToPostpone
-	// despite happening to share the same numeric value (4).
+	// applies here at the receiver's duty queue, which holds a partial for a
+	// not-yet-started duty only until its next duty starts. Independent of
+	// validatorRegistrationDutySlotsToPostpone despite happening to share the
+	// same numeric value (4).
 	validatorRegistrationSchedulingSlack = 4
 
 	// validatorRegistrationExecutionSlotsToPostpone is the earliest slot,
@@ -59,11 +60,12 @@ const (
 	//
 	// Unlike voluntary-exit, validator-registration's inbound validation does
 	// not lock to a per-slot dutyStore key (the dutyLimit is a constant 2);
-	// the failure mode if we broadcast too early is the receiver's runner
-	// returning ErrNoDutyAssigned, which is retryable for ~1 slot before the
-	// message is dropped. The periodic VRSubmitter loop will eventually
-	// resubmit anyway — but the gate mirrors voluntary-exit's pattern for
-	// consistency and reduces the retry-window race for slow-EL peers.
+	// the failure mode if we broadcast too early is that the receiver's duty
+	// queue holds our partial until its own duty starts, and drops it as a
+	// past slot if that duty is for a later slot. The periodic VRSubmitter
+	// loop will eventually resubmit anyway — but the gate mirrors
+	// voluntary-exit's pattern for consistency and narrows that race for
+	// slow-EL peers.
 	validatorRegistrationExecutionSlotsToPostpone = executionclient.FollowDistance + validatorRegistrationSchedulingSlack
 )
 

--- a/protocol/v2/ssv/runner/aggregator.go
+++ b/protocol/v2/ssv/runner/aggregator.go
@@ -105,11 +105,6 @@ func (r *AggregatorRunner) ProcessPreConsensus(ctx context.Context, logger *zap.
 	span := trace.SpanFromContext(ctx)
 
 	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
-		// also needs to be retried.
-		err = NewRetryableError(err)
-	}
 	if err != nil {
 		return fmt.Errorf("failed processing selection proof message: %w", err)
 	}
@@ -294,11 +289,6 @@ func (r *AggregatorRunner) ProcessPostConsensus(ctx context.Context, logger *zap
 	span := trace.SpanFromContext(ctx)
 
 	hasQuorum, roots, err := r.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
-		// also needs to be retried.
-		err = NewRetryableError(err)
-	}
 	if err != nil {
 		return fmt.Errorf("failed processing post consensus message: %w", err)
 	}

--- a/protocol/v2/ssv/runner/committee.go
+++ b/protocol/v2/ssv/runner/committee.go
@@ -508,9 +508,6 @@ func (r *CommitteeRunner) ProcessPostConsensus(ctx context.Context, logger *zap.
 
 	span.AddEvent("base post consensus message processing")
 	hasQuorum, roots, err := r.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) {
-		err = NewRetryableError(err)
-	}
 	if err != nil {
 		return fmt.Errorf("failed processing post consensus message: %w", err)
 	}

--- a/protocol/v2/ssv/runner/error.go
+++ b/protocol/v2/ssv/runner/error.go
@@ -3,6 +3,8 @@ package runner
 import (
 	"errors"
 	"fmt"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
 )
 
 var (
@@ -56,6 +58,25 @@ func IsRetryable(err error) bool {
 	var retryableErr *RetryableError
 	return errors.As(err, &retryableErr)
 }
+
+// codedSentinel pairs one of the sentinels above with the spec error code it reports. spectypes.WrapError
+// alone cannot carry a sentinel: the spec's Error type has no Unwrap, so anything it wraps is invisible
+// to errors.Is, and the retry classification the runners build on errors.Is (ErrNoDutyAssigned,
+// ErrRunningDutySucceeded) never fires. Unwrap exposes both — the coded error for errors.As (spec tests,
+// observability) and the sentinel for errors.Is — under the sentinel's own message text.
+type codedSentinel struct {
+	coded    *spectypes.Error
+	sentinel error
+}
+
+// withCode tags a sentinel (or an error wrapping one) with a spec error code; see codedSentinel.
+func withCode(code int, sentinel error) error {
+	return &codedSentinel{coded: spectypes.WrapError(code, sentinel), sentinel: sentinel}
+}
+
+func (e *codedSentinel) Error() string { return e.sentinel.Error() }
+
+func (e *codedSentinel) Unwrap() []error { return []error{e.coded, e.sentinel} }
 
 // recoverableReconstructError tags a post-consensus BLS-reconstruction failure as recoverable.
 // It is attached at the push site inside the reconstruct goroutine, which has by construction

--- a/protocol/v2/ssv/runner/error.go
+++ b/protocol/v2/ssv/runner/error.go
@@ -61,9 +61,8 @@ func IsRetryable(err error) bool {
 
 // codedSentinel pairs one of the sentinels above with the spec error code it reports. spectypes.WrapError
 // alone cannot carry a sentinel: the spec's Error type has no Unwrap, so anything it wraps is invisible
-// to errors.Is, and the retry classification the runners build on errors.Is (ErrNoDutyAssigned,
-// ErrRunningDutySucceeded) never fires. Unwrap exposes both — the coded error for errors.As (spec tests,
-// observability) and the sentinel for errors.Is — under the sentinel's own message text.
+// to errors.Is. Unwrap exposes both — the coded error for errors.As (spec tests, observability) and the
+// sentinel for errors.Is — under the sentinel's own message text.
 type codedSentinel struct {
 	coded    *spectypes.Error
 	sentinel error

--- a/protocol/v2/ssv/runner/error_test.go
+++ b/protocol/v2/ssv/runner/error_test.go
@@ -21,6 +21,23 @@ func TestRetryableError(t *testing.T) {
 // tagged error is recoverable, and the tag survives further wrapping. Crucially, it also verifies the
 // tag never hides the wrapped chain — a code-tagged *spectypes.Error stays reachable via errors.As, so
 // the committee role still observably emits the reconstruct error code even after tagging.
+// withCode keeps both halves reachable through any further wrapping — the sentinel for errors.Is and
+// the coded spec error for errors.As — and reports the sentinel's own text, so spec tests keyed on
+// error codes and callers keyed on sentinels agree on the same error value.
+func TestWithCode(t *testing.T) {
+	err := fmt.Errorf("processing: %w", NewRetryableError(withCode(spectypes.NoRunningDutyErrorCode, ErrNoDutyAssigned)))
+
+	require.ErrorIs(t, err, ErrNoDutyAssigned)
+	var specErr *spectypes.Error
+	require.ErrorAs(t, err, &specErr)
+	require.Equal(t, spectypes.NoRunningDutyErrorCode, specErr.Code)
+	require.True(t, IsRetryable(err))
+	require.Equal(t, "processing: "+ErrNoDutyAssigned.Error(), err.Error())
+
+	// spectypes.WrapError alone loses the sentinel — the reason withCode exists.
+	require.NotErrorIs(t, spectypes.WrapError(spectypes.NoRunningDutyErrorCode, ErrNoDutyAssigned), ErrNoDutyAssigned)
+}
+
 func TestIsRecoverableReconstructError(t *testing.T) {
 	t.Run("plain error is not recoverable", func(t *testing.T) {
 		require.False(t, isRecoverableReconstructError(errors.New("boom")))

--- a/protocol/v2/ssv/runner/error_test.go
+++ b/protocol/v2/ssv/runner/error_test.go
@@ -17,10 +17,6 @@ func TestRetryableError(t *testing.T) {
 	require.True(t, IsRetryable(wrappedErr))
 }
 
-// TestIsRecoverableReconstructError pins the classifier the post-consensus defer relies on: only a
-// tagged error is recoverable, and the tag survives further wrapping. Crucially, it also verifies the
-// tag never hides the wrapped chain — a code-tagged *spectypes.Error stays reachable via errors.As, so
-// the committee role still observably emits the reconstruct error code even after tagging.
 // withCode keeps both halves reachable through any further wrapping — the sentinel for errors.Is and
 // the coded spec error for errors.As — and reports the sentinel's own text, so spec tests keyed on
 // error codes and callers keyed on sentinels agree on the same error value.
@@ -38,6 +34,10 @@ func TestWithCode(t *testing.T) {
 	require.NotErrorIs(t, spectypes.WrapError(spectypes.NoRunningDutyErrorCode, ErrNoDutyAssigned), ErrNoDutyAssigned)
 }
 
+// TestIsRecoverableReconstructError pins the classifier the post-consensus defer relies on: only a
+// tagged error is recoverable, and the tag survives further wrapping. Crucially, it also verifies the
+// tag never hides the wrapped chain — a code-tagged *spectypes.Error stays reachable via errors.As, so
+// the committee role still observably emits the reconstruct error code even after tagging.
 func TestIsRecoverableReconstructError(t *testing.T) {
 	t.Run("plain error is not recoverable", func(t *testing.T) {
 		require.False(t, isRecoverableReconstructError(errors.New("boom")))

--- a/protocol/v2/ssv/runner/proposer.go
+++ b/protocol/v2/ssv/runner/proposer.go
@@ -116,11 +116,6 @@ func (r *ProposerRunner) ProcessPreConsensus(ctx context.Context, logger *zap.Lo
 	span := trace.SpanFromContext(ctx)
 
 	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
-		// also needs to be retried.
-		err = NewRetryableError(err)
-	}
 	if err != nil {
 		return fmt.Errorf("failed processing randao message: %w", err)
 	}
@@ -341,11 +336,6 @@ func (r *ProposerRunner) ProcessPostConsensus(ctx context.Context, logger *zap.L
 	span := trace.SpanFromContext(ctx)
 
 	hasQuorum, roots, err := r.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
-		// also needs to be retried.
-		err = NewRetryableError(err)
-	}
 	if err != nil {
 		return fmt.Errorf("failed processing post consensus message: %w", err)
 	}

--- a/protocol/v2/ssv/runner/runner_signatures.go
+++ b/protocol/v2/ssv/runner/runner_signatures.go
@@ -86,7 +86,7 @@ func (b *BaseRunner) validatePartialSigMsg(
 		))
 	}
 	if psigMsgs.Slot > expectedSlot {
-		return NewRetryableError(spectypes.WrapError(spectypes.PartialSigMessageFutureSlotErrorCode, fmt.Errorf(
+		return NewRetryableError(withCode(spectypes.PartialSigMessageFutureSlotErrorCode, fmt.Errorf(
 			"%w: message slot: %d, expected slot: %d",
 			ErrFuturePartialSigMsg,
 			psigMsgs.Slot,

--- a/protocol/v2/ssv/runner/runner_validations.go
+++ b/protocol/v2/ssv/runner/runner_validations.go
@@ -21,10 +21,10 @@ func (b *BaseRunner) ValidatePreConsensusMsg(
 	psigMsgs *spectypes.PartialSignatureMessages,
 ) error {
 	if !b.hasDutyAssigned() {
-		return spectypes.WrapError(spectypes.NoRunningDutyErrorCode, ErrNoDutyAssigned)
+		return withCode(spectypes.NoRunningDutyErrorCode, ErrNoDutyAssigned)
 	}
 	if b.hasDutySucceeded() {
-		return spectypes.WrapError(spectypes.NoRunningDutyErrorCode, ErrRunningDutySucceeded)
+		return withCode(spectypes.NoRunningDutyErrorCode, ErrRunningDutySucceeded)
 	}
 
 	// Validate the pre-consensus message differently depending on a message type.
@@ -64,10 +64,10 @@ func (b *BaseRunner) FallBackAndVerifyEachSignature(container *ssv.PartialSigCon
 
 func (b *BaseRunner) ValidatePostConsensusMsg(ctx context.Context, runner Runner, psigMsgs *spectypes.PartialSignatureMessages) error {
 	if !b.hasDutyAssigned() {
-		return spectypes.WrapError(spectypes.NoRunningDutyErrorCode, ErrNoDutyAssigned)
+		return withCode(spectypes.NoRunningDutyErrorCode, ErrNoDutyAssigned)
 	}
 	if b.hasDutySucceeded() {
-		return spectypes.WrapError(spectypes.NoRunningDutyErrorCode, ErrRunningDutySucceeded)
+		return withCode(spectypes.NoRunningDutyErrorCode, ErrRunningDutySucceeded)
 	}
 
 	// slotIsRelevant ensures the post-consensus message is even remotely relevant (eg. we might have already
@@ -87,7 +87,7 @@ func (b *BaseRunner) ValidatePostConsensusMsg(ctx context.Context, runner Runner
 			))
 		}
 		if psigMsgs.Slot > maxSlot {
-			return NewRetryableError(spectypes.WrapError(spectypes.PartialSigMessageFutureSlotErrorCode, fmt.Errorf(
+			return NewRetryableError(withCode(spectypes.PartialSigMessageFutureSlotErrorCode, fmt.Errorf(
 				"%w: message slot: %d, want at most: %d",
 				ErrFuturePartialSigMsg,
 				psigMsgs.Slot,
@@ -101,13 +101,13 @@ func (b *BaseRunner) ValidatePostConsensusMsg(ctx context.Context, runner Runner
 	}
 
 	if !b.HasStartedQBFTInstance() {
-		return NewRetryableError(spectypes.WrapError(spectypes.NoRunningConsensusInstanceErrorCode, ErrInstanceNotFound))
+		return NewRetryableError(withCode(spectypes.NoRunningConsensusInstanceErrorCode, ErrInstanceNotFound))
 	}
 
 	// TODO https://github.com/ssvlabs/ssv-spec/issues/142 need to fix with this issue solution instead.
 	decided, decidedValueBytes := b.State.RunningInstance.IsDecided()
 	if !decided || len(b.State.DecidedValue) == 0 {
-		return NewRetryableError(spectypes.WrapError(spectypes.NoDecidedValueErrorCode, ErrNoDecidedValue))
+		return NewRetryableError(withCode(spectypes.NoDecidedValueErrorCode, ErrNoDecidedValue))
 	}
 
 	// Validate the post-consensus message differently depending on a message type.

--- a/protocol/v2/ssv/runner/runner_validations.go
+++ b/protocol/v2/ssv/runner/runner_validations.go
@@ -20,6 +20,11 @@ func (b *BaseRunner) ValidatePreConsensusMsg(
 	runner Runner,
 	psigMsgs *spectypes.PartialSignatureMessages,
 ) error {
+	// A message for a duty this runner has not started, or has already finished, is not retried: while
+	// no duty runs, the duty queue pops only duty-start events, so such a message waits in the queue
+	// and is processed once the duty starts — or, if it was for the finished duty, is dropped by the
+	// slot check once the next one starts. The sentinels stay identifiable (withCode) for callers and
+	// tests; no runner attaches a retry to them.
 	if !b.hasDutyAssigned() {
 		return withCode(spectypes.NoRunningDutyErrorCode, ErrNoDutyAssigned)
 	}
@@ -63,6 +68,7 @@ func (b *BaseRunner) FallBackAndVerifyEachSignature(container *ssv.PartialSigCon
 }
 
 func (b *BaseRunner) ValidatePostConsensusMsg(ctx context.Context, runner Runner, psigMsgs *spectypes.PartialSignatureMessages) error {
+	// Not retried; see ValidatePreConsensusMsg.
 	if !b.hasDutyAssigned() {
 		return withCode(spectypes.NoRunningDutyErrorCode, ErrNoDutyAssigned)
 	}

--- a/protocol/v2/ssv/runner/runner_validations_test.go
+++ b/protocol/v2/ssv/runner/runner_validations_test.go
@@ -9,44 +9,67 @@ import (
 	"go.uber.org/zap"
 )
 
-// The retry classification a runner applies to a message that reaches it before its duty started, or
-// after the duty succeeded, is keyed on errors.Is against the runner sentinels. Those sentinels travel
-// inside a coded spec error, so this pins that they stay reachable end to end: the proposer retries
-// both cases, while the committee runner — whose per-slot runner never starts again — retries only
-// the not-yet-started one.
-func TestRetryClassification_SentinelsReachable(t *testing.T) {
+// A partial that reaches a runner before its duty started, or after the duty succeeded, is reported
+// through the two duty-state sentinels and is not retried: the duty queue already holds such messages
+// while no duty runs (see ValidatePreConsensusMsg). For every runner, pre- and post-consensus, the
+// sentinel is reachable to errors.Is, the spec code to errors.As, and the error is not retryable.
+func TestDutyStateSentinels_NotRetried(t *testing.T) {
 	msgs := &spectypes.PartialSignatureMessages{
 		Type:     spectypes.RandaoPartialSig,
 		Slot:     1,
 		Messages: []*spectypes.PartialSignatureMessage{{Signer: 1, ValidatorIndex: 1}},
 	}
 	ctx, logger := context.Background(), zap.NewNop()
+	succeeded := func() *BaseRunner {
+		state := NewRunnerState(3, &spectypes.ValidatorDuty{Type: spectypes.BNRoleProposer, Slot: 1})
+		state.Succeeded = true
+		return &BaseRunner{State: state}
+	}
 
-	t.Run("proposer: no duty yet is retried", func(t *testing.T) {
-		r := &ProposerRunner{BaseRunner: &BaseRunner{}}
-		err := r.ProcessPreConsensus(ctx, logger, msgs)
-		require.ErrorIs(t, err, ErrNoDutyAssigned)
-		require.True(t, IsRetryable(err))
-	})
+	runners := []struct {
+		name    string
+		process func(*BaseRunner) error
+	}{
+		{"proposer pre-consensus", func(b *BaseRunner) error {
+			return (&ProposerRunner{BaseRunner: b}).ProcessPreConsensus(ctx, logger, msgs)
+		}},
+		{"proposer post-consensus", func(b *BaseRunner) error {
+			return (&ProposerRunner{BaseRunner: b}).ProcessPostConsensus(ctx, logger, msgs)
+		}},
+		{"aggregator pre-consensus", func(b *BaseRunner) error {
+			return (&AggregatorRunner{BaseRunner: b}).ProcessPreConsensus(ctx, logger, msgs)
+		}},
+		{"sync-committee contribution pre-consensus", func(b *BaseRunner) error {
+			return (&SyncCommitteeAggregatorRunner{BaseRunner: b}).ProcessPreConsensus(ctx, logger, msgs)
+		}},
+		{"validator registration pre-consensus", func(b *BaseRunner) error {
+			return (&ValidatorRegistrationRunner{BaseRunner: b}).ProcessPreConsensus(ctx, logger, msgs)
+		}},
+		{"voluntary exit pre-consensus", func(b *BaseRunner) error {
+			return (&VoluntaryExitRunner{BaseRunner: b}).ProcessPreConsensus(ctx, logger, msgs)
+		}},
+		{"committee post-consensus", func(b *BaseRunner) error {
+			return (&CommitteeRunner{BaseRunner: b}).ProcessPostConsensus(ctx, logger, msgs)
+		}},
+	}
+	for _, r := range runners {
+		t.Run(r.name, func(t *testing.T) {
+			err := r.process(&BaseRunner{})
+			require.ErrorIs(t, err, ErrNoDutyAssigned)
+			requireSpecCode(t, err, spectypes.NoRunningDutyErrorCode)
+			require.False(t, IsRetryable(err))
 
-	t.Run("proposer: duty already succeeded is retried", func(t *testing.T) {
-		r := &ProposerRunner{BaseRunner: &BaseRunner{State: &State{Succeeded: true}}}
-		err := r.ProcessPreConsensus(ctx, logger, msgs)
-		require.ErrorIs(t, err, ErrRunningDutySucceeded)
-		require.True(t, IsRetryable(err))
-	})
+			err = r.process(succeeded())
+			require.ErrorIs(t, err, ErrRunningDutySucceeded)
+			requireSpecCode(t, err, spectypes.NoRunningDutyErrorCode)
+			require.False(t, IsRetryable(err))
+		})
+	}
+}
 
-	t.Run("committee: no duty yet is retried", func(t *testing.T) {
-		r := &CommitteeRunner{BaseRunner: &BaseRunner{}}
-		err := r.ProcessPostConsensus(ctx, logger, msgs)
-		require.ErrorIs(t, err, ErrNoDutyAssigned)
-		require.True(t, IsRetryable(err))
-	})
-
-	t.Run("committee: duty already succeeded is dropped", func(t *testing.T) {
-		r := &CommitteeRunner{BaseRunner: &BaseRunner{State: &State{Succeeded: true}}}
-		err := r.ProcessPostConsensus(ctx, logger, msgs)
-		require.ErrorIs(t, err, ErrRunningDutySucceeded)
-		require.False(t, IsRetryable(err))
-	})
+func requireSpecCode(t *testing.T, err error, code int) {
+	t.Helper()
+	var specErr *spectypes.Error
+	require.ErrorAs(t, err, &specErr)
+	require.Equal(t, code, specErr.Code)
 }

--- a/protocol/v2/ssv/runner/runner_validations_test.go
+++ b/protocol/v2/ssv/runner/runner_validations_test.go
@@ -1,0 +1,52 @@
+package runner
+
+import (
+	"context"
+	"testing"
+
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// The retry classification a runner applies to a message that reaches it before its duty started, or
+// after the duty succeeded, is keyed on errors.Is against the runner sentinels. Those sentinels travel
+// inside a coded spec error, so this pins that they stay reachable end to end: the proposer retries
+// both cases, while the committee runner — whose per-slot runner never starts again — retries only
+// the not-yet-started one.
+func TestRetryClassification_SentinelsReachable(t *testing.T) {
+	msgs := &spectypes.PartialSignatureMessages{
+		Type:     spectypes.RandaoPartialSig,
+		Slot:     1,
+		Messages: []*spectypes.PartialSignatureMessage{{Signer: 1, ValidatorIndex: 1}},
+	}
+	ctx, logger := context.Background(), zap.NewNop()
+
+	t.Run("proposer: no duty yet is retried", func(t *testing.T) {
+		r := &ProposerRunner{BaseRunner: &BaseRunner{}}
+		err := r.ProcessPreConsensus(ctx, logger, msgs)
+		require.ErrorIs(t, err, ErrNoDutyAssigned)
+		require.True(t, IsRetryable(err))
+	})
+
+	t.Run("proposer: duty already succeeded is retried", func(t *testing.T) {
+		r := &ProposerRunner{BaseRunner: &BaseRunner{State: &State{Succeeded: true}}}
+		err := r.ProcessPreConsensus(ctx, logger, msgs)
+		require.ErrorIs(t, err, ErrRunningDutySucceeded)
+		require.True(t, IsRetryable(err))
+	})
+
+	t.Run("committee: no duty yet is retried", func(t *testing.T) {
+		r := &CommitteeRunner{BaseRunner: &BaseRunner{}}
+		err := r.ProcessPostConsensus(ctx, logger, msgs)
+		require.ErrorIs(t, err, ErrNoDutyAssigned)
+		require.True(t, IsRetryable(err))
+	})
+
+	t.Run("committee: duty already succeeded is dropped", func(t *testing.T) {
+		r := &CommitteeRunner{BaseRunner: &BaseRunner{State: &State{Succeeded: true}}}
+		err := r.ProcessPostConsensus(ctx, logger, msgs)
+		require.ErrorIs(t, err, ErrRunningDutySucceeded)
+		require.False(t, IsRetryable(err))
+	})
+}

--- a/protocol/v2/ssv/runner/sync_committee_contribution.go
+++ b/protocol/v2/ssv/runner/sync_committee_contribution.go
@@ -91,11 +91,6 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPreConsensus(ctx context.Context,
 	span := trace.SpanFromContext(ctx)
 
 	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
-		// also needs to be retried.
-		err = NewRetryableError(err)
-	}
 	if err != nil {
 		return fmt.Errorf("failed processing sync committee selection proof message: %w", err)
 	}
@@ -315,11 +310,6 @@ func (r *SyncCommitteeAggregatorRunner) ProcessPostConsensus(ctx context.Context
 	span := trace.SpanFromContext(ctx)
 
 	hasQuorum, roots, err := r.basePostConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
-		// also needs to be retried.
-		err = NewRetryableError(err)
-	}
 	if err != nil {
 		return fmt.Errorf("failed processing post consensus message: %w", err)
 	}

--- a/protocol/v2/ssv/runner/validator_registration.go
+++ b/protocol/v2/ssv/runner/validator_registration.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -94,11 +93,6 @@ func (r *ValidatorRegistrationRunner) ProcessPreConsensus(ctx context.Context, l
 	span := trace.SpanFromContext(ctx)
 
 	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
-		// also needs to be retried.
-		err = NewRetryableError(err)
-	}
 	if err != nil {
 		return fmt.Errorf("failed processing validator registration message: %w", err)
 	}

--- a/protocol/v2/ssv/runner/voluntary_exit.go
+++ b/protocol/v2/ssv/runner/voluntary_exit.go
@@ -85,11 +85,6 @@ func (r *VoluntaryExitRunner) ProcessPreConsensus(ctx context.Context, logger *z
 	}
 
 	hasQuorum, roots, err := r.basePreConsensusMsgProcessing(ctx, logger, r, signedMsg)
-	if errors.Is(err, ErrNoDutyAssigned) || errors.Is(err, ErrRunningDutySucceeded) {
-		// Since we are re-using the same runner for different duties, ErrRunningDutySucceeded error
-		// also needs to be retried.
-		err = NewRetryableError(err)
-	}
 	if err != nil {
 		return fmt.Errorf("failed processing voluntary exit message: %w", err)
 	}

--- a/protocol/v2/ssv/validator/committee_queue.go
+++ b/protocol/v2/ssv/validator/committee_queue.go
@@ -93,12 +93,7 @@ func (c *Committee) ConsumeQueue(
 	defer logger.Debug("📪 queue consumer is closed")
 
 	// msgStates keeps track of in-flight processing state (retry count + span context) per message.
-	// Since this map grows over time, we need to clean it up automatically. There is no specific TTL value
-	// to use for its entries - it just needs to be large enough to prevent unnecessary (but non-harmful)
-	// retries from happening.
-	msgStates := ttlcache.New(
-		ttlcache.WithTTL[messageKey, *messageProcessingState](10 * time.Minute),
-	)
+	msgStates := newMessageStates(messageStateTTL)
 	go msgStates.Start()
 	defer msgStates.Stop()
 

--- a/protocol/v2/ssv/validator/msg_queue.go
+++ b/protocol/v2/ssv/validator/msg_queue.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/jellydator/ttlcache/v3"
 	specqbft "github.com/ssvlabs/ssv-spec/qbft"
 	spectypes "github.com/ssvlabs/ssv-spec/types"
 	"go.opentelemetry.io/otel/trace"
@@ -34,6 +36,24 @@ type messageProcessingState struct {
 }
 
 type messageKey string
+
+// messageStateTTL bounds how long a message's processing state outlives its last attempt: long enough
+// for a retried message parked in the queue to keep its retry count and span across a realistic wait,
+// short enough that the cache does not grow without bound.
+const messageStateTTL = 10 * time.Minute
+
+// newMessageStates returns the per-message processing-state cache the queue consumers share. A state
+// normally ends its span when the message is processed or dropped; one that expires instead — a retried
+// message still parked in the queue — ends it here, so the span is exported rather than lost.
+func newMessageStates(ttl time.Duration) *ttlcache.Cache[messageKey, *messageProcessingState] {
+	states := ttlcache.New(ttlcache.WithTTL[messageKey, *messageProcessingState](ttl))
+	states.OnEviction(func(_ context.Context, reason ttlcache.EvictionReason, item *ttlcache.Item[messageKey, *messageProcessingState]) {
+		if reason == ttlcache.EvictionReasonExpired {
+			item.Value().span.End()
+		}
+	})
+	return states
+}
 
 const maxInt64DecimalLen = 20 // enough for uint64 max or int64 min in base 10
 

--- a/protocol/v2/ssv/validator/msg_queue_states_test.go
+++ b/protocol/v2/ssv/validator/msg_queue_states_test.go
@@ -1,0 +1,28 @@
+package validator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// A message state that expires — its message retried and then parked in the queue past the TTL — ends
+// its span on eviction, so the span is exported instead of leaking with the state.
+func TestNewMessageStates_ExpiryEndsSpan(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	ctx, span := provider.Tracer("test").Start(context.Background(), "message")
+
+	states := newMessageStates(20 * time.Millisecond)
+	go states.Start()
+	defer states.Stop()
+	states.Set("key", &messageProcessingState{ctx: ctx, span: span}, ttlcache.DefaultTTL)
+
+	require.Eventually(t, func() bool { return len(exporter.GetSpans()) == 1 }, 2*time.Second, 5*time.Millisecond)
+}

--- a/protocol/v2/ssv/validator/queue_validator.go
+++ b/protocol/v2/ssv/validator/queue_validator.go
@@ -104,12 +104,7 @@ func (v *Validator) StartQueueConsumer(
 		defer v.logger.Debug("📪 queue consumer is closed")
 
 		// msgStates keeps track of in-flight processing state (retry count + span context) per message.
-		// Since this map grows over time, we need to clean it up automatically. There is no specific TTL value
-		// to use for its entries - it just needs to be large enough to prevent unnecessary (but non-harmful)
-		// retries from happening.
-		msgStates := ttlcache.New(
-			ttlcache.WithTTL[messageKey, *messageProcessingState](10 * time.Minute),
-		)
+		msgStates := newMessageStates(messageStateTTL)
 		go msgStates.Start()
 		defer msgStates.Stop()
 

--- a/protocol/v2/ssv/validator/queue_validator_test.go
+++ b/protocol/v2/ssv/validator/queue_validator_test.go
@@ -1,0 +1,87 @@
+package validator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	spectypes "github.com/ssvlabs/ssv-spec/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ssvlabs/ssv/networkconfig"
+	"github.com/ssvlabs/ssv/protocol/v2/message"
+	"github.com/ssvlabs/ssv/protocol/v2/ssv/queue"
+	"github.com/ssvlabs/ssv/protocol/v2/ssv/runner"
+	ssvtypes "github.com/ssvlabs/ssv/protocol/v2/types"
+)
+
+// While a runner has no running duty, its consumer takes only duty-start events from the queue: a
+// partial for a duty this operator has not started yet waits there and is processed once the duty
+// starts. This is what keeps the runners' duty-state sentinels out of reach through the queue (see
+// runner.ValidatePreConsensusMsg) and lets a slightly early message survive.
+func TestConsumeQueue_HoldsMessagesUntilDutyStarts(t *testing.T) {
+	logger := zap.NewNop()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	netCfg := networkconfig.TestNetwork
+	duty := &spectypes.ValidatorDuty{Type: spectypes.BNRoleProposer, Slot: phase0.Slot(10)}
+	msgID := spectypes.NewMsgID(netCfg.DomainType, duty.PubKey[:], spectypes.RoleProposer)
+	proposer := &runner.ProposerRunner{BaseRunner: &runner.BaseRunner{RunnerRoleType: spectypes.RoleProposer}}
+
+	v := &Validator{
+		logger:        logger,
+		ctx:           ctx,
+		cancel:        cancel,
+		NetworkConfig: netCfg,
+		Operator:      &spectypes.CommitteeMember{},
+		Share:         &ssvtypes.SSVShare{},
+		Queues:        map[spectypes.RunnerRole]queue.Queue{spectypes.RoleProposer: queue.New(logger, 16)},
+		DutyRunners:   runner.ValidatorDutyRunners{spectypes.RoleProposer: proposer},
+	}
+
+	partial := makeTestSSVMessage(t, spectypes.SSVPartialSignatureMsgType, msgID, &spectypes.PartialSignatureMessages{
+		Type:     spectypes.RandaoPartialSig,
+		Slot:     duty.Slot,
+		Messages: []*spectypes.PartialSignatureMessage{{PartialSignature: make([]byte, 96), Signer: 1, ValidatorIndex: 1}},
+	})
+	require.True(t, v.Queues[spectypes.RoleProposer].TryPush(partial))
+
+	delivered := make(chan *queue.SSVMessage, 4)
+	v.StartQueueConsumer(msgID, func(_ context.Context, _ *zap.Logger, msg *queue.SSVMessage) error {
+		if event, ok := msg.Body.(*ssvtypes.EventMsg); ok && event.Type == ssvtypes.ExecuteDuty {
+			// The duty starts: from here on the runner has a running duty and the filter lifts.
+			proposer.State = runner.NewRunnerState(3, duty)
+		}
+		delivered <- msg
+		return nil
+	})
+
+	select {
+	case msg := <-delivered:
+		t.Fatalf("message of type %d delivered before the duty started", msg.MsgType)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	executeDuty, err := createDutyExecuteMsg(duty, duty.PubKey, netCfg.DomainType, spectypes.RoleProposer)
+	require.NoError(t, err)
+	decoded, err := queue.DecodeSSVMessage(executeDuty)
+	require.NoError(t, err)
+	require.True(t, v.Queues[spectypes.RoleProposer].TryPush(decoded))
+
+	require.Equal(t, message.SSVEventMsgType, receiveDelivered(t, delivered).MsgType, "the duty-start event goes first")
+	require.Equal(t, spectypes.SSVPartialSignatureMsgType, receiveDelivered(t, delivered).MsgType, "the held partial follows once the duty runs")
+}
+
+func receiveDelivered(t *testing.T, delivered <-chan *queue.SSVMessage) *queue.SSVMessage {
+	t.Helper()
+	select {
+	case msg := <-delivered:
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatal("no message delivered")
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary

The runners wrapped `ErrNoDutyAssigned` and `ErrRunningDutySucceeded` with `spectypes.WrapError` and then checked `errors.Is` against them to decide on a retry. The spec's `Error` type has no `Unwrap`, and its `Is` matches any coded error regardless of code, so `errors.Is` never reached the sentinel.

Following review, the branches turn out to be unreachable rather than merely dead: a runner's duty state changes only inside the queue consumer's own message processing, and that consumer pops only duty-start events while no duty is running. No message reaches a runner in either state, so the retry could never fire. Had it fired, the re-pushed message would have been parked behind that same filter until the next duty, holding an open span.

## Changes

- `withCode` wraps the runner sentinels so both halves stay reachable: the coded spec error for `errors.As` (spec tests, code maps) and the sentinel for `errors.Is`. Message text is unchanged, and the ssv spec-test vectors pass unchanged.
- The nine `errors.Is` retry branches are removed. The contract is stated once, at the producer in `ValidatePreConsensusMsg`: a message for a not-yet-started or finished duty waits in the queue and is processed when the duty starts, or is dropped by the slot check if it was for a finished duty.
- The per-message state cache both consumers share now ends the span of an entry that expires, so a retried message parked past the TTL no longer leaks its span.
- The validator-registration scheduler comment that described the receiver side as a one-slot retry is corrected.

## Tests

- `TestConsumeQueue_HoldsMessagesUntilDutyStarts` pins the queue contract: a partial for a not-yet-started duty stays in the queue until the duty-start event, then follows it.
- `TestDutyStateSentinels_NotRetried` covers every runner, pre- and post-consensus: sentinel reachable, spec code reachable, not retryable.
- `TestNewMessageStates_ExpiryEndsSpan` covers the eviction hook, `TestWithCode` the wrapper contract.

## Notes

- Pre-existing since coded errors were introduced; unrelated to the Glamsterdam work.
- The Gloas branch (#2901) adds three more producers of these sentinels (proposer preferences, request auth, envelope) that should move to `withCode` when it rebases onto this.
